### PR TITLE
🎨  Fix clippy warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,1 @@
-// Module declarations
-pub mod settings {
-    mod embedding_repository_settings;
-    mod settings;
-    mod vector_memory_repository_settings;
-
-    pub(crate) use embedding_repository_settings::EmbeddingRepositorySettings;
-    pub use settings::Settings;
-    pub(crate) use vector_memory_repository_settings::VectorMemoryRepositorySettings;
-}
+pub mod settings;

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,0 +1,7 @@
+mod app_settings;
+mod embedding_repository_settings;
+mod vector_memory_repository_settings;
+
+pub use app_settings::Settings;
+pub(crate) use embedding_repository_settings::EmbeddingRepositorySettings;
+pub(crate) use vector_memory_repository_settings::VectorMemoryRepositorySettings;

--- a/src/config/settings/app_settings.rs
+++ b/src/config/settings/app_settings.rs
@@ -1,0 +1,160 @@
+use config::Config;
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+use std::env;
+
+use crate::errors::CustomError;
+use crate::models::vector::EmbeddingModel;
+
+#[derive(Debug, Deserialize)]
+pub struct Settings {
+    qdrant_connection_string: SecretString,
+    oxigraph_connection_string: SecretString,
+    openai_api_key: SecretString,
+    embedding_model: SecretString,
+}
+
+impl Settings {
+    /// Creates a new Settings instance.
+    ///
+    /// # Description
+    ///
+    /// Primary constructor for creating a Settings instance. Takes a pre-configured Config object that defines all required settings.
+    /// This allows for flexible configuration sourcing while maintaining a clean initialization interface.
+    ///
+    /// # Parameters
+    ///
+    /// - `config`: A `config::Config` instance containing all required settings:
+    ///     - `qdrant_connection_string`: Connection string for Qdrant database
+    ///     - `oxigraph_connection_string`: Connection string for Oxigraph database
+    ///     - `openai_api_key`: API key for OpenAI services
+    ///
+    /// # Returns
+    ///
+    /// A `Result` which is:
+    ///
+    /// - `Ok`: A new `Settings` instance with the provided configuration
+    /// - `Err`: A `CustomError` if any required settings are missing or invalid
+    pub fn new(config: Config) -> Result<Self, CustomError> {
+        config.try_deserialize().map_err(|e| {
+            CustomError::ConfigParseError(format!("Failed to parse external configuration: {e}"))
+        })
+    }
+
+    /// Loads settings from environment variables and configuration files using default loaders.
+    ///
+    /// # Description
+    ///
+    /// This function provides a convenient way to load settings using the default environment and configuration loaders.
+    /// If a `.env` file exists in the project root it will be loaded automatically.
+    /// When the file is absent the function relies solely on the current environment variables.
+    ///
+    /// # Important
+    ///
+    /// This function is intended ONLY for use in integration tests and should not be used anywhere else in the codebase.
+    /// For production code, use the `Settings::new()` constructor with an explicitly configured `Config` instance.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` which is:
+    ///
+    /// - `Ok`: A new `Settings` instance with configuration loaded from environment and config files
+    /// - `Err`: A `CustomError` if:
+    ///     - Environment variables are missing or invalid
+    ///     - There are errors parsing the configuration
+    ///
+    pub(crate) fn load() -> Result<Self, CustomError> {
+        dotenvy::dotenv().ok();
+
+        let qdrant_connection_string = env::var("QDRANT_CONNECTION_STRING")
+            .map_err(|e| CustomError::ConfigParseError(format!("QDRANT_CONNECTION_STRING: {e}")))?;
+        let oxigraph_connection_string = env::var("OXIGRAPH_CONNECTION_STRING").map_err(|e| {
+            CustomError::ConfigParseError(format!("OXIGRAPH_CONNECTION_STRING: {e}"))
+        })?;
+        let openai_api_key = env::var("OPENAI_API_KEY")
+            .map_err(|e| CustomError::ConfigParseError(format!("OPENAI_API_KEY: {e}")))?;
+        let embedding_model = env::var("EMBEDDING_MODEL")
+            .map_err(|e| CustomError::ConfigParseError(format!("EMBEDDING_MODEL: {e}")))?;
+
+        Ok(Self {
+            qdrant_connection_string: SecretString::new(qdrant_connection_string.into()),
+            oxigraph_connection_string: SecretString::new(oxigraph_connection_string.into()),
+            openai_api_key: SecretString::new(openai_api_key.into()),
+            embedding_model: SecretString::new(embedding_model.into()),
+        })
+    }
+
+    pub fn get_qdrant_connection(&self) -> &str {
+        self.qdrant_connection_string.expose_secret()
+    }
+
+    #[allow(dead_code)] // Remove after implementing Oxigraph
+    pub fn get_oxigraph_connection(&self) -> &str {
+        self.oxigraph_connection_string.expose_secret()
+    }
+
+    pub fn get_openai_api_key(&self) -> &str {
+        self.openai_api_key.expose_secret()
+    }
+
+    pub(crate) fn get_embedding_model(&self) -> Result<EmbeddingModel, CustomError> {
+        self.embedding_model.expose_secret().parse()
+    }
+}
+
+#[cfg(test)]
+impl Settings {
+    pub fn new_for_tests(
+        qdrant_connection_string: SecretString,
+        oxigraph_connection_string: SecretString,
+        openai_api_key: SecretString,
+        embedding_model: SecretString,
+    ) -> Self {
+        Settings {
+            qdrant_connection_string,
+            oxigraph_connection_string,
+            openai_api_key,
+            embedding_model,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::CustomError;
+
+    #[test]
+    fn test_settings_new_success() {
+        let external_config = Config::builder()
+            .set_override("qdrant_connection_string", "external_qdrant")
+            .unwrap()
+            .set_override("oxigraph_connection_string", "external_oxigraph")
+            .unwrap()
+            .set_override("openai_api_key", "external_openai")
+            .unwrap()
+            .set_override("embedding_model", "TextEmbedding3Small")
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let result = Settings::new(external_config);
+        assert!(result.is_ok());
+
+        let settings = result.unwrap();
+        assert_eq!(settings.get_qdrant_connection(), "external_qdrant");
+        assert_eq!(settings.get_oxigraph_connection(), "external_oxigraph");
+    }
+
+    #[test]
+    fn test_settings_new_error() {
+        let incomplete_config = Config::builder()
+            .set_override("qdrant_connection_string", "external_qdrant")
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let result = Settings::new(incomplete_config);
+        assert!(matches!(result, Err(CustomError::ConfigParseError(_))));
+    }
+}

--- a/src/errors/custom.rs
+++ b/src/errors/custom.rs
@@ -1,5 +1,4 @@
 use qdrant_client::QdrantError;
-use serde_json;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -26,7 +25,7 @@ pub enum CustomError {
     DatabaseError(String),
 
     #[error("Vector database error: {0}")]
-    QdrantError(#[from] QdrantError),
+    QdrantError(#[source] Box<QdrantError>),
 
     #[error("Embedding initialization error: {0}")]
     EmbeddingInitializationError(String),
@@ -36,4 +35,10 @@ pub enum CustomError {
 
     #[error("Serialization error: {0}")]
     SerializationError(#[from] serde_json::Error),
+}
+
+impl From<QdrantError> for CustomError {
+    fn from(err: QdrantError) -> Self {
+        CustomError::QdrantError(Box::new(err))
+    }
 }

--- a/src/infrastructures/external_services/qdrant_vector_memory_repository.rs
+++ b/src/infrastructures/external_services/qdrant_vector_memory_repository.rs
@@ -55,7 +55,7 @@ impl QdrantVectorMemoryRepository {
             }
         };
         let uuid = Uuid::parse_str(&id_str)
-            .map_err(|e| CustomError::DatabaseError(format!("Invalid UUID format: {}", e)))?;
+            .map_err(|e| CustomError::DatabaseError(format!("Invalid UUID format: {e}")))?;
 
         // Extract vector
         let vectors_output = point_data
@@ -102,9 +102,7 @@ impl QdrantVectorMemoryRepository {
                 .trim_matches('"')
                 .to_string();
             let timestamp = DateTime::parse_from_rfc3339(&timestamp_str)
-                .map_err(|e| {
-                    CustomError::DatabaseError(format!("Invalid timestamp format: {}", e))
-                })?
+                .map_err(|e| CustomError::DatabaseError(format!("Invalid timestamp format: {e}")))?
                 .with_timezone(&Utc);
 
             // Extract location
@@ -124,7 +122,7 @@ impl QdrantVectorMemoryRepository {
                 .to_string();
             let participants: Vec<String> =
                 serde_json::from_str(&participants_str).map_err(|e| {
-                    CustomError::DatabaseError(format!("Invalid participants format: {}", e))
+                    CustomError::DatabaseError(format!("Invalid participants format: {e}"))
                 })?;
 
             VectorMetadata::new_episodic(uuid, content, timestamp, location_text, participants)
@@ -188,7 +186,7 @@ impl QdrantVectorMemoryRepository {
             for participant in participants {
                 conditions.push(Condition::matches(
                     "participants",
-                    format!("*{}*", participant),
+                    format!("*{participant}*"),
                 ));
             }
         }
@@ -247,8 +245,7 @@ impl VectorMemoryRepository for QdrantVectorMemoryRepository {
         let memories = self.get_memories_by_ids(&[id]).await;
         if memories.is_err() {
             return Err(CustomError::DatabaseError(format!(
-                "Memory with ID {} not found",
-                id
+                "Memory with ID {id} not found",
             )));
         }
 
@@ -347,8 +344,7 @@ impl VectorMemoryRepository for QdrantVectorMemoryRepository {
 
             if !missing_ids.is_empty() {
                 return Err(CustomError::DatabaseError(format!(
-                    "Memories with IDs {:?} not found",
-                    missing_ids
+                    "Memories with IDs {missing_ids:?} not found",
                 )));
             }
         }

--- a/src/models/vector/enums/embedding_model.rs
+++ b/src/models/vector/enums/embedding_model.rs
@@ -73,8 +73,7 @@ impl FromStr for EmbeddingModel {
             "text-embedding-3-large" => Ok(Self::TextEmbedding3Large),
             "text-embedding-ada-002" => Ok(Self::TextEmbeddingAda002),
             _ => Err(CustomError::ConfigParseError(format!(
-                "Invalid embedding model: {}",
-                s
+                "Invalid embedding model: {s}",
             ))),
         }
     }

--- a/src/repositories/memory_repository.rs
+++ b/src/repositories/memory_repository.rs
@@ -108,7 +108,7 @@ impl MemoryRepository {
         memories
             .into_iter()
             .next()
-            .ok_or_else(|| CustomError::DatabaseError(format!("Memory with ID {} not found", id)))
+            .ok_or_else(|| CustomError::DatabaseError(format!("Memory with ID {id} not found")))
     }
 
     /// Retrieves multiple memory entries by their unique identifiers.


### PR DESCRIPTION
### Motivation and Context
<!--
1. Why is this change required?
2. What problem does it solve / scenario it enables?
3. If it fixes or closes an issue, add “Fixes #<num>”.
-->
- Bring the codebase to a clean Clippy state so warnings can be treated as errors in CI (quality gate).
- Align module organization with the repository’s .clinerules to avoid “module inception” smells and improve maintainability.
- Resolve clippy::result_large_err by reducing the size of error variants without altering external behavior.
- Standardize formatting messages to modern Rust style (uninlined format args).

### Description
<!--
High-level overview of the approach and design.
If helpful, point to relevant modules / files / data flow.
-->
Non-invasive cleanup with zero functional changes:

1) Clippy cleanup
- Replaced uninlined format! args with the {var} style across modules.
- Removed a redundant import flagged by clippy::single_component_path_imports.

2) Error size reduction
- Boxed the large QdrantError variant to resolve clippy::result_large_err:
  - CustomError::QdrantError(#[source] Box<QdrantError>)
  - Implemented From<QdrantError> for CustomError to preserve ergonomic use of ?.
  - No change to caller behavior or error messages.

3) Module organization (per .clinerules)
- Avoided “module inception” in config/settings by:
  - Using a top-level module file to declare submodules: src/config/settings.rs
  - Renaming the inner “settings” module to app_settings to prevent name collision.
  - Re-exporting symbols:
    - pub use app_settings::Settings;
    - pub(crate) use embedding_repository_settings::EmbeddingRepositorySettings;
    - pub(crate) use vector_memory_repository_settings::VectorMemoryRepositorySettings;
- Updated src/config.rs to only declare pub mod settings; letting settings.rs own its submodules.

4) Targeted touch-ups
- In Qdrant repository and Memory repository paths, standardized error messages and format patterns.
- No logic changes to search, store, update, delete, or bulk operations.

Affected files (representative)
- src/errors/custom.rs
- src/config.rs
- src/config/settings.rs
- src/config/settings/app_settings.rs
- src/infrastructures/external_services/qdrant_vector_memory_repository.rs
- src/models/vector/enums/embedding_model.rs
- src/repositories/memory_repository.rs

Suggested verification (local)
- cargo check --all-targets
- cargo clippy --all-targets -- -D warnings
- cargo test --verbose
- cargo fmt -- --check

### Checklist
<!-- Tick all that apply before requesting review -->

- [x] Code builds with **no errors or warnings**
      `cargo check --all-targets`
- [x] **Unit tests pass**
      `cargo test --verbose`
- [x] **Clippy** passes with warnings denied
      `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt` has been run
- [x] Documentation updated where needed
- [x] BREAKING CHANGE? **No**
- [x] I didn’t break anyone 😊

### Additional Notes (optional)
<!-- Logs, screenshots, things reviewers should focus on, etc. -->
- Reviewers: please pay particular attention to:
  - Error boxing change (CustomError::QdrantError) — behavior unchanged, but reduces Err size.
  - Module organization: app_settings module naming and re-exports — public API still exposes config::settings::Settings while keeping internal settings types crate-visible.
- No user-facing or API-breaking changes are expected; changes are internal refactors and lint fixes only.