### PR TITLE
:white_check_mark: Fix stale Qdrant reads after upsert

### DIFF
--- a/src/internal/infrastructures/external_services/qdrant_vector_memory_repository.rs
+++ b/src/internal/infrastructures/external_services/qdrant_vector_memory_repository.rs
@@ -315,8 +315,9 @@ impl VectorMemoryRepository for QdrantVectorMemoryRepository {
         let payload = Self::build_qdrant_payload(memory)?;
 
         let point = PointStruct::new(memory.id.to_string(), memory.embedding.clone(), payload);
-        let upsert_req =
-            UpsertPointsBuilder::new(&self.config.collection_name, vec![point]).build();
+        let upsert_req = UpsertPointsBuilder::new(&self.config.collection_name, vec![point])
+            .wait(true)
+            .build();
         self.client.upsert_points(upsert_req).await?;
         Ok(())
     }
@@ -456,7 +457,9 @@ impl VectorMemoryRepository for QdrantVectorMemoryRepository {
             })
             .collect::<Result<_, CustomError>>()?;
 
-        let upsert_req = UpsertPointsBuilder::new(&self.config.collection_name, points).build();
+        let upsert_req = UpsertPointsBuilder::new(&self.config.collection_name, points)
+            .wait(true)
+            .build();
         self.client.upsert_points(upsert_req).await?;
         Ok(())
     }


### PR DESCRIPTION
### Motivation and Context
Qdrant upserts can be acknowledged before an immediate read observes the updated payload. This caused `test_update_memory` to sometimes retrieve `Original content` right after updating to `Updated content`.

### Description
Adds `.wait(true)` to Qdrant upsert requests in `QdrantVectorMemoryRepository` so single-memory writes and bulk inserts wait until changes are applied before returning. This keeps update/create visibility consistent for immediate reads without changing the public API.

### Checklist

- [x] Code builds with **no errors or warnings**
      `cargo check --all-targets`
- [x] **Unit tests pass**
      `cargo test --verbose`
- [x] **Clippy** passes with warnings denied
      `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt` has been run
- [x] Documentation updated where needed
- [x] BREAKING CHANGE? **No**
- [x] I didn’t break anyone 😊

### Additional Notes (optional)
Validation also covered the previously failing `memory_modification_tests`; all 5 tests passed as part of the full verbose suite.