### PR TITLE
⚡ Introduce scored memory types

### DIFF
--- a/src/infrastructures/external_services/qdrant_vector_memory_repository.rs
+++ b/src/infrastructures/external_services/qdrant_vector_memory_repository.rs
@@ -14,8 +14,8 @@ use uuid::Uuid;
 use crate::config::settings::VectorMemoryRepositorySettings;
 use crate::errors::CustomError;
 use crate::models::memory::dto::MemoryFilters;
-use crate::models::memory::MemoryEntry;
 use crate::models::memory::MemoryType;
+use crate::models::memory::{MemoryEntry, ScoredMemoryEntry};
 use crate::models::vector::VectorMetadata;
 use crate::repositories::VectorMemoryRepository;
 
@@ -351,7 +351,7 @@ impl VectorMemoryRepository for QdrantVectorMemoryRepository {
         query_vector: &'a [f32],
         top_k: usize,
         filters: Option<&'a MemoryFilters>,
-    ) -> Result<Vec<MemoryEntry>, CustomError> {
+    ) -> Result<Vec<ScoredMemoryEntry>, CustomError> {
         let mut builder = SearchPointsBuilder::new(
             &self.config.collection_name,
             query_vector.to_vec(),
@@ -379,8 +379,13 @@ impl VectorMemoryRepository for QdrantVectorMemoryRepository {
         let results = response
             .result
             .into_iter()
-            .map(|scored| self.point_to_memory_entry(scored))
-            .collect::<Result<Vec<_>, _>>()?;
+            .map(|scored| {
+                let score = scored.score;
+                let entry = self.point_to_memory_entry(scored)?;
+                Ok(ScoredMemoryEntry { entry, score })
+            })
+            .collect::<Result<Vec<_>, CustomError>>()?;
+
         Ok(results)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use crate::repositories::MemoryRepository;
 // Re-export types for public use
 pub use crate::config::settings::Settings;
 pub use crate::errors::CustomError;
-pub use crate::models::memory::dto::{Memory, MemoryFilters, MemoryInput};
+pub use crate::models::memory::dto::{Memory, MemoryFilters, MemoryInput, ScoredMemory};
 pub use crate::models::memory::MemoryType;
 
 // Re-export for integration tests
@@ -212,11 +212,12 @@ impl AgentMemory {
         query: &str,
         top_k: usize,
         filters: Option<MemoryFilters>,
-    ) -> Result<Vec<Memory>, CustomError> {
+    ) -> Result<Vec<ScoredMemory>, CustomError> {
         let entries = self
             .memory_repo
             .search_memories(query, top_k, filters)
             .await?;
+
         Ok(entries
             .into_iter()
             .map(|entry| entry.into_public())

--- a/src/models.rs
+++ b/src/models.rs
@@ -4,10 +4,12 @@ pub mod memory {
         mod memory;
         mod memory_filters;
         mod memory_input;
+        mod scored_memory;
 
         pub use memory::Memory;
         pub use memory_filters::MemoryFilters;
         pub use memory_input::MemoryInput;
+        pub use scored_memory::ScoredMemory;
     }
 
     mod enums {
@@ -16,7 +18,7 @@ pub mod memory {
 
     mod memory_entry;
     pub use enums::memory_type::MemoryType;
-    pub(crate) use memory_entry::MemoryEntry;
+    pub(crate) use memory_entry::{MemoryEntry, ScoredMemoryEntry};
 }
 
 pub(crate) mod vector {

--- a/src/models.rs
+++ b/src/models.rs
@@ -17,8 +17,10 @@ pub mod memory {
     }
 
     mod memory_entry;
+    mod scored_memory_entry;
     pub use enums::memory_type::MemoryType;
-    pub(crate) use memory_entry::{MemoryEntry, ScoredMemoryEntry};
+    pub(crate) use memory_entry::MemoryEntry;
+    pub(crate) use scored_memory_entry::ScoredMemoryEntry;
 }
 
 pub(crate) mod vector {

--- a/src/models/memory/dto/scored_memory.rs
+++ b/src/models/memory/dto/scored_memory.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+use crate::models::memory::dto::Memory;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScoredMemory {
+    pub memory: Memory,
+    pub score: f32,
+}

--- a/src/models/memory/memory_entry.rs
+++ b/src/models/memory/memory_entry.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 
 use crate::errors::CustomError;
 use crate::models::memory::dto::Memory;
+use crate::models::memory::dto::ScoredMemory;
 use crate::models::memory::MemoryType;
 use crate::models::vector::VectorMetadata;
 
@@ -16,6 +17,12 @@ pub(crate) struct MemoryEntry {
     pub(crate) timestamp: Option<DateTime<Utc>>,
     pub(crate) location_text: Option<String>,
     pub(crate) participants: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ScoredMemoryEntry {
+    pub(crate) entry: MemoryEntry,
+    pub(crate) score: f32,
 }
 
 impl MemoryEntry {
@@ -66,6 +73,15 @@ impl MemoryEntry {
             timestamp: self.timestamp,
             location_text: self.location_text,
             participants: self.participants,
+        }
+    }
+}
+
+impl ScoredMemoryEntry {
+    pub(crate) fn into_public(self) -> ScoredMemory {
+        ScoredMemory {
+            memory: self.entry.into_public(),
+            score: self.score,
         }
     }
 }

--- a/src/models/memory/memory_entry.rs
+++ b/src/models/memory/memory_entry.rs
@@ -4,7 +4,6 @@ use uuid::Uuid;
 
 use crate::errors::CustomError;
 use crate::models::memory::dto::Memory;
-use crate::models::memory::dto::ScoredMemory;
 use crate::models::memory::MemoryType;
 use crate::models::vector::VectorMetadata;
 
@@ -17,12 +16,6 @@ pub(crate) struct MemoryEntry {
     pub(crate) timestamp: Option<DateTime<Utc>>,
     pub(crate) location_text: Option<String>,
     pub(crate) participants: Option<Vec<String>>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct ScoredMemoryEntry {
-    pub(crate) entry: MemoryEntry,
-    pub(crate) score: f32,
 }
 
 impl MemoryEntry {
@@ -73,15 +66,6 @@ impl MemoryEntry {
             timestamp: self.timestamp,
             location_text: self.location_text,
             participants: self.participants,
-        }
-    }
-}
-
-impl ScoredMemoryEntry {
-    pub(crate) fn into_public(self) -> ScoredMemory {
-        ScoredMemory {
-            memory: self.entry.into_public(),
-            score: self.score,
         }
     }
 }

--- a/src/models/memory/scored_memory_entry.rs
+++ b/src/models/memory/scored_memory_entry.rs
@@ -1,0 +1,17 @@
+use crate::models::memory::dto::ScoredMemory;
+use crate::models::memory::MemoryEntry;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ScoredMemoryEntry {
+    pub(crate) entry: MemoryEntry,
+    pub(crate) score: f32,
+}
+
+impl ScoredMemoryEntry {
+    pub(crate) fn into_public(self) -> ScoredMemory {
+        ScoredMemory {
+            memory: self.entry.into_public(),
+            score: self.score,
+        }
+    }
+}

--- a/src/repositories/memory_repository.rs
+++ b/src/repositories/memory_repository.rs
@@ -2,7 +2,7 @@ use uuid::Uuid;
 
 use crate::errors::CustomError;
 use crate::models::memory::dto::MemoryFilters;
-use crate::models::memory::MemoryEntry;
+use crate::models::memory::{MemoryEntry, ScoredMemoryEntry};
 use crate::models::vector::VectorMetadata;
 use crate::repositories::{EmbeddingRepository, VectorMemoryRepository};
 
@@ -196,7 +196,7 @@ impl MemoryRepository {
         query: &str,
         top_k: usize,
         filters: Option<MemoryFilters>,
-    ) -> Result<Vec<MemoryEntry>, CustomError> {
+    ) -> Result<Vec<ScoredMemoryEntry>, CustomError> {
         let query_embedding = self.embed_repo.generate_embedding(query).await?;
         self.vector_repo
             .search_memory(&query_embedding, top_k, filters.as_ref())

--- a/src/repositories/vector_memory_repository.rs
+++ b/src/repositories/vector_memory_repository.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 use crate::errors::CustomError;
 use crate::models::memory::dto::MemoryFilters;
-use crate::models::memory::MemoryEntry;
+use crate::models::memory::{MemoryEntry, ScoredMemoryEntry};
 
 /// Repository trait for storing and retrieving memories using a vector database.
 ///
@@ -86,7 +86,7 @@ pub(crate) trait VectorMemoryRepository: Send + Sync {
         query_vector: &'a [f32],
         top_k: usize,
         filters: Option<&'a MemoryFilters>,
-    ) -> Result<Vec<MemoryEntry>, CustomError>;
+    ) -> Result<Vec<ScoredMemoryEntry>, CustomError>;
 
     /// Inserts multiple memories in a single operation.
     ///
@@ -145,7 +145,7 @@ impl<T: VectorMemoryRepository + ?Sized> VectorMemoryRepository for Box<T> {
         query_vector: &'a [f32],
         top_k: usize,
         filters: Option<&'a MemoryFilters>,
-    ) -> Result<Vec<MemoryEntry>, CustomError> {
+    ) -> Result<Vec<ScoredMemoryEntry>, CustomError> {
         (**self).search_memory(query_vector, top_k, filters).await
     }
 

--- a/tests/memory_search_tests.rs
+++ b/tests/memory_search_tests.rs
@@ -53,9 +53,18 @@ async fn test_basic_search() {
         "Should have found at least one memory"
     );
 
+    assert!(
+        memories.iter().all(|m| m.score.is_finite()),
+        "All results should have finite scores"
+    );
+    assert!(
+        memories.windows(2).all(|w| w[0].score >= w[1].score),
+        "Results should be ordered by descending score"
+    );
+
     // The first result should be the one with "fox" in it
     assert!(
-        memories[0].content.contains("fox"),
+        memories[0].memory.content.contains("fox"),
         "First result should contain 'fox'"
     );
 
@@ -125,17 +134,28 @@ async fn test_search_with_memory_type_filter() {
         "Should have found at least one memory"
     );
 
+    assert!(
+        memories.iter().all(|m| m.score.is_finite()),
+        "All results should have finite scores"
+    );
+    assert!(
+        memories.windows(2).all(|w| w[0].score >= w[1].score),
+        "Results should be ordered by descending score"
+    );
+
     // All results should be episodic memories
     for memory in &memories {
         assert_eq!(
-            memory.memory_type,
+            memory.memory.memory_type,
             MemoryType::Episodic,
             "All results should be episodic memories"
         );
     }
 
     // The result should contain the episodic memory about vacation, not the semantic one
-    let has_episodic_vacation = memories.iter().any(|m| m.content.contains("vacation"));
+    let has_episodic_vacation = memories
+        .iter()
+        .any(|m| m.memory.content.contains("vacation"));
     assert!(
         has_episodic_vacation,
         "Results should include episodic memory about vacation"
@@ -212,10 +232,21 @@ async fn test_search_with_date_filter() {
         "Should have found at least one memory"
     );
 
+    assert!(
+        memories.iter().all(|m| m.score.is_finite()),
+        "All results should have finite scores"
+    );
+    assert!(
+        memories.windows(2).all(|w| w[0].score >= w[1].score),
+        "Results should be ordered by descending score"
+    );
+
     // Results should only include memories from the last 2 days
-    let has_recent = memories.iter().any(|m| m.content.contains("today"));
-    let has_yesterday = memories.iter().any(|m| m.content.contains("yesterday"));
-    let has_old = memories.iter().any(|m| m.content.contains("last week"));
+    let has_recent = memories.iter().any(|m| m.memory.content.contains("today"));
+    let has_yesterday = memories
+        .iter()
+        .any(|m| m.memory.content.contains("yesterday"));
+    let has_old = memories.iter().any(|m| m.memory.content.contains("last week"));
 
     assert!(has_recent, "Results should include today's memory");
     assert!(has_yesterday, "Results should include yesterday's memory");

--- a/tests/memory_search_tests.rs
+++ b/tests/memory_search_tests.rs
@@ -246,7 +246,9 @@ async fn test_search_with_date_filter() {
     let has_yesterday = memories
         .iter()
         .any(|m| m.memory.content.contains("yesterday"));
-    let has_old = memories.iter().any(|m| m.memory.content.contains("last week"));
+    let has_old = memories
+        .iter()
+        .any(|m| m.memory.content.contains("last week"));
 
     assert!(has_recent, "Results should include today's memory");
     assert!(has_yesterday, "Results should include yesterday's memory");

--- a/tests/qdrant_full_text_filter_tests.rs
+++ b/tests/qdrant_full_text_filter_tests.rs
@@ -115,7 +115,9 @@ async fn test_location_text_full_text_token_match() {
     );
 
     assert!(
-        results.iter().any(|m| m.memory.content.contains("Manhattan")),
+        results
+            .iter()
+            .any(|m| m.memory.content.contains("Manhattan")),
         "Expected to find memory in 'New York City' when filtering by 'New York'"
     );
 

--- a/tests/qdrant_full_text_filter_tests.rs
+++ b/tests/qdrant_full_text_filter_tests.rs
@@ -45,7 +45,18 @@ async fn test_participants_full_text_token_match() {
         .unwrap();
 
     assert!(
-        results.iter().any(|m| m.content.contains("Alice Johnson")),
+        results.iter().all(|m| m.score.is_finite()),
+        "All results should have finite scores"
+    );
+    assert!(
+        results.windows(2).all(|w| w[0].score >= w[1].score),
+        "Results should be ordered by descending score"
+    );
+
+    assert!(
+        results
+            .iter()
+            .any(|m| m.memory.content.contains("Alice Johnson")),
         "Expected to find memory containing 'Alice Johnson' via token match on participants"
     );
 
@@ -95,7 +106,16 @@ async fn test_location_text_full_text_token_match() {
         .unwrap();
 
     assert!(
-        results.iter().any(|m| m.content.contains("Manhattan")),
+        results.iter().all(|m| m.score.is_finite()),
+        "All results should have finite scores"
+    );
+    assert!(
+        results.windows(2).all(|w| w[0].score >= w[1].score),
+        "Results should be ordered by descending score"
+    );
+
+    assert!(
+        results.iter().any(|m| m.memory.content.contains("Manhattan")),
         "Expected to find memory in 'New York City' when filtering by 'New York'"
     );
 


### PR DESCRIPTION
### Motivation and Context
This change preserves Qdrant similarity scores returned during vector search instead of discarding them. Keeping scores is required for upcoming hybrid retrieval work (ranking/merging and optional retrieval traces), and also enables callers to reason about result ordering beyond just “first match”.

BREAKING CHANGE: the public search API now returns scored results.

### Description
- Introduces a scored result type end-to-end:
  - Public DTO: `ScoredMemory { memory: Memory, score: f32 }` in scored_memory.rs
  - Internal retrieval type: `ScoredMemoryEntry { entry: MemoryEntry, score: f32 }` in scored_memory_entry.rs
- Plumbs scores from Qdrant through the repository stack:
  - Qdrant `ScoredPoint.score` is now captured during search and returned as `ScoredMemoryEntry` in qdrant_vector_memory_repository.rs
  - `VectorMemoryRepository::search_memory` now returns `Vec<ScoredMemoryEntry>` in vector_memory_repository.rs
  - `MemoryRepository::search_memories` now returns `Vec<ScoredMemoryEntry>` in memory_repository.rs
  - `AgentMemory::search_memories` now returns `Vec<ScoredMemory>` in lib.rs
- Updates integration tests to consume scored search results and assert:
  - score is finite
  - results are ordered by descending score  
  See memory_search_tests.rs and qdrant_full_text_filter_tests.rs.

**API changes (breaking)**
- `AgentMemory::search_memories(...)` changed from `Result<Vec<Memory>, CustomError>` to `Result<Vec<ScoredMemory>, CustomError>`. Callers should update usages from `result.content` to `result.memory.content` and optionally use `result.score`.

### Checklist
- [x] Code builds with **no errors or warnings**
      `cargo check --all-targets`
- [x] **Unit tests pass**
      `cargo test` (CI-style run; integration tests updated)
- [x] **Clippy** passes with warnings denied
      `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt` has been run
- [x] Documentation updated where needed
- [x] BREAKING CHANGE? **Yes** — `search_memories` now returns scored results (`ScoredMemory`)
- [x] I didn’t break anyone 😊

### Additional Notes (optional)