### PR TITLE
:recycle: Rename from AgentMemory to CharacterMemory

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,16 +4,16 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug unit tests in library 'agent_memory'",
+            "name": "Debug unit tests in library 'character_memory'",
             "cargo": {
                 "args": [
                     "test",
                     "--no-run",
                     "--lib",
-                    "--package=agent_memory"
+                    "--package=character_memory"
                 ],
                 "filter": {
-                    "name": "agent_memory",
+                    "name": "character_memory",
                     "kind": "lib"
                 }
             },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,25 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "agent_memory"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "chrono",
- "config",
- "dotenvy",
- "mockall",
- "qdrant-client",
- "reqwest",
- "secrecy",
- "serde",
- "serde_json",
- "thiserror 2.0.14",
- "tokio",
- "uuid",
-]
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +219,25 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "character_memory"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "config",
+ "dotenvy",
+ "mockall",
+ "qdrant-client",
+ "reqwest",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.14",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "chrono"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "agent_memory"
+name = "character_memory"
 version = "0.1.0"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# AgentMemory
+# CharacterMemory
 
 ## Construction
 
-`AgentMemory::new(settings, collection_name)` constructs the default OpenAI + Qdrant-backed instance.
+`CharacterMemory::new(settings, collection_name)` constructs the default OpenAI + Qdrant-backed instance.
 
-For deterministic tests or custom embedding backends, use `AgentMemory::new_with_embedding_provider(settings, collection_name, embed_provider)` with your own implementation of `EmbeddingProvider`.
+For deterministic tests or custom embedding backends, use `CharacterMemory::new_with_embedding_provider(settings, collection_name, embed_provider)` with your own implementation of `EmbeddingProvider`.
 
 ## Running Tests
 
@@ -15,7 +15,7 @@ These integration tests require a local Qdrant instance reachable over gRPC (def
 Using `docker run`:
 
 ```sh
-docker run -d --name agentmemory-qdrant -p 6333:6333 -p 6334:6334 qdrant/qdrant:latest
+docker run -d --name charactermemory-qdrant -p 6333:6333 -p 6334:6334 qdrant/qdrant:latest
 ```
 
 Or using Compose:

--- a/docs/roadmap/agent_thread_kickoff.md
+++ b/docs/roadmap/agent_thread_kickoff.md
@@ -127,9 +127,9 @@ Provide a public construction path where callers can inject embedding generation
 ## Scope
 - Make the embedding provider interface public (or expose a public builder).
 - Add a constructor like:
-  - `AgentMemory::new_with_repositories(embed_repo, vector_repo)` OR
-  - `AgentMemoryBuilder` with `.embedding_provider(...)` / `.vector_store(...)`.
-- Keep the existing convenience path (`AgentMemory::new(settings, collection_name)`) as a default.
+  - `CharacterMemory::new_with_repositories(embed_repo, vector_repo)` OR
+  - `CharacterMemoryBuilder` with `.embedding_provider(...)` / `.vector_store(...)`.
+- Keep the existing convenience path (`CharacterMemory::new(settings, collection_name)`) as a default.
 
 ## Non-goals
 - No change in default behavior for existing users unless explicitly desired.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,19 +44,19 @@ pub mod test_utils {
     }
 }
 
-/// AgentMemory provides a high-level API for memory operations.
+/// CharacterMemory provides a high-level API for memory operations.
 ///
 /// # Description
 ///
 /// This struct serves as the main entry point for memory operations,
 /// providing a high-level interface for storing, retrieving, and
 /// searching memory entries.
