### PR TITLE
📝 Update roadmap to clarify library philosophy

### DIFF
--- a/docs/roadmap/development_roadmap.md
+++ b/docs/roadmap/development_roadmap.md
@@ -111,18 +111,24 @@ Design principle:
 * `RetrievalBundle`
 
   * `query`
-  * `candidates[]`: `{ id, score?, content_excerpt, payload_metadata, graph_context }`
+  * `results[]`: `{ id, content_excerpt, payload_metadata, graph_context }`
   * `entities[]`, `locations[]`, `time_anchors[]` (normalized aggregates)
   * `provenance`: stable IDs suitable for caller-side citations
+
+  Optional trace (debug/provenance aid; not required for callers):
+
+  * `trace?`: includes internal stage diagnostics such as vector candidate ids + scores, graph expansion summary, and merge/ranking rationale.
 
 ### 5.2 Core operations (shape, not exact signatures)
 
 * `upsert(record) -> id`
 * `get_by_id(id) -> record + graph_context`
-* `vector_search(query, filters) -> [candidate ids + scores]`
-* `graph_expand(ids, policy) -> context per id`
 * `hybrid_search(query, filters, policy) -> RetrievalBundle`
 * Optional: `graph_query_*` helpers (by entity, location, time range, etc.)
+
+Implementation note:
+
+* The hybrid flow may internally perform vector search and graph expansion. These are not necessarily exposed as stable, user-facing APIs.
 
 ### 5.3 Caller responsibility
 

--- a/docs/roadmap/development_roadmap.md
+++ b/docs/roadmap/development_roadmap.md
@@ -92,6 +92,11 @@ Recommended IRI schemes (example):
 
 Callers should integrate against a small, stable set of interfaces.
 
+Design principle:
+
+* **Usability first:** callers should use a single, high-level hybrid retrieval API (`hybrid_search`) rather than composing vector-only and graph-only stages.
+* **Traceability separately:** internal stage outputs (vector candidates/scores, graph expansions, merge decisions) can be exposed as an *optional* retrieval trace for debugging and provenance, without requiring callers to implement selection logic.
+
 ### 5.1 Core types
 
 * `MemoryRecord`


### PR DESCRIPTION
### Motivation and Context
This change clarifies the **intended public API** for retrieval to avoid encouraging “vector-only” or “graph-only” usage patterns that would produce incomplete results and force callers to reimplement hybrid logic.

It solves ambiguity in the roadmap around whether callers should compose `vector_search`/`graph_expand` themselves by making **`hybrid_search` the recommended retrieval entrypoint**, while still supporting **traceability** through optional diagnostic traces.

### Description
Documentation-only update to the roadmap:
- Establishes a **hybrid-first usability principle**: callers should use `hybrid_search` rather than composing vector and graph stages.
- Separates **traceability** from usability by introducing an optional `trace?` concept for internal stage diagnostics (vector candidates + scores, graph expansion summary, merge/ranking rationale).
- Updates the `RetrievalBundle` shape to focus on a final caller-facing `results[]` list, with optional trace data for debugging/provenance.

Files updated:
- development_roadmap.md

### Checklist
- [x] Code builds with **no errors or warnings**
      `cargo check --all-targets` *(N/A — docs-only change)*
- [x] **Unit tests pass**
      `cargo test --verbose` *(N/A — docs-only change)*
- [x] **Clippy** passes with warnings denied
      `cargo clippy --all-targets -- -D warnings` *(N/A — docs-only change)*
- [x] `cargo fmt` has been run *(N/A — docs-only change)*
- [x] Documentation updated where needed
- [x] BREAKING CHANGE? **No**
- [x] I didn’t break anyone 😊

### Additional Notes (optional)
This update is intentionally scoped to documentation/architecture guidance only; no code or API changes are included.