-pub struct AgentMemory {
+pub struct CharacterMemory {
     memory_repo: MemoryRepository,
 }
 
-impl AgentMemory {
-    /// Constructs a new AgentMemory instance using a caller-provided embedding provider.
+impl CharacterMemory {
+    /// Constructs a new CharacterMemory instance using a caller-provided embedding provider.
     ///
     /// # Description
     ///
@@ -76,7 +76,7 @@ impl AgentMemory {
     ///
     /// A `Result` which is:
     ///
-    /// - `Ok(Self)`: A new [`AgentMemory`] instance backed by the provided embedding provider
+    /// - `Ok(Self)`: A new [`CharacterMemory`] instance backed by the provided embedding provider
     ///   and a Qdrant-based vector memory repository.
     /// - `Err(CustomError)`: Returned if any error occurs while creating the vector memory
     ///   repository or when resolving configuration from `settings`.
@@ -95,7 +95,7 @@ impl AgentMemory {
         Ok(Self { memory_repo })
     }
 
-    /// Constructs a new AgentMemory instance.
+    /// Constructs a new CharacterMemory instance.
     ///
     /// # Parameters
     ///
@@ -106,7 +106,7 @@ impl AgentMemory {
     ///
     /// A `Result` which is:
     ///
-    /// - `Ok`: A new `AgentMemory` instance
+    /// - `Ok`: A new `CharacterMemory` instance
     /// - `Err`: A `CustomError` if initialization fails
     pub async fn new(settings: Settings, collection_name: String) -> Result<Self, CustomError> {
         // Configure and create the embedding provider

--- a/tests/initialization_tests.rs
+++ b/tests/initialization_tests.rs
@@ -1,10 +1,10 @@
 mod test_utils;
-use test_utils::{cleanup_collection, setup_agent_memory};
+use test_utils::{cleanup_collection, setup_character_memory};
 
 #[tokio::test]
-async fn test_agent_memory_initialization() {
+async fn test_character_memory_initialization() {
     // Setup
-    let (_agent_memory, collection_name) = setup_agent_memory().await;
+    let (_character_memory, collection_name) = setup_character_memory().await;
 
     // The setup function already calls init_storage, so if we got here without errors,
     // it means initialization was successful

--- a/tests/memory_creation_tests.rs
+++ b/tests/memory_creation_tests.rs
@@ -1,11 +1,11 @@
-use agent_memory::{MemoryInput, MemoryType};
+use character_memory::{MemoryInput, MemoryType};
 use chrono::Utc;
 mod test_utils;
 
 #[tokio::test]
 async fn test_create_episodic_memory() {
     // Setup
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     let memory_input = MemoryInput {
         id: None,
@@ -17,7 +17,7 @@ async fn test_create_episodic_memory() {
     };
 
     // Create the memory
-    let result = agent_memory.create_memory(memory_input).await;
+    let result = character_memory.create_memory(memory_input).await;
 
     // Verify the result
     assert!(result.is_ok(), "Failed to create episodic memory");
@@ -37,7 +37,7 @@ async fn test_create_episodic_memory() {
 #[tokio::test]
 async fn test_create_semantic_memory() {
     // Setup
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     let memory_input = MemoryInput {
         id: None,
@@ -49,7 +49,7 @@ async fn test_create_semantic_memory() {
     };
 
     // Create the memory
-    let result = agent_memory.create_memory(memory_input).await;
+    let result = character_memory.create_memory(memory_input).await;
 
     // Verify the result
     assert!(result.is_ok(), "Failed to create semantic memory");
@@ -65,7 +65,7 @@ async fn test_create_semantic_memory() {
 #[tokio::test]
 async fn test_bulk_create_memories() {
     // Setup
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     let memory_inputs = vec![
         MemoryInput {
@@ -95,7 +95,7 @@ async fn test_bulk_create_memories() {
     ];
 
     // Bulk create memories
-    let result = agent_memory.bulk_create_memories(&memory_inputs).await;
+    let result = character_memory.bulk_create_memories(&memory_inputs).await;
 
     // Verify the result
     assert!(result.is_ok(), "Failed to bulk create memories");

--- a/tests/memory_modification_tests.rs
+++ b/tests/memory_modification_tests.rs
@@ -1,4 +1,4 @@
-use agent_memory::{MemoryInput, MemoryType};
+use character_memory::{MemoryInput, MemoryType};
 use chrono::Utc;
 use uuid::Uuid;
 mod test_utils;
@@ -6,7 +6,7 @@ mod test_utils;
 #[tokio::test]
 async fn test_update_memory() {
     // Setup
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     // Create a test memory
     let memory_input = MemoryInput {
@@ -19,9 +19,9 @@ async fn test_update_memory() {
     };
 
     // Create the memory and get its ID
-    let created_memory = agent_memory.create_memory(memory_input).await.unwrap();
+    let created_memory = character_memory.create_memory(memory_input).await.unwrap();
     let memory_id = created_memory.id;
-    test_utils::wait_for_memory(&agent_memory, memory_id).await;
+    test_utils::wait_for_memory(&character_memory, memory_id).await;
 
     // Create an updated memory input with the same ID
     let updated_input = MemoryInput {
@@ -34,7 +34,7 @@ async fn test_update_memory() {
     };
 
     // Update the memory
-    let result = agent_memory.update_memory(updated_input).await;
+    let result = character_memory.update_memory(updated_input).await;
 
     // Verify the result
     assert!(result.is_ok(), "Failed to update memory");
@@ -52,7 +52,7 @@ async fn test_update_memory() {
     );
 
     // Verify the update by retrieving the memory
-    let retrieved = agent_memory.get_memory_by_id(memory_id).await.unwrap();
+    let retrieved = character_memory.get_memory_by_id(memory_id).await.unwrap();
     assert_eq!(retrieved.content, "Updated content");
 
     // Cleanup
@@ -62,7 +62,7 @@ async fn test_update_memory() {
 #[tokio::test]
 async fn test_update_memory_type() {
     // Setup
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     // Create a test memory with Episodic type
     let memory_input = MemoryInput {
@@ -75,9 +75,9 @@ async fn test_update_memory_type() {
     };
 
     // Create the memory and get its ID
-    let created_memory = agent_memory.create_memory(memory_input).await.unwrap();
+    let created_memory = character_memory.create_memory(memory_input).await.unwrap();
     let memory_id = created_memory.id;
-    test_utils::wait_for_memory(&agent_memory, memory_id).await;
+    test_utils::wait_for_memory(&character_memory, memory_id).await;
 
     // Create an updated memory input with Semantic type
     let updated_input = MemoryInput {
@@ -90,7 +90,7 @@ async fn test_update_memory_type() {
     };
 
     // Update the memory
-    let result = agent_memory.update_memory(updated_input).await;
+    let result = character_memory.update_memory(updated_input).await;
 
     // Verify the result
     assert!(result.is_ok(), "Failed to update memory type");
@@ -109,7 +109,7 @@ async fn test_update_memory_type() {
 #[tokio::test]
 async fn test_update_nonexistent_memory() {
     // Setup
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     // Generate a random UUID that doesn't exist in the database
     let nonexistent_id = Uuid::new_v4();
@@ -125,7 +125,7 @@ async fn test_update_nonexistent_memory() {
     };
 
     // Try to update a nonexistent memory
-    let result = agent_memory.update_memory(update_input).await;
+    let result = character_memory.update_memory(update_input).await;
 
     // Verify the result is an error
     assert!(
@@ -140,7 +140,7 @@ async fn test_update_nonexistent_memory() {
 #[tokio::test]
 async fn test_delete_memory() {
     // Setup
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     // Create a test memory
     let memory_input = MemoryInput {
@@ -153,18 +153,18 @@ async fn test_delete_memory() {
     };
 
     // Create the memory and get its ID
-    let created_memory = agent_memory.create_memory(memory_input).await.unwrap();
+    let created_memory = character_memory.create_memory(memory_input).await.unwrap();
     let memory_id = created_memory.id;
-    test_utils::wait_for_memory(&agent_memory, memory_id).await;
+    test_utils::wait_for_memory(&character_memory, memory_id).await;
 
     // Delete the memory
-    let result = agent_memory.delete_memory(memory_id).await;
+    let result = character_memory.delete_memory(memory_id).await;
 
     // Verify the deletion was successful
     assert!(result.is_ok(), "Failed to delete memory");
 
     // Try to retrieve the deleted memory
-    let retrieve_result = agent_memory.get_memory_by_id(memory_id).await;
+    let retrieve_result = character_memory.get_memory_by_id(memory_id).await;
 
     // Verify the memory no longer exists
     assert!(
@@ -179,13 +179,13 @@ async fn test_delete_memory() {
 #[tokio::test]
 async fn test_delete_nonexistent_memory() {
     // Setup
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     // Generate a random UUID that doesn't exist in the database
     let nonexistent_id = Uuid::new_v4();
 
     // Try to delete a nonexistent memory
-    let result = agent_memory.delete_memory(nonexistent_id).await;
+    let result = character_memory.delete_memory(nonexistent_id).await;
 
     // Verify the result is an error
     assert!(

--- a/tests/memory_retrieval_tests.rs
+++ b/tests/memory_retrieval_tests.rs
@@ -1,4 +1,4 @@
-use agent_memory::{MemoryInput, MemoryType};
+use character_memory::{MemoryInput, MemoryType};
 use chrono::Utc;
 use uuid::Uuid;
 mod test_utils;
@@ -6,7 +6,7 @@ mod test_utils;
 #[tokio::test]
 async fn test_get_memory_by_id() {
     // Setup
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     // Create a test memory
     let memory_input = MemoryInput {
@@ -19,11 +19,11 @@ async fn test_get_memory_by_id() {
     };
 
     // Create the memory and get its ID
-    let created_memory = agent_memory.create_memory(memory_input).await.unwrap();
+    let created_memory = character_memory.create_memory(memory_input).await.unwrap();
     let memory_id = created_memory.id;
 
     // Retrieve the memory by ID
-    let retrieved_memory = test_utils::wait_for_memory(&agent_memory, memory_id).await;
+    let retrieved_memory = test_utils::wait_for_memory(&character_memory, memory_id).await;
     assert_eq!(retrieved_memory.id, memory_id);
     assert_eq!(retrieved_memory.content, "Test memory for retrieval");
     assert_eq!(retrieved_memory.memory_type, MemoryType::Episodic);
@@ -35,13 +35,13 @@ async fn test_get_memory_by_id() {
 #[tokio::test]
 async fn test_get_memory_by_nonexistent_id() {
     // Setup
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     // Generate a random UUID that doesn't exist in the database
     let nonexistent_id = Uuid::new_v4();
 
     // Try to retrieve a memory with a nonexistent ID
-    let result = agent_memory.get_memory_by_id(nonexistent_id).await;
+    let result = character_memory.get_memory_by_id(nonexistent_id).await;
 
     // Verify the result is an error
     assert!(
@@ -56,7 +56,7 @@ async fn test_get_memory_by_nonexistent_id() {
 #[tokio::test]
 async fn test_get_memories_by_ids() {
     // Setup
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     // Create multiple test memories
     let memory_inputs = vec![
@@ -79,17 +79,17 @@ async fn test_get_memories_by_ids() {
     ];
 
     // Create the memories and collect their IDs
-    let created_memories = agent_memory
+    let created_memories = character_memory
         .bulk_create_memories(&memory_inputs)
         .await
         .unwrap();
     let memory_ids: Vec<Uuid> = created_memories.iter().map(|m| m.id).collect();
     for memory_id in &memory_ids {
-        test_utils::wait_for_memory(&agent_memory, *memory_id).await;
+        test_utils::wait_for_memory(&character_memory, *memory_id).await;
     }
 
     // Retrieve the memories by IDs
-    let result = agent_memory.get_memories_by_ids(&memory_ids).await;
+    let result = character_memory.get_memories_by_ids(&memory_ids).await;
 
     // Verify the result
     assert!(result.is_ok(), "Failed to retrieve memories by IDs");

--- a/tests/memory_search_tests.rs
+++ b/tests/memory_search_tests.rs
@@ -1,11 +1,11 @@
-use agent_memory::{MemoryFilters, MemoryInput, MemoryType};
+use character_memory::{MemoryFilters, MemoryInput, MemoryType};
 use chrono::{Duration, Utc};
 mod test_utils;
 
 #[tokio::test]
 async fn test_basic_search() {
     // Setup
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     // Create test memories with different content
     let memory_inputs = vec![
@@ -36,16 +36,16 @@ async fn test_basic_search() {
     ];
 
     // Create the memories
-    let created_memories = agent_memory
+    let created_memories = character_memory
         .bulk_create_memories(&memory_inputs)
         .await
         .unwrap();
     for memory in &created_memories {
-        test_utils::wait_for_memory(&agent_memory, memory.id).await;
+        test_utils::wait_for_memory(&character_memory, memory.id).await;
     }
 
     // Search for memories related to "fox"
-    let result = agent_memory.search_memories("fox", 10, None).await;
+    let result = character_memory.search_memories("fox", 10, None).await;
 
     // Verify the result
     assert!(result.is_ok(), "Failed to search memories");
@@ -78,7 +78,7 @@ async fn test_basic_search() {
 #[tokio::test]
 async fn test_search_with_memory_type_filter() {
     // Setup
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     // Create test memories with different types
     let memory_inputs = vec![
@@ -109,12 +109,12 @@ async fn test_search_with_memory_type_filter() {
     ];
 
     // Create the memories
-    let created_memories = agent_memory
+    let created_memories = character_memory
         .bulk_create_memories(&memory_inputs)
         .await
         .unwrap();
     for memory in &created_memories {
-        test_utils::wait_for_memory(&agent_memory, memory.id).await;
+        test_utils::wait_for_memory(&character_memory, memory.id).await;
     }
 
     // Create a filter for episodic memories
@@ -127,7 +127,7 @@ async fn test_search_with_memory_type_filter() {
     };
 
     // Search for memories related to "vacation" with episodic filter
-    let result = agent_memory
+    let result = character_memory
         .search_memories("vacation", 10, Some(filters))
         .await;
 
@@ -174,7 +174,7 @@ async fn test_search_with_memory_type_filter() {
 #[tokio::test]
 async fn test_search_with_date_filter() {
     // Setup
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     // Create test memories with different timestamps
     let now = Utc::now();
@@ -209,12 +209,12 @@ async fn test_search_with_date_filter() {
     ];
 
     // Create the memories
-    let created_memories = agent_memory
+    let created_memories = character_memory
         .bulk_create_memories(&memory_inputs)
         .await
         .unwrap();
     for memory in &created_memories {
-        test_utils::wait_for_memory(&agent_memory, memory.id).await;
+        test_utils::wait_for_memory(&character_memory, memory.id).await;
     }
 
     // Create a filter for memories from the last 2 days
@@ -228,7 +228,7 @@ async fn test_search_with_date_filter() {
     };
 
     // Search for memories with date filter
-    let result = agent_memory
+    let result = character_memory
         .search_memories("memory", 10, Some(filters))
         .await;
 

--- a/tests/qdrant_full_text_filter_tests.rs
+++ b/tests/qdrant_full_text_filter_tests.rs
@@ -1,10 +1,10 @@
-use agent_memory::{MemoryFilters, MemoryInput, MemoryType};
+use character_memory::{MemoryFilters, MemoryInput, MemoryType};
 use chrono::Utc;
 mod test_utils;
 
 #[tokio::test]
 async fn test_participants_full_text_token_match() {
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     let now = Utc::now();
     let memory_inputs = vec![
@@ -26,12 +26,12 @@ async fn test_participants_full_text_token_match() {
         },
     ];
 
-    let created_memories = agent_memory
+    let created_memories = character_memory
         .bulk_create_memories(&memory_inputs)
         .await
         .unwrap();
     for memory in &created_memories {
-        test_utils::wait_for_memory(&agent_memory, memory.id).await;
+        test_utils::wait_for_memory(&character_memory, memory.id).await;
     }
 
     let filters = MemoryFilters {
@@ -42,7 +42,7 @@ async fn test_participants_full_text_token_match() {
         participants: Some(vec!["Alice".to_string()]),
     };
 
-    let results = agent_memory
+    let results = character_memory
         .search_memories("Alice", 10, Some(filters))
         .await
         .unwrap();
@@ -68,7 +68,7 @@ async fn test_participants_full_text_token_match() {
 
 #[tokio::test]
 async fn test_location_text_full_text_token_match() {
-    let (agent_memory, collection_name) = test_utils::setup_agent_memory().await;
+    let (character_memory, collection_name) = test_utils::setup_character_memory().await;
 
     let now = Utc::now();
     let memory_inputs = vec![
@@ -90,12 +90,12 @@ async fn test_location_text_full_text_token_match() {
         },
     ];
 
-    let created_memories = agent_memory
+    let created_memories = character_memory
         .bulk_create_memories(&memory_inputs)
         .await
         .unwrap();
     for memory in &created_memories {
-        test_utils::wait_for_memory(&agent_memory, memory.id).await;
+        test_utils::wait_for_memory(&character_memory, memory.id).await;
     }
 
     let filters = MemoryFilters {
@@ -106,7 +106,7 @@ async fn test_location_text_full_text_token_match() {
         participants: None,
     };
 
-    let results = agent_memory
+    let results = character_memory
         .search_memories("Manhattan", 10, Some(filters))
         .await
         .unwrap();

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -1,6 +1,6 @@
-use agent_memory::test_utils::load_test_settings;
-use agent_memory::{AgentMemory, CustomError, EmbeddingProvider, Memory};
 use async_trait::async_trait;
+use character_memory::test_utils::load_test_settings;
+use character_memory::{CharacterMemory, CustomError, EmbeddingProvider, Memory};
 use qdrant_client::Qdrant;
 use std::env;
 use std::sync::Once;
@@ -84,8 +84,8 @@ fn embedding_vector_size_from_env() -> usize {
     }
 }
 
-// Setup AgentMemory instance with a unique collection
-pub async fn setup_agent_memory() -> (AgentMemory, String) {
+// Setup CharacterMemory instance with a unique collection
+pub async fn setup_character_memory() -> (CharacterMemory, String) {
     initialize();
 
     let collection_name = unique_collection_name();
@@ -96,25 +96,28 @@ pub async fn setup_agent_memory() -> (AgentMemory, String) {
         embedding_vector_size_from_env(),
     ));
 
-    let agent_memory =
-        AgentMemory::new_with_embedding_provider(settings, collection_name.clone(), embed_provider)
-            .await
-            .expect("Failed to create AgentMemory");
+    let character_memory = CharacterMemory::new_with_embedding_provider(
+        settings,
+        collection_name.clone(),
+        embed_provider,
+    )
+    .await
+    .expect("Failed to create CharacterMemory");
 
-    agent_memory
+    character_memory
         .init_storage()
         .await
         .expect("Failed to initialize storage");
 
-    (agent_memory, collection_name)
+    (character_memory, collection_name)
 }
 
 #[allow(dead_code)]
-pub async fn wait_for_memory(agent_memory: &AgentMemory, memory_id: Uuid) -> Memory {
+pub async fn wait_for_memory(character_memory: &CharacterMemory, memory_id: Uuid) -> Memory {
     let mut last_error = None;
 
     for _attempt in 0..20 {
-        match agent_memory.get_memory_by_id(memory_id).await {
+        match character_memory.get_memory_by_id(memory_id).await {
             Ok(memory) => return memory,
             Err(error) => last_error = Some(error),
         }


### PR DESCRIPTION
### Motivation and Context

The repository has been renamed from AgentMemory to CharacterMemory. This change removes old project terminology from the crate metadata, public API, tests, documentation, roadmap examples, and local debug configuration so the codebase consistently uses the new name.

### Description

- Rename the Rust crate/package from `agent_memory` to `character_memory`.
- Rename the primary public API type from `AgentMemory` to `CharacterMemory`.
- Update test imports, helper names, local variables, README examples, roadmap API examples, Qdrant container naming, and VS Code launch metadata.

### Checklist

- [x] Code builds with **no errors or warnings**
      `cargo check --all-targets`
- [x] **Unit tests pass**
      `cargo test --verbose`
- [x] **Clippy** passes with warnings denied
      `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt` has been run
- [x] Documentation updated where needed
- [x] BREAKING CHANGE? **Yes** / downstream users must update crate imports from `agent_memory` to `character_memory` and the primary type from `AgentMemory` to `CharacterMemory`.
- [x] I didn't break anyone 😊

### Additional Notes (optional)

Qdrant was started locally with `docker compose -f docker-compose.qdrant.yml up -d` before running the full integration test suite.