### PR TITLE
:sparkles: Add store contracts and deterministic fakes

### DIFF
--- a/.github/workflows/check_formatting.yaml
+++ b/.github/workflows/check_formatting.yaml
@@ -17,6 +17,7 @@ jobs:
     - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
+        toolchain: 1.95.0
         components: rustfmt
 
     - name: Check formatting

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.95.0
           override: true
           components: clippy
 

--- a/docs/coding-agent/lessons.md
+++ b/docs/coding-agent/lessons.md
@@ -21,6 +21,33 @@ Purpose:
 
 ## Entries
 
+## 2026-04-28 - Explain Temporary Suppressions  [tags: review, code-quality, communication]
+
+Context:
+- Plan: `docs/coding-agent/plans/completed/v0-1-store-contracts-test-harness-plan.md`
+- Task/Wave: PR review follow-up
+- Roles involved: Orchestrator
+
+Symptom:
+- Added `allow` suppressions for transitional v0.1 contract/test-support code without explaining why they exist or when they can be removed.
+- User clarified that code should not just work without context when the safe revision point is not obvious.
+
+Root cause:
+- Treated the suppression as self-explanatory implementation scaffolding instead of documenting the temporary boundary it protects.
+
+Fix applied:
+- Added concise rationale and removal-condition comments for the transitional `dead_code` and `unused_imports` suppressions.
+
+Prevention:
+- Repo rule candidate:
+  - audience: common
+  - proposed rule: Temporary lint suppressions should explain why they exist and when they can be safely removed, unless the reason is obvious from nearby code.
+- Dispatch/plan guardrail:
+  - During review follow-up, inspect newly added `allow` attributes for rationale and removal conditions before marking comments resolved.
+
+Evidence:
+- Suppression comments added to v0.1 store contract and test-support modules.
+
 ## 2026-04-27 - Hidden PR Template Discovery  [tags: tooling, output-contract]
 
 Context:

--- a/docs/coding-agent/plans/active/v0-1-vector-graph-adapter-foundations-plan.md
+++ b/docs/coding-agent/plans/active/v0-1-vector-graph-adapter-foundations-plan.md
@@ -1,0 +1,228 @@
+# Plan: v0.1 Vector And Graph Adapter Foundations
+
+- status: draft
+- generated: 2026-04-27
+- last_updated: 2026-04-27
+- work_type: mixed
+
+## Goal
+- Build the first live-adapter foundation on top of the v0.1 store contracts and deterministic test harness.
+- Keep Qdrant responsible for vector candidate recall and filterable payload hints.
+- Introduce Oxigraph/RDF graph authority behavior for canonical v0.1 memory objects and links without implementing remember/retrieve/link/correct/forget pipelines.
+
+## Definition of Done
+- Qdrant-facing vector payload mapping exists for indexed v0.1 object records without making Qdrant authoritative for graph relationships.
+- Natural-language embedding surface builders exist for indexed v0.1 objects and remain deterministic in tests.
+- Oxigraph/RDF mapping exists for canonical domain objects and memory links.
+- Adapter tests cover payload/RDF mapping, stable IDs/graph URIs, lifecycle/currentness fields, and bounded graph expansion behavior at the adapter-foundation level.
+- Required Rust checks and targeted adapter-foundation tests pass, or blockers are recorded with evidence.
+- Reviewer approves the adapter-foundation diff and validation evidence.
+
+## Scope / Non-goals
+- Scope:
+  - Qdrant payload record/mapping for `Episode`, `Observation`, `DerivedMemory`, `MemoryThread`, and `Entity` vector candidates.
+  - Natural-language embedding surface construction for vector-indexed records.
+  - Oxigraph/RDF vocabulary and mapping for canonical v0.1 objects and `MemoryLink` relationships.
+  - Adapter-foundation tests that can run deterministically without requiring live services where practical.
+  - Gated or documented live-service checks only where adapter behavior requires them.
+- Non-goals:
+  - Public `remember`, `retrieve`, `link`, `correct`, or `forget` pipeline implementation.
+  - Full hybrid retrieval, reranking, continuity context pack assembly, or rationale generation.
+  - Production raw input storage.
+  - Compatibility wrappers for the old flat API.
+  - Broad removal of legacy flat API surfaces unless directly required to integrate the new adapter foundation.
+
+## Context (workspace)
+- Related files/areas:
+  - `src/api/types/domain.rs`
+  - `src/internal/models/vector/**`
+  - `src/internal/repositories/**`
+  - `src/internal/infrastructures/external_services/**`
+  - `src/config/**`
+  - `tests/**`
+  - `docs/coding-agent/plans/completed/v0-1-store-contracts-test-harness-plan.md`
+- Existing patterns or references:
+  - Store contracts now live under `src/internal/repositories/` and use canonical v0.1 domain types.
+  - Deterministic fakes and fixtures live under `src/internal/repositories/test_support.rs` behind `cfg(test)`.
+  - Existing Qdrant adapter code is legacy flat-memory-shaped and should be replaced or isolated as v0.1 adapter work lands.
+- Repo reference docs consulted:
+  - `docs/design/roadmap-phases/v0_1_storage_and_backend_contracts.md`
+  - `docs/decisions/implementation/ADR-I-0003-qdrant-oxigraph-defaults.md`
+  - `docs/decisions/implementation/ADR-I-0005-qdrant-payload-vs-graph-authority.md`
+  - `docs/decisions/implementation/ADR-I-0006-bounded-graph-expansion.md`
+
+## Open Questions
+- Q1: Should this chunk add the Oxigraph crate and use an embedded/in-memory Oxigraph test path immediately, or first land RDF mapping helpers with a trait-backed fake and add the dependency in a narrower follow-up?
+- Q2: Should Qdrant live-service checks remain fully gated in this chunk, or should an adapter smoke test be required when local Qdrant configuration is present?
+
+## Assumptions
+- A1: Qdrant payload mapping can be implemented as provider-specific adapter code while keeping the internal `VectorCandidateStore` contract provider-neutral.
+- A2: Oxigraph graph authority should be introduced behind the `GraphAuthorityStore` contract and should not leak RDF/SPARQL types into canonical domain models.
+- A3: Graph relationships and lifecycle/currentness remain authoritative in the graph store; duplicated Qdrant payload fields are filter hints.
+- A4: Raw input remains consumer-owned; adapters should carry or preserve raw references only.
+
+## Tasks
+
+### Task_1: Select adapter module and dependency boundary
+- type: design
+- owns:
+  - `src/internal/infrastructures/**`
+  - `src/internal/repositories/**`
+  - `src/internal/models/**`
+  - `Cargo.toml`
+  - `docs/coding-agent/plans/active/v0-1-vector-graph-adapter-foundations-plan.md`
+- depends_on: []
+- description: |
+  Inspect the current Qdrant adapter/config layout and choose the concrete module/dependency boundary for v0.1 Qdrant and Oxigraph adapter foundations before implementation.
+- acceptance:
+  - Decision records where Qdrant payload mapping and Oxigraph/RDF mapping will live.
+  - Decision records whether this chunk adds an Oxigraph dependency or defers it.
+  - Decision keeps vendor-specific types out of canonical domain and provider-neutral repository contracts.
+  - Decision identifies any legacy flat adapter pieces that can be replaced or must temporarily coexist for compilation.
+- validation:
+  - kind: review
+    required: true
+    owner: worker
+    detail: "Inspect adapter/config layout and record the selected v0.1 adapter boundary."
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Review adapter boundary for consistency with store contracts and storage ADRs."
+
+### Task_2: Add Qdrant vector payload foundation
+- type: impl
+- owns:
+  - `src/internal/models/vector/**`
+  - `src/internal/infrastructures/external_services/**`
+  - `src/internal/repositories/**`
+- depends_on: [Task_1]
+- description: |
+  Add Qdrant-facing payload mapping for v0.1 vector candidate records and natural-language embedding surfaces without implementing retrieval pipelines.
+- acceptance:
+  - Payload mapping includes stable object ID, graph URI, object/record type, schema version, embedding text, content text, lifecycle/currentness hints where applicable, and relevant episode/observation/thread/entity IDs.
+  - Embedding surface builders produce natural-language text rather than structured metadata templates.
+  - Mapping tests cover representative v0.1 objects using deterministic fixtures.
+  - Qdrant remains candidate/filter infrastructure and does not become graph authority.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo fmt --check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --no-run"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "Run targeted vector payload/embedding-surface tests added by this task."
+
+### Task_3: Add graph authority mapping foundation
+- type: impl
+- owns:
+  - `Cargo.toml`
+  - `src/internal/infrastructures/**`
+  - `src/internal/repositories/**`
+  - `src/internal/models/**`
+- depends_on: [Task_1]
+- description: |
+  Add RDF/Oxigraph graph authority mapping or a pre-Oxigraph RDF mapping layer, depending on the Task_1 boundary decision.
+- acceptance:
+  - Mapping covers canonical objects and `MemoryLink` relationships needed for provenance, entity/thread links, supersession, retention state, and currentness.
+  - Stable graph URIs use the canonical domain helper.
+  - Bounded expansion adapter behavior or mapping-level expansion inputs preserve explicit max-depth/max-node limits.
+  - No retrieval context-pack or public pipeline behavior is implemented.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo fmt --check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --no-run"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "Run targeted graph mapping/adapter-foundation tests added by this task."
+
+### Task_4: Validate adapter boundaries and update next plan
+- type: review
+- owns:
+  - `docs/coding-agent/plans/active/**`
+- depends_on: [Task_2, Task_3]
+- description: |
+  Review the adapter-foundation diff and validation evidence. If approved, draft the next concrete remember/link pipeline plan from the landed adapter shape.
+- acceptance:
+  - Reviewer approves the adapter-foundation diff or blocking issues are resolved/waived.
+  - Required validation evidence from Tasks 1-3 is present.
+  - This plan's Progress Log and Decision Log are updated with outcomes.
+  - A separate active plan for remember/link pipelines is drafted from the landed code shape.
+- validation:
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Review adapter-foundation implementation against storage contracts, ADRs, and validation evidence."
+  - kind: review
+    required: true
+    owner: orchestrator
+    detail: "Confirm the next concrete plan is independent and based on landed adapter-foundation code."
+
+## Task Waves (explicit parallel dispatch sets)
+
+- Wave 1 (design gate): [Task_1]
+- Wave 2 (adapter mappings): [Task_2, Task_3]
+- Wave 3 (review and next-plan draft): [Task_4]
+
+## E2E / Visual Validation Spec
+
+- Not applicable. This is Rust storage adapter infrastructure with no UI/user-flow surface.
+
+## Rollback / Safety
+- Keep vendor-specific Qdrant/Oxigraph types outside canonical domain model modules.
+- Keep graph authority semantics in graph mapping/adapter code; Qdrant payload fields are filter hints only.
+- Keep raw input storage consumer-owned and preserve only raw references.
+- Keep live-service checks gated and documented if they cannot run deterministically in local unit tests.
+
+## Quality Routing Note
+- Routing level: L2
+- In-scope docs: Rust adapter architecture, storage boundary design, deterministic adapter/mapping tests, validation evidence, data-integrity boundaries.
+- Out-of-scope docs: UI/E2E, auth/security, public pipeline behavior, production raw storage.
+- Top risks: data-integrity, external dependency/integration, contract/API/schema compatibility, architectural drift between Qdrant payload hints and graph authority.
+- Risk profile: medium-high; this chunk introduces live-backend adapter foundations and may add an Oxigraph dependency, but should keep behavior bounded to mappings/adapters.
+- Required checks: `cargo fmt --check`, `cargo check`, `cargo test --no-run`, targeted mapping/adapter tests, Reviewer gate.
+- Optional recommended checks: gated Qdrant/Oxigraph live-service smoke checks if local prerequisites are available and documented.
+- At Risk items: Oxigraph dependency timing, live-service validation prerequisites, and avoiding duplicated graph authority in Qdrant payloads.
+
+## Progress Log
+
+- 2026-04-27 Plan drafted.
+  - Summary: Created the next concrete plan from the landed v0.1 store contracts and deterministic test harness shape.
+  - Validation evidence: Pending approval and execution.
+  - Notes: Draft keeps remember/retrieve/link/correct/forget pipelines out of scope.
+
+## Decision Log
+
+- 2026-04-27 Decision: Draft adapter-foundation plan from store contract shape
+  - Trigger / new insight: Store contracts and deterministic fakes now define provider-neutral boundaries for vector candidates, graph authority, embeddings, and raw reference resolution.
+  - Plan delta: Created `v0-1-vector-graph-adapter-foundations-plan.md` as the next concrete plan.
+  - Tradeoffs considered: Splitting adapter foundations from remember/retrieve pipelines keeps storage mapping and backend responsibilities reviewable before behavior pipelines depend on them.
+  - User approval: pending.
+
+## Notes
+- Risks:
+  - Qdrant payload fields can drift from graph truth unless later write flows update both predictably.
+  - Oxigraph dependency and test strategy may need a design gate before implementation.
+  - Hub entities can create expansion pressure; adapter tests should preserve explicit bounds.
+- Edge cases:
+  - Suppressed/deleted and non-current/superseded state must be represented for later filtering, even if retrieval filtering is not implemented here.
+  - Raw refs must survive mapping without adding raw text storage to Qdrant or Oxigraph.
+  - Natural-language embedding surfaces should avoid metadata-template strings that hurt semantic recall.

--- a/docs/coding-agent/plans/completed/v0-1-store-contracts-test-harness-plan.md
+++ b/docs/coding-agent/plans/completed/v0-1-store-contracts-test-harness-plan.md
@@ -51,7 +51,13 @@
   - `docs/decisions/implementation/ADR-I-0006-bounded-graph-expansion.md`
 
 ## Open Questions
-- Q1: Should fake graph expansion live entirely in tests, or should an in-memory graph implementation live under internal test-support modules for reuse by later pipeline tests?
+- None for Task_1. Q1 resolved: reusable fake graph expansion and reusable fake stores/fixtures should live under internal `cfg(test)` test-support modules when later pipeline tests need to share them; module-local `tests.rs` files remain acceptable for tests that are not reusable.
+
+## Review Mode
+- mode: remediation
+- scope: final-plan-review
+- max_iterations: 2
+- status: completed
 
 ## Assumptions
 - A1: Store contracts may live under `src/internal/repositories` or a new internal store module, but must depend on canonical public domain types rather than old flat DTOs.
@@ -204,6 +210,48 @@
   - Validation evidence: Pending approval and execution.
   - Notes: Drafted from the landed domain foundation model shape.
 
+- 2026-04-27 Task_1 completed: selected store contract/test-support boundary.
+  - Summary: Inspected the current internal repository and model layout, confirmed the existing `MemoryRepository`, `VectorMemoryRepository`, `MemoryEntry`, `VectorMetadata`, and `ScoredMemoryEntry` stack is legacy flat API infrastructure, and recorded the v0.1 boundary before implementation.
+  - Validation evidence: Manual review of `src/api/types/domain.rs`, `src/api/types/domain/tests.rs`, `src/internal/repositories.rs`, `src/internal/repositories/memory_repository.rs`, `src/internal/repositories/vector_memory_repository.rs`, `src/internal/models.rs`, `src/internal/models/memory/**`, `src/internal/models/vector/**`, `src/internal.rs`, and `tests/test_utils.rs`.
+  - Notes: No Rust code or live Qdrant/Oxigraph adapter behavior was changed; cargo commands were not required for this docs/design-only task.
+
+- 2026-04-27 Task_1 reviewer gate approved.
+  - Summary: Reviewer approved the selected production/test-support/legacy boundary with no findings.
+  - Validation evidence: Reviewer confirmed the decision is recorded in the Progress Log and Decision Log, keeps v0.1 contracts tied to canonical domain types and IDs, scopes old flat repository/model pieces as replacement-target legacy, separates production contracts from `cfg(test)` support, and resolves Q1.
+  - Notes: Residual risk is limited to Task_3 deciding whether later integration tests need a public test-helper route or should stay source-module-local.
+
+- 2026-04-27 Task_2 complete: defined v0.1 store and embedder contracts.
+  - Summary: Added provider-neutral contracts for vector candidate storage, graph authority storage, deterministic embedding, and raw reference resolution. Added vector candidate/search/match and embedding input model types under the internal vector model boundary.
+  - Validation evidence: Worker ran `cargo fmt --check`, `cargo check`, and `cargo test --no-run`; all passed after formatting the new Rust modules.
+  - Notes: Contracts use canonical v0.1 `MemoryId`, `ObjectType`, `MemoryObject`, and `MemoryLink` types and do not add live Qdrant/Oxigraph adapters, production raw storage, or pipeline behavior.
+
+- 2026-04-27 Task_3 complete: added deterministic fake stores and fixtures.
+  - Summary: Added `cfg(test)` repository test support with in-memory fake vector, graph, embedder, and raw reference resolver implementations plus representative v0.1 fixtures covering episode, observation, entities, soft thread link, derived reflection, user preference, open loop, commitment, correction/suppression, and hub entity seeds.
+  - Validation evidence: Worker ran final `cargo fmt --check`, `cargo check`, `cargo test --no-run`, and targeted `cargo test internal::repositories::test_support`; all passed. Targeted tests covered fake vector upsert/search/delete, fake graph object/link/lifecycle/raw-ref preservation, deterministic embedding, file-backed raw reference resolution, and fixture scenario coverage.
+  - Notes: Initial formatting and `cfg(test)` compile issues were fixed before final validation; no service-backed tests or live adapters were introduced.
+
+- 2026-04-27 Task_4 complete: final review approved and adapter-foundation plan drafted.
+  - Summary: Final Reviewer approved the store contracts and deterministic test harness with no findings, and remediation mode completed with zero follow-up iterations. Drafted the next active plan for vector and graph adapter foundations.
+  - Validation evidence: Reviewer reviewed changed code and validation evidence, reran `cargo fmt --check`, `cargo check`, `cargo test --no-run`, and `cargo test internal::repositories::test_support`; all passed. Structured remediation appendix reported `structured_findings: []`, `status: APPROVED`, and `highest_severity: NONE`.
+  - Notes: The next plan is independent and keeps remember/retrieve/link/correct/forget pipeline behavior out of scope.
+
+## Review Remediation Log
+
+### Iteration 0 Result
+- Reviewer status: APPROVED
+- Highest severity: NONE
+- Kept findings: none
+- Discarded findings: none
+- Directives: none
+- Follow-up task: none
+- Validation result after follow-up: not applicable; post-review PR-template validation also passed `cargo fmt`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --verbose` after a small clippy cleanup.
+- Stop reason: approved
+
+### Final Cleanup Review Result
+- Reviewer status after clippy cleanup: APPROVED
+- Remaining findings: none
+- Stop reason: approved
+
 ## Decision Log (append-only; re-plans and major discoveries)
 
 - 2026-04-27 Decision: Draft store contracts plan from landed domain model
@@ -211,6 +259,16 @@
   - Plan delta: Created `v0-1-store-contracts-test-harness-plan.md` as the next concrete plan.
   - Tradeoffs considered: Defining contracts and fakes before live adapters keeps later Qdrant/Oxigraph work testable without external services.
   - User approval: pending.
+
+- 2026-04-27 Decision: Place v0.1 store contracts in internal repositories with test-only reusable support
+  - Trigger / new insight: Task_1 review found the current repository/model stack is organized around legacy flat `MemoryInput`/`MemoryType` DTOs and vector database concerns rather than the canonical v0.1 object model.
+  - Production boundary: Add v0.1 contract traits under direct files in `src/internal/repositories/` and re-export them from `src/internal/repositories.rs`. These contracts must depend on canonical domain types and IDs from `src/api/types/domain.rs`; do not duplicate `Episode`, `Observation`, `Entity`, `MemoryThread`, `DerivedMemory`, or `MemoryLink` under `src/internal/models`.
+  - Vector candidate boundary: If Task_2 needs a vector candidate record that is not itself a canonical domain object, place it under `src/internal/models/vector/` using a direct filename and re-export it through `src/internal/models/vector.rs`.
+  - Test-support boundary: Put reusable deterministic fakes, fixture builders, and fake graph expansion support in `src/internal/repositories/test_support.rs` behind `cfg(test)` when they need reuse across later pipeline tests. Keep one-off assertions in module-local `tests.rs` files when they are not reusable.
+  - Legacy boundary: Treat `MemoryRepository`, `VectorMemoryRepository`, `MemoryEntry`, `VectorMetadata`, `ScoredMemoryEntry`, and the current Qdrant adapter as replacement targets for v0.1. Keep them only while needed for current compilation during replacement, and do not add compatibility wrappers for the old flat API.
+  - Non-goals preserved: This decision does not implement live Qdrant/Oxigraph adapters, remember/retrieve/link/correct/forget pipelines, or production raw storage.
+  - Tradeoffs considered: Keeping reusable fakes under internal `cfg(test)` support avoids service dependencies and duplication in later pipeline tests, while keeping production contracts in repository modules preserves a narrow internal boundary for adapter work.
+  - User approval: directed by Task_1 objective.
 
 ## Notes
 - Risks:

--- a/docs/coding-agent/plans/completed/v0-1-vector-graph-adapter-foundations-plan.md
+++ b/docs/coding-agent/plans/completed/v0-1-vector-graph-adapter-foundations-plan.md
@@ -1,6 +1,6 @@
 # Plan: v0.1 Vector And Graph Adapter Foundations
 
-- status: draft
+- status: done
 - generated: 2026-04-27
 - last_updated: 2026-04-27
 - work_type: mixed

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]

--- a/src/internal/models/vector.rs
+++ b/src/internal/models/vector.rs
@@ -2,6 +2,9 @@ mod candidate_record;
 mod embedding_model;
 mod vector_metadata;
 
+// Transitional v0.1 contract surface: these re-exports are consumed by test
+// support before production adapters use all of them. Remove once adapter or
+// pipeline code consumes the surface directly, or prune unused exports.
 #[allow(unused_imports)]
 pub(crate) use candidate_record::{
     EmbeddingInput, VectorCandidateMatch, VectorCandidateRecord, VectorCandidateSearch,

--- a/src/internal/models/vector.rs
+++ b/src/internal/models/vector.rs
@@ -1,5 +1,11 @@
+mod candidate_record;
 mod embedding_model;
 mod vector_metadata;
 
+#[allow(unused_imports)]
+pub(crate) use candidate_record::{
+    EmbeddingInput, VectorCandidateMatch, VectorCandidateRecord, VectorCandidateSearch,
+    VectorSurface,
+};
 pub(crate) use embedding_model::EmbeddingModel;
 pub(crate) use vector_metadata::VectorMetadata;

--- a/src/internal/models/vector/candidate_record.rs
+++ b/src/internal/models/vector/candidate_record.rs
@@ -1,3 +1,6 @@
+// Transitional v0.1 contract model surface: some fields/builders are reserved
+// for adapter and pipeline chunks. Remove once those chunks consume the record
+// types directly, or prune unused members.
 #![allow(dead_code)]
 
 use crate::api::types::{MemoryId, ObjectType};

--- a/src/internal/models/vector/candidate_record.rs
+++ b/src/internal/models/vector/candidate_record.rs
@@ -1,0 +1,156 @@
+#![allow(dead_code)]
+
+use crate::api::types::{MemoryId, ObjectType};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VectorSurface {
+    Summary,
+    Text,
+    Name,
+    DerivedText,
+    Query,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct EmbeddingInput {
+    pub(crate) object_id: Option<MemoryId>,
+    pub(crate) object_type: Option<ObjectType>,
+    pub(crate) surface: VectorSurface,
+    pub(crate) text: String,
+}
+
+impl EmbeddingInput {
+    pub(crate) fn new(
+        object_id: Option<MemoryId>,
+        object_type: Option<ObjectType>,
+        surface: VectorSurface,
+        text: impl Into<String>,
+    ) -> Self {
+        Self {
+            object_id,
+            object_type,
+            surface,
+            text: text.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct VectorCandidateRecord {
+    pub(crate) object_id: MemoryId,
+    pub(crate) object_type: ObjectType,
+    pub(crate) surface: VectorSurface,
+    pub(crate) embedding: Vec<f32>,
+}
+
+impl VectorCandidateRecord {
+    pub(crate) fn new(
+        object_id: MemoryId,
+        object_type: ObjectType,
+        surface: VectorSurface,
+        embedding: Vec<f32>,
+    ) -> Self {
+        Self {
+            object_id,
+            object_type,
+            surface,
+            embedding,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct VectorCandidateSearch {
+    pub(crate) query_embedding: Vec<f32>,
+    pub(crate) limit: usize,
+    pub(crate) object_types: Vec<ObjectType>,
+}
+
+impl VectorCandidateSearch {
+    pub(crate) fn new(query_embedding: Vec<f32>, limit: usize) -> Self {
+        Self {
+            query_embedding,
+            limit,
+            object_types: Vec::new(),
+        }
+    }
+
+    pub(crate) fn with_object_types(mut self, object_types: Vec<ObjectType>) -> Self {
+        self.object_types = object_types;
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct VectorCandidateMatch {
+    pub(crate) object_id: MemoryId,
+    pub(crate) object_type: ObjectType,
+    pub(crate) surface: VectorSurface,
+    pub(crate) score: f32,
+}
+
+impl VectorCandidateMatch {
+    pub(crate) fn new(
+        object_id: MemoryId,
+        object_type: ObjectType,
+        surface: VectorSurface,
+        score: f32,
+    ) -> Self {
+        Self {
+            object_id,
+            object_type,
+            surface,
+            score,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vector_candidate_record_keeps_domain_identity_and_embedding_surface() {
+        let object_id = MemoryId::new_v4();
+        let record = VectorCandidateRecord::new(
+            object_id,
+            ObjectType::Observation,
+            VectorSurface::Text,
+            vec![0.1, 0.2, 0.3],
+        );
+
+        assert_eq!(record.object_id, object_id);
+        assert_eq!(record.object_type, ObjectType::Observation);
+        assert_eq!(record.surface, VectorSurface::Text);
+        assert_eq!(record.embedding, vec![0.1, 0.2, 0.3]);
+    }
+
+    #[test]
+    fn vector_candidate_search_can_scope_by_canonical_object_types() {
+        let search = VectorCandidateSearch::new(vec![1.0, 0.0], 10)
+            .with_object_types(vec![ObjectType::Episode, ObjectType::DerivedMemory]);
+
+        assert_eq!(search.query_embedding, vec![1.0, 0.0]);
+        assert_eq!(search.limit, 10);
+        assert_eq!(
+            search.object_types,
+            vec![ObjectType::Episode, ObjectType::DerivedMemory]
+        );
+    }
+
+    #[test]
+    fn embedding_input_keeps_raw_text_consumer_supplied() {
+        let object_id = MemoryId::new_v4();
+        let input = EmbeddingInput::new(
+            Some(object_id),
+            Some(ObjectType::Episode),
+            VectorSurface::Summary,
+            "episode summary",
+        );
+
+        assert_eq!(input.object_id, Some(object_id));
+        assert_eq!(input.object_type, Some(ObjectType::Episode));
+        assert_eq!(input.surface, VectorSurface::Summary);
+        assert_eq!(input.text, "episode summary");
+    }
+}

--- a/src/internal/repositories.rs
+++ b/src/internal/repositories.rs
@@ -7,15 +7,28 @@ pub(crate) mod test_support;
 mod vector_candidate_store;
 mod vector_memory_repository;
 
+// Transitional v0.1 contract surface: remove this allow once adapter or
+// pipeline code consumes the embedder contract directly, or prune the re-export.
 #[allow(unused_imports)]
 pub(crate) use embedder::MemoryEmbedder;
+
+// Transitional v0.1 contract surface: remove this allow once adapter or
+// pipeline code consumes the graph authority contract directly, or prune unused
+// exports.
 #[allow(unused_imports)]
 pub(crate) use graph_authority_store::{
     GraphAuthorityStore, GraphExpansion, GraphExpansionQuery, GraphObjectQuery,
 };
 pub(crate) use memory_repository::MemoryRepository;
+
+// Transitional v0.1 contract surface: remove this allow once adapter or
+// pipeline code consumes raw-reference resolution directly, or prune unused
+// exports.
 #[allow(unused_imports)]
 pub(crate) use raw_reference_resolver::{RawReference, RawReferenceResolver};
+
+// Transitional v0.1 contract surface: remove this allow once adapter or
+// pipeline code consumes vector candidate storage directly, or prune the re-export.
 #[allow(unused_imports)]
 pub(crate) use vector_candidate_store::VectorCandidateStore;
 pub(crate) use vector_memory_repository::VectorMemoryRepository;

--- a/src/internal/repositories.rs
+++ b/src/internal/repositories.rs
@@ -1,5 +1,21 @@
+mod embedder;
+mod graph_authority_store;
 mod memory_repository;
+mod raw_reference_resolver;
+#[cfg(test)]
+pub(crate) mod test_support;
+mod vector_candidate_store;
 mod vector_memory_repository;
 
+#[allow(unused_imports)]
+pub(crate) use embedder::MemoryEmbedder;
+#[allow(unused_imports)]
+pub(crate) use graph_authority_store::{
+    GraphAuthorityStore, GraphExpansion, GraphExpansionQuery, GraphObjectQuery,
+};
 pub(crate) use memory_repository::MemoryRepository;
+#[allow(unused_imports)]
+pub(crate) use raw_reference_resolver::{RawReference, RawReferenceResolver};
+#[allow(unused_imports)]
+pub(crate) use vector_candidate_store::VectorCandidateStore;
 pub(crate) use vector_memory_repository::VectorMemoryRepository;

--- a/src/internal/repositories/embedder.rs
+++ b/src/internal/repositories/embedder.rs
@@ -1,3 +1,6 @@
+// Transitional v0.1 repository contract: implemented first so later adapters
+// and pipelines can target a stable boundary. Remove once production consumers
+// exercise the full contract, or prune unused methods.
 #![allow(dead_code)]
 
 use async_trait::async_trait;

--- a/src/internal/repositories/embedder.rs
+++ b/src/internal/repositories/embedder.rs
@@ -1,0 +1,24 @@
+#![allow(dead_code)]
+
+use async_trait::async_trait;
+
+use crate::errors::CustomError;
+use crate::internal::models::vector::EmbeddingInput;
+
+#[async_trait]
+pub(crate) trait MemoryEmbedder: Send + Sync {
+    async fn embed(&self, input: &EmbeddingInput) -> Result<Vec<f32>, CustomError>;
+
+    async fn embed_batch(&self, inputs: &[EmbeddingInput]) -> Result<Vec<Vec<f32>>, CustomError>;
+}
+
+#[async_trait]
+impl<T: MemoryEmbedder + ?Sized> MemoryEmbedder for Box<T> {
+    async fn embed(&self, input: &EmbeddingInput) -> Result<Vec<f32>, CustomError> {
+        (**self).embed(input).await
+    }
+
+    async fn embed_batch(&self, inputs: &[EmbeddingInput]) -> Result<Vec<Vec<f32>>, CustomError> {
+        (**self).embed_batch(inputs).await
+    }
+}

--- a/src/internal/repositories/graph_authority_store.rs
+++ b/src/internal/repositories/graph_authority_store.rs
@@ -1,0 +1,157 @@
+#![allow(dead_code)]
+
+use async_trait::async_trait;
+
+use crate::api::types::{MemoryId, MemoryLink, MemoryObject, ObjectType};
+use crate::errors::CustomError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GraphObjectQuery {
+    pub(crate) object_ids: Vec<MemoryId>,
+    pub(crate) object_types: Vec<ObjectType>,
+    pub(crate) limit: Option<usize>,
+}
+
+impl GraphObjectQuery {
+    pub(crate) fn by_ids(object_ids: Vec<MemoryId>) -> Self {
+        Self {
+            object_ids,
+            object_types: Vec::new(),
+            limit: None,
+        }
+    }
+
+    pub(crate) fn by_types(object_types: Vec<ObjectType>, limit: Option<usize>) -> Self {
+        Self {
+            object_ids: Vec::new(),
+            object_types,
+            limit,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GraphExpansionQuery {
+    pub(crate) root_id: MemoryId,
+    pub(crate) root_type: ObjectType,
+    pub(crate) max_depth: u8,
+    pub(crate) max_nodes: usize,
+    pub(crate) allowed_object_types: Vec<ObjectType>,
+}
+
+impl GraphExpansionQuery {
+    pub(crate) fn new(
+        root_id: MemoryId,
+        root_type: ObjectType,
+        max_depth: u8,
+        max_nodes: usize,
+    ) -> Self {
+        Self {
+            root_id,
+            root_type,
+            max_depth,
+            max_nodes,
+            allowed_object_types: Vec::new(),
+        }
+    }
+
+    pub(crate) fn with_allowed_object_types(mut self, object_types: Vec<ObjectType>) -> Self {
+        self.allowed_object_types = object_types;
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct GraphExpansion {
+    pub(crate) objects: Vec<MemoryObject>,
+    pub(crate) links: Vec<MemoryLink>,
+}
+
+impl GraphExpansion {
+    pub(crate) fn new(objects: Vec<MemoryObject>, links: Vec<MemoryLink>) -> Self {
+        Self { objects, links }
+    }
+}
+
+#[async_trait]
+pub(crate) trait GraphAuthorityStore: Send + Sync {
+    async fn upsert_objects(&self, objects: &[MemoryObject]) -> Result<(), CustomError>;
+
+    async fn upsert_links(&self, links: &[MemoryLink]) -> Result<(), CustomError>;
+
+    async fn query_objects(
+        &self,
+        query: &GraphObjectQuery,
+    ) -> Result<Vec<MemoryObject>, CustomError>;
+
+    async fn expand_bounded(
+        &self,
+        query: &GraphExpansionQuery,
+    ) -> Result<GraphExpansion, CustomError>;
+}
+
+#[async_trait]
+impl<T: GraphAuthorityStore + ?Sized> GraphAuthorityStore for Box<T> {
+    async fn upsert_objects(&self, objects: &[MemoryObject]) -> Result<(), CustomError> {
+        (**self).upsert_objects(objects).await
+    }
+
+    async fn upsert_links(&self, links: &[MemoryLink]) -> Result<(), CustomError> {
+        (**self).upsert_links(links).await
+    }
+
+    async fn query_objects(
+        &self,
+        query: &GraphObjectQuery,
+    ) -> Result<Vec<MemoryObject>, CustomError> {
+        (**self).query_objects(query).await
+    }
+
+    async fn expand_bounded(
+        &self,
+        query: &GraphExpansionQuery,
+    ) -> Result<GraphExpansion, CustomError> {
+        (**self).expand_bounded(query).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn graph_queries_use_domain_ids_and_object_types() {
+        let episode_id = MemoryId::new_v4();
+        let by_ids = GraphObjectQuery::by_ids(vec![episode_id]);
+        let by_types = GraphObjectQuery::by_types(vec![ObjectType::Episode], Some(5));
+
+        assert_eq!(by_ids.object_ids, vec![episode_id]);
+        assert_eq!(by_ids.object_types, Vec::<ObjectType>::new());
+        assert_eq!(by_types.object_types, vec![ObjectType::Episode]);
+        assert_eq!(by_types.limit, Some(5));
+    }
+
+    #[test]
+    fn bounded_expansion_query_carries_explicit_limits() {
+        let root_id = MemoryId::new_v4();
+        let query = GraphExpansionQuery::new(root_id, ObjectType::Entity, 2, 25)
+            .with_allowed_object_types(vec![ObjectType::Observation, ObjectType::DerivedMemory]);
+
+        assert_eq!(query.root_id, root_id);
+        assert_eq!(query.root_type, ObjectType::Entity);
+        assert_eq!(query.max_depth, 2);
+        assert_eq!(query.max_nodes, 25);
+        assert_eq!(
+            query.allowed_object_types,
+            vec![ObjectType::Observation, ObjectType::DerivedMemory]
+        );
+    }
+
+    #[test]
+    fn graph_expansion_groups_objects_and_links_without_store_behavior() {
+        let expansion = GraphExpansion::new(Vec::new(), Vec::new());
+
+        assert!(expansion.objects.is_empty());
+        assert!(expansion.links.is_empty());
+    }
+}

--- a/src/internal/repositories/graph_authority_store.rs
+++ b/src/internal/repositories/graph_authority_store.rs
@@ -1,3 +1,6 @@
+// Transitional v0.1 repository contract: implemented before the live graph
+// adapter and retrieval pipeline. Remove once those chunks consume the full
+// contract surface, or prune unused query shapes.
 #![allow(dead_code)]
 
 use async_trait::async_trait;

--- a/src/internal/repositories/raw_reference_resolver.rs
+++ b/src/internal/repositories/raw_reference_resolver.rs
@@ -1,0 +1,45 @@
+#![allow(dead_code)]
+
+use async_trait::async_trait;
+
+use crate::errors::CustomError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RawReference {
+    pub(crate) reference: String,
+    pub(crate) text: String,
+}
+
+impl RawReference {
+    pub(crate) fn new(reference: impl Into<String>, text: impl Into<String>) -> Self {
+        Self {
+            reference: reference.into(),
+            text: text.into(),
+        }
+    }
+}
+
+#[async_trait]
+pub(crate) trait RawReferenceResolver: Send + Sync {
+    async fn resolve(&self, reference: &str) -> Result<Option<RawReference>, CustomError>;
+}
+
+#[async_trait]
+impl<T: RawReferenceResolver + ?Sized> RawReferenceResolver for Box<T> {
+    async fn resolve(&self, reference: &str) -> Result<Option<RawReference>, CustomError> {
+        (**self).resolve(reference).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_reference_is_resolved_content_not_storage_configuration() {
+        let raw = RawReference::new("chat://conversation/1#turn=2", "hello");
+
+        assert_eq!(raw.reference, "chat://conversation/1#turn=2");
+        assert_eq!(raw.text, "hello");
+    }
+}

--- a/src/internal/repositories/raw_reference_resolver.rs
+++ b/src/internal/repositories/raw_reference_resolver.rs
@@ -1,3 +1,6 @@
+// Transitional v0.1 repository contract: raw references are resolved by later
+// adapters/pipelines while raw storage remains consumer-owned. Remove once the
+// resolver is consumed directly, or prune unused DTO/method surface.
 #![allow(dead_code)]
 
 use async_trait::async_trait;

--- a/src/internal/repositories/test_support.rs
+++ b/src/internal/repositories/test_support.rs
@@ -261,11 +261,16 @@ impl FixtureRawReferenceResolver {
         Self::default()
     }
 
-    pub(crate) fn insert(&self, reference: impl Into<String>, text: impl Into<String>) {
+    pub(crate) fn insert(
+        &self,
+        reference: impl Into<String>,
+        text: impl Into<String>,
+    ) -> Result<(), CustomError> {
         let raw_reference = RawReference::new(reference, text);
-        let mut entries = self.entries.lock().unwrap();
+        let mut entries = lock(&self.entries)?;
         entries.retain(|entry| entry.reference != raw_reference.reference);
         entries.push(raw_reference);
+        Ok(())
     }
 
     pub(crate) fn insert_file(
@@ -275,8 +280,7 @@ impl FixtureRawReferenceResolver {
     ) -> Result<(), CustomError> {
         let text = fs::read_to_string(path)
             .map_err(|error| CustomError::DatabaseError(error.to_string()))?;
-        self.insert(reference, text);
-        Ok(())
+        self.insert(reference, text)
     }
 }
 
@@ -687,6 +691,10 @@ fn surface_rank(surface: VectorSurface) -> u8 {
 }
 
 fn cosine_similarity(left: &[f32], right: &[f32]) -> f32 {
+    if left.len() != right.len() {
+        return 0.0;
+    }
+
     let dot_product: f32 = left
         .iter()
         .zip(right.iter())
@@ -906,5 +914,10 @@ mod tests {
             .hub_links
             .iter()
             .any(|link| link.from_id == fixtures.hub_entity.id));
+    }
+
+    #[test]
+    fn cosine_similarity_rejects_mismatched_dimensions() {
+        assert_eq!(cosine_similarity(&[1.0, 0.0], &[1.0, 0.0, 0.0]), 0.0);
     }
 }

--- a/src/internal/repositories/test_support.rs
+++ b/src/internal/repositories/test_support.rs
@@ -215,7 +215,7 @@ impl GraphAuthorityStore for FakeGraphAuthorityStore {
                     && visited.contains(&(link.to_id, link.to_type))
             })
             .collect();
-        expanded_links.sort_by(|left, right| left.id.cmp(&right.id));
+        expanded_links.sort_by_key(|link| link.id);
 
         Ok(GraphExpansion::new(expanded_objects, expanded_links))
     }

--- a/src/internal/repositories/test_support.rs
+++ b/src/internal/repositories/test_support.rs
@@ -1,3 +1,6 @@
+// Transitional v0.1 test harness: exposes reusable fakes and fixtures for
+// downstream adapter/pipeline tests before every helper is used. Remove once
+// downstream tests consume the full support surface, or prune unused helpers.
 #![allow(dead_code)]
 
 use std::collections::{HashSet, VecDeque};

--- a/src/internal/repositories/test_support.rs
+++ b/src/internal/repositories/test_support.rs
@@ -1,0 +1,907 @@
+#![allow(dead_code)]
+
+use std::collections::{HashSet, VecDeque};
+use std::fs;
+use std::path::Path;
+use std::sync::{Mutex, MutexGuard};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::api::types::{
+    DerivedMemory, DerivedType, Entity, EntityType, Episode, MemoryId, MemoryLink, MemoryObject,
+    MemoryThread, Modality, ObjectType, Observation, RelationType, RetentionState, Stability,
+    ThreadStatus, DEFAULT_SCHEMA_VERSION,
+};
+use crate::errors::CustomError;
+use crate::internal::models::vector::{
+    EmbeddingInput, VectorCandidateMatch, VectorCandidateRecord, VectorCandidateSearch,
+    VectorSurface,
+};
+use crate::internal::repositories::{
+    GraphAuthorityStore, GraphExpansion, GraphExpansionQuery, GraphObjectQuery, MemoryEmbedder,
+    RawReference, RawReferenceResolver, VectorCandidateStore,
+};
+
+#[derive(Debug, Default)]
+pub(crate) struct FakeVectorCandidateStore {
+    records: Mutex<Vec<VectorCandidateRecord>>,
+}
+
+impl FakeVectorCandidateStore {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl VectorCandidateStore for FakeVectorCandidateStore {
+    async fn upsert_candidates(
+        &self,
+        candidates: &[VectorCandidateRecord],
+    ) -> Result<(), CustomError> {
+        let mut records = lock(&self.records)?;
+
+        for candidate in candidates {
+            records.retain(|record| {
+                record.object_id != candidate.object_id || record.surface != candidate.surface
+            });
+            records.push(candidate.clone());
+        }
+
+        Ok(())
+    }
+
+    async fn search_candidates(
+        &self,
+        query: &VectorCandidateSearch,
+    ) -> Result<Vec<VectorCandidateMatch>, CustomError> {
+        let records = lock(&self.records)?;
+        let mut matches: Vec<_> = records
+            .iter()
+            .filter(|record| {
+                query.object_types.is_empty() || query.object_types.contains(&record.object_type)
+            })
+            .map(|record| {
+                VectorCandidateMatch::new(
+                    record.object_id,
+                    record.object_type,
+                    record.surface,
+                    cosine_similarity(&query.query_embedding, &record.embedding),
+                )
+            })
+            .collect();
+
+        matches.sort_by(|left, right| {
+            right
+                .score
+                .total_cmp(&left.score)
+                .then_with(|| left.object_id.cmp(&right.object_id))
+                .then_with(|| {
+                    object_type_rank(left.object_type).cmp(&object_type_rank(right.object_type))
+                })
+                .then_with(|| surface_rank(left.surface).cmp(&surface_rank(right.surface)))
+        });
+        matches.truncate(query.limit);
+
+        Ok(matches)
+    }
+
+    async fn delete_candidates(&self, object_ids: &[MemoryId]) -> Result<(), CustomError> {
+        let delete_ids: HashSet<_> = object_ids.iter().copied().collect();
+        lock(&self.records)?.retain(|record| !delete_ids.contains(&record.object_id));
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct FakeGraphAuthorityStore {
+    objects: Mutex<Vec<MemoryObject>>,
+    links: Mutex<Vec<MemoryLink>>,
+}
+
+impl FakeGraphAuthorityStore {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl GraphAuthorityStore for FakeGraphAuthorityStore {
+    async fn upsert_objects(&self, objects: &[MemoryObject]) -> Result<(), CustomError> {
+        let mut stored = lock(&self.objects)?;
+
+        for object in objects {
+            let (object_id, object_type) = object_identity(object);
+            stored.retain(|existing| object_identity(existing) != (object_id, object_type));
+            stored.push(object.clone());
+        }
+
+        Ok(())
+    }
+
+    async fn upsert_links(&self, links: &[MemoryLink]) -> Result<(), CustomError> {
+        let mut stored = lock(&self.links)?;
+
+        for link in links {
+            stored.retain(|existing| existing.id != link.id);
+            stored.push(link.clone());
+        }
+
+        Ok(())
+    }
+
+    async fn query_objects(
+        &self,
+        query: &GraphObjectQuery,
+    ) -> Result<Vec<MemoryObject>, CustomError> {
+        let mut objects: Vec<_> = lock(&self.objects)?
+            .iter()
+            .filter(|object| {
+                let (object_id, object_type) = object_identity(object);
+                (query.object_ids.is_empty() || query.object_ids.contains(&object_id))
+                    && (query.object_types.is_empty() || query.object_types.contains(&object_type))
+            })
+            .cloned()
+            .collect();
+
+        sort_objects(&mut objects);
+        if let Some(limit) = query.limit {
+            objects.truncate(limit);
+        }
+
+        Ok(objects)
+    }
+
+    async fn expand_bounded(
+        &self,
+        query: &GraphExpansionQuery,
+    ) -> Result<GraphExpansion, CustomError> {
+        if query.max_nodes == 0 {
+            return Ok(GraphExpansion::new(Vec::new(), Vec::new()));
+        }
+
+        let objects = lock(&self.objects)?.clone();
+        let links = lock(&self.links)?.clone();
+        let mut visited = HashSet::new();
+        let mut queue = VecDeque::from([(query.root_id, query.root_type, 0_u8)]);
+
+        while let Some((object_id, object_type, depth)) = queue.pop_front() {
+            if visited.len() >= query.max_nodes || !visited.insert((object_id, object_type)) {
+                continue;
+            }
+
+            if depth >= query.max_depth {
+                continue;
+            }
+
+            let mut neighbors: Vec<_> = links
+                .iter()
+                .filter_map(|link| {
+                    if link.from_id == object_id && link.from_type == object_type {
+                        Some((link.to_id, link.to_type))
+                    } else if link.to_id == object_id && link.to_type == object_type {
+                        Some((link.from_id, link.from_type))
+                    } else {
+                        None
+                    }
+                })
+                .filter(|(_, neighbor_type)| {
+                    query.allowed_object_types.is_empty()
+                        || query.allowed_object_types.contains(neighbor_type)
+                })
+                .collect();
+            neighbors.sort_by_key(|node| stable_node_key(*node));
+
+            for neighbor in neighbors {
+                if visited.len() + queue.len() >= query.max_nodes && !visited.contains(&neighbor) {
+                    continue;
+                }
+                queue.push_back((neighbor.0, neighbor.1, depth + 1));
+            }
+        }
+
+        let mut expanded_objects: Vec<_> = objects
+            .into_iter()
+            .filter(|object| visited.contains(&object_identity(object)))
+            .collect();
+        sort_objects(&mut expanded_objects);
+
+        let mut expanded_links: Vec<_> = links
+            .into_iter()
+            .filter(|link| {
+                visited.contains(&(link.from_id, link.from_type))
+                    && visited.contains(&(link.to_id, link.to_type))
+            })
+            .collect();
+        expanded_links.sort_by(|left, right| left.id.cmp(&right.id));
+
+        Ok(GraphExpansion::new(expanded_objects, expanded_links))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DeterministicMemoryEmbedder {
+    dimensions: usize,
+}
+
+impl DeterministicMemoryEmbedder {
+    pub(crate) fn new(dimensions: usize) -> Self {
+        Self { dimensions }
+    }
+}
+
+#[async_trait]
+impl MemoryEmbedder for DeterministicMemoryEmbedder {
+    async fn embed(&self, input: &EmbeddingInput) -> Result<Vec<f32>, CustomError> {
+        Ok(deterministic_embedding(input, self.dimensions))
+    }
+
+    async fn embed_batch(&self, inputs: &[EmbeddingInput]) -> Result<Vec<Vec<f32>>, CustomError> {
+        let embeddings = inputs
+            .iter()
+            .map(|input| deterministic_embedding(input, self.dimensions))
+            .collect();
+
+        Ok(embeddings)
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct FixtureRawReferenceResolver {
+    entries: Mutex<Vec<RawReference>>,
+}
+
+impl FixtureRawReferenceResolver {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn insert(&self, reference: impl Into<String>, text: impl Into<String>) {
+        let raw_reference = RawReference::new(reference, text);
+        let mut entries = self.entries.lock().unwrap();
+        entries.retain(|entry| entry.reference != raw_reference.reference);
+        entries.push(raw_reference);
+    }
+
+    pub(crate) fn insert_file(
+        &self,
+        reference: impl Into<String>,
+        path: &Path,
+    ) -> Result<(), CustomError> {
+        let text = fs::read_to_string(path)
+            .map_err(|error| CustomError::DatabaseError(error.to_string()))?;
+        self.insert(reference, text);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl RawReferenceResolver for FixtureRawReferenceResolver {
+    async fn resolve(&self, reference: &str) -> Result<Option<RawReference>, CustomError> {
+        Ok(lock(&self.entries)?
+            .iter()
+            .find(|entry| entry.reference == reference)
+            .cloned())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RepresentativeFixtures {
+    pub(crate) episode: Episode,
+    pub(crate) salient_observation: Observation,
+    pub(crate) user_entity: Entity,
+    pub(crate) assistant_entity: Entity,
+    pub(crate) project_entity: Entity,
+    pub(crate) hub_entity: Entity,
+    pub(crate) soft_thread: MemoryThread,
+    pub(crate) derived_reflection: DerivedMemory,
+    pub(crate) user_preference: DerivedMemory,
+    pub(crate) open_loop: DerivedMemory,
+    pub(crate) commitment: DerivedMemory,
+    pub(crate) correction: DerivedMemory,
+    pub(crate) suppressed_seed: DerivedMemory,
+    pub(crate) soft_thread_link: MemoryLink,
+    pub(crate) hub_links: Vec<MemoryLink>,
+}
+
+impl RepresentativeFixtures {
+    pub(crate) fn objects(&self) -> Vec<MemoryObject> {
+        vec![
+            MemoryObject::Episode(self.episode.clone()),
+            MemoryObject::Observation(self.salient_observation.clone()),
+            MemoryObject::Entity(self.user_entity.clone()),
+            MemoryObject::Entity(self.assistant_entity.clone()),
+            MemoryObject::Entity(self.project_entity.clone()),
+            MemoryObject::Entity(self.hub_entity.clone()),
+            MemoryObject::MemoryThread(self.soft_thread.clone()),
+            MemoryObject::DerivedMemory(self.derived_reflection.clone()),
+            MemoryObject::DerivedMemory(self.user_preference.clone()),
+            MemoryObject::DerivedMemory(self.open_loop.clone()),
+            MemoryObject::DerivedMemory(self.commitment.clone()),
+            MemoryObject::DerivedMemory(self.correction.clone()),
+            MemoryObject::DerivedMemory(self.suppressed_seed.clone()),
+        ]
+    }
+
+    pub(crate) fn links(&self) -> Vec<MemoryLink> {
+        let mut links = vec![self.soft_thread_link.clone()];
+        links.extend(self.hub_links.clone());
+        links
+    }
+}
+
+pub(crate) fn representative_fixtures() -> RepresentativeFixtures {
+    let episode = simple_episode();
+    let salient_observation = salient_observation(episode.id, fixture_id(1));
+    let user_entity = entity(
+        fixture_id(1),
+        EntityType::User,
+        "Kohta",
+        Some("person:kohta"),
+    );
+    let assistant_entity = entity(
+        fixture_id(2),
+        EntityType::Assistant,
+        "Assistant",
+        Some("assistant:default"),
+    );
+    let project_entity = entity(
+        fixture_id(3),
+        EntityType::Project,
+        "CharacterMemory",
+        Some("project:character-memory"),
+    );
+    let hub_entity = entity(
+        fixture_id(4),
+        EntityType::Concept,
+        "v0.1 contracts",
+        Some("concept:v0.1-contracts"),
+    );
+    let soft_thread = soft_thread();
+    let derived_reflection = derived_memory(
+        fixture_id(30),
+        DerivedType::Reflection,
+        "The user wants service-free contract tests before pipeline wiring.",
+        episode.id,
+        salient_observation.id,
+        vec![soft_thread.id],
+        vec![user_entity.id, project_entity.id],
+        true,
+        Vec::new(),
+        RetentionState::Active,
+    );
+    let user_preference = derived_memory(
+        fixture_id(31),
+        DerivedType::UserPreference,
+        "Prefer deterministic local fakes for contract-level tests.",
+        episode.id,
+        salient_observation.id,
+        vec![soft_thread.id],
+        vec![user_entity.id],
+        true,
+        Vec::new(),
+        RetentionState::Active,
+    );
+    let open_loop = derived_memory(
+        fixture_id(32),
+        DerivedType::OpenLoop,
+        "Add pipeline tests once store contracts have reusable fakes.",
+        episode.id,
+        salient_observation.id,
+        vec![soft_thread.id],
+        vec![project_entity.id],
+        true,
+        Vec::new(),
+        RetentionState::Active,
+    );
+    let commitment = derived_memory(
+        fixture_id(33),
+        DerivedType::Commitment,
+        "Complete Task_3 with service-free validation.",
+        episode.id,
+        salient_observation.id,
+        vec![soft_thread.id],
+        vec![assistant_entity.id, project_entity.id],
+        true,
+        Vec::new(),
+        RetentionState::Active,
+    );
+    let correction = derived_memory(
+        fixture_id(34),
+        DerivedType::Correction,
+        "Correction seed supersedes an outdated preference seed.",
+        episode.id,
+        salient_observation.id,
+        vec![soft_thread.id],
+        vec![user_entity.id],
+        true,
+        vec![fixture_id(35)],
+        RetentionState::Active,
+    );
+    let suppressed_seed = derived_memory(
+        fixture_id(35),
+        DerivedType::UserPreference,
+        "Suppressed seed retained to prove lifecycle preservation.",
+        episode.id,
+        salient_observation.id,
+        vec![soft_thread.id],
+        vec![user_entity.id],
+        false,
+        Vec::new(),
+        RetentionState::Suppressed,
+    );
+    let soft_thread_link = link(
+        fixture_id(50),
+        salient_observation.id,
+        ObjectType::Observation,
+        soft_thread.id,
+        ObjectType::MemoryThread,
+        RelationType::PartOfThread,
+    );
+    let hub_links = vec![
+        link(
+            fixture_id(51),
+            hub_entity.id,
+            ObjectType::Entity,
+            episode.id,
+            ObjectType::Episode,
+            RelationType::Involves,
+        ),
+        link(
+            fixture_id(52),
+            hub_entity.id,
+            ObjectType::Entity,
+            derived_reflection.id,
+            ObjectType::DerivedMemory,
+            RelationType::About,
+        ),
+        link(
+            fixture_id(53),
+            correction.id,
+            ObjectType::DerivedMemory,
+            suppressed_seed.id,
+            ObjectType::DerivedMemory,
+            RelationType::Supersedes,
+        ),
+        link(
+            fixture_id(54),
+            open_loop.id,
+            ObjectType::DerivedMemory,
+            commitment.id,
+            ObjectType::DerivedMemory,
+            RelationType::FulfillsCommitment,
+        ),
+    ];
+
+    RepresentativeFixtures {
+        episode,
+        salient_observation,
+        user_entity,
+        assistant_entity,
+        project_entity,
+        hub_entity,
+        soft_thread,
+        derived_reflection,
+        user_preference,
+        open_loop,
+        commitment,
+        correction,
+        suppressed_seed,
+        soft_thread_link,
+        hub_links,
+    }
+}
+
+pub(crate) fn simple_episode() -> Episode {
+    Episode {
+        id: fixture_id(10),
+        object_type: ObjectType::Episode,
+        modality: Modality::Chat,
+        source_conversation_id: Some("conversation:v0.1-fixture".to_owned()),
+        started_at: Some(timestamp("2026-04-27T10:00:00Z")),
+        ended_at: Some(timestamp("2026-04-27T10:10:00Z")),
+        participant_entity_ids: vec![fixture_id(1), fixture_id(2)],
+        summary: "Discussed deterministic v0.1 store contract fixtures.".to_owned(),
+        raw_ref: Some("file:fixtures/raw/simple-episode.txt".to_owned()),
+        salience_score: 0.8,
+        retention_state: RetentionState::Active,
+        created_at: timestamp("2026-04-27T10:11:00Z"),
+        schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+    }
+}
+
+pub(crate) fn salient_observation(
+    episode_id: MemoryId,
+    speaker_entity_id: MemoryId,
+) -> Observation {
+    Observation {
+        id: fixture_id(20),
+        object_type: ObjectType::Observation,
+        episode_id,
+        speaker_entity_id: Some(speaker_entity_id),
+        observed_at: Some(timestamp("2026-04-27T10:03:00Z")),
+        modality: Modality::Chat,
+        text: "Use deterministic fakes instead of service-backed stores.".to_owned(),
+        raw_ref: Some("file:fixtures/raw/salient-observation.txt".to_owned()),
+        salience_score: 0.9,
+        retention_state: RetentionState::Active,
+        created_at: timestamp("2026-04-27T10:11:01Z"),
+        schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+    }
+}
+
+fn entity(
+    id: MemoryId,
+    entity_type: EntityType,
+    name: impl Into<String>,
+    canonical_key: Option<&str>,
+) -> Entity {
+    Entity {
+        id,
+        object_type: ObjectType::Entity,
+        entity_type,
+        name: name.into(),
+        aliases: Vec::new(),
+        canonical_key: canonical_key.map(str::to_owned),
+        summary: Some("Representative fixture entity.".to_owned()),
+        created_at: timestamp("2026-04-27T10:11:02Z"),
+        updated_at: timestamp("2026-04-27T10:11:03Z"),
+        schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+    }
+}
+
+fn soft_thread() -> MemoryThread {
+    MemoryThread {
+        id: fixture_id(25),
+        object_type: ObjectType::MemoryThread,
+        title: "v0.1 contract test support".to_owned(),
+        summary: "Soft thread connecting store-contract fixture objects.".to_owned(),
+        status: ThreadStatus::Active,
+        last_touched_at: timestamp("2026-04-27T10:11:04Z"),
+        salience_score: 0.7,
+        canonical_key: Some("thread:v0.1-contract-test-support".to_owned()),
+        created_at: timestamp("2026-04-27T10:11:02Z"),
+        updated_at: timestamp("2026-04-27T10:11:04Z"),
+        schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn derived_memory(
+    id: MemoryId,
+    derived_type: DerivedType,
+    text: impl Into<String>,
+    episode_id: MemoryId,
+    observation_id: MemoryId,
+    thread_ids: Vec<MemoryId>,
+    entity_ids: Vec<MemoryId>,
+    is_current: bool,
+    supersedes: Vec<MemoryId>,
+    retention_state: RetentionState,
+) -> DerivedMemory {
+    DerivedMemory {
+        id,
+        object_type: ObjectType::DerivedMemory,
+        derived_type,
+        text: text.into(),
+        derived_from_episode_ids: vec![episode_id],
+        derived_from_observation_ids: vec![observation_id],
+        thread_ids,
+        entity_ids,
+        confidence: 0.85,
+        salience_score: 0.75,
+        stability: Stability::Medium,
+        is_current,
+        supersedes,
+        retention_state,
+        created_at: timestamp("2026-04-27T10:11:05Z"),
+        updated_at: timestamp("2026-04-27T10:11:06Z"),
+        schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+    }
+}
+
+fn link(
+    id: MemoryId,
+    from_id: MemoryId,
+    from_type: ObjectType,
+    to_id: MemoryId,
+    to_type: ObjectType,
+    relation: RelationType,
+) -> MemoryLink {
+    MemoryLink {
+        id,
+        object_type: ObjectType::MemoryLink,
+        from_id,
+        from_type,
+        to_id,
+        to_type,
+        relation,
+        confidence: 0.9,
+        rationale: Some("Representative fixture link.".to_owned()),
+        created_at: timestamp("2026-04-27T10:11:07Z"),
+        schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+    }
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, CustomError> {
+    mutex
+        .lock()
+        .map_err(|error| CustomError::DatabaseError(format!("test support lock poisoned: {error}")))
+}
+
+fn fixture_id(suffix: u128) -> MemoryId {
+    Uuid::from_u128(0x550e_8400_e29b_41d4_a716_4466_5544_0000 + suffix)
+}
+
+fn timestamp(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+        .unwrap()
+        .with_timezone(&Utc)
+}
+
+fn object_identity(object: &MemoryObject) -> (MemoryId, ObjectType) {
+    match object {
+        MemoryObject::Episode(object) => (object.id, object.object_type),
+        MemoryObject::Observation(object) => (object.id, object.object_type),
+        MemoryObject::Entity(object) => (object.id, object.object_type),
+        MemoryObject::MemoryThread(object) => (object.id, object.object_type),
+        MemoryObject::DerivedMemory(object) => (object.id, object.object_type),
+        MemoryObject::MemoryLink(object) => (object.id, object.object_type),
+    }
+}
+
+fn sort_objects(objects: &mut [MemoryObject]) {
+    objects.sort_by(|left, right| {
+        stable_node_key(object_identity(left)).cmp(&stable_node_key(object_identity(right)))
+    });
+}
+
+fn stable_node_key(node: (MemoryId, ObjectType)) -> (MemoryId, u8) {
+    (node.0, object_type_rank(node.1))
+}
+
+fn object_type_rank(object_type: ObjectType) -> u8 {
+    match object_type {
+        ObjectType::Episode => 0,
+        ObjectType::Observation => 1,
+        ObjectType::Entity => 2,
+        ObjectType::MemoryThread => 3,
+        ObjectType::DerivedMemory => 4,
+        ObjectType::MemoryLink => 5,
+    }
+}
+
+fn surface_rank(surface: VectorSurface) -> u8 {
+    match surface {
+        VectorSurface::Summary => 0,
+        VectorSurface::Text => 1,
+        VectorSurface::Name => 2,
+        VectorSurface::DerivedText => 3,
+        VectorSurface::Query => 4,
+    }
+}
+
+fn cosine_similarity(left: &[f32], right: &[f32]) -> f32 {
+    let dot_product: f32 = left
+        .iter()
+        .zip(right.iter())
+        .map(|(left, right)| left * right)
+        .sum();
+    let left_magnitude = left.iter().map(|value| value * value).sum::<f32>().sqrt();
+    let right_magnitude = right.iter().map(|value| value * value).sum::<f32>().sqrt();
+
+    if left_magnitude == 0.0 || right_magnitude == 0.0 {
+        0.0
+    } else {
+        dot_product / (left_magnitude * right_magnitude)
+    }
+}
+
+fn deterministic_embedding(input: &EmbeddingInput, dimensions: usize) -> Vec<f32> {
+    let mut embedding = vec![0.0; dimensions];
+    if dimensions == 0 {
+        return embedding;
+    }
+
+    let seed = format!("{:?}|{:?}|{}", input.object_type, input.surface, input.text);
+    for (index, byte) in seed.bytes().enumerate() {
+        let slot = index % dimensions;
+        let signed = (byte as f32 / 255.0) - 0.5;
+        embedding[slot] += signed;
+    }
+
+    let magnitude = embedding
+        .iter()
+        .map(|value| value * value)
+        .sum::<f32>()
+        .sqrt();
+    if magnitude > 0.0 {
+        for value in &mut embedding {
+            *value /= magnitude;
+        }
+    }
+
+    embedding
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn vector_fake_upserts_searches_and_deletes_deterministically() {
+        let store = FakeVectorCandidateStore::new();
+        let fixtures = representative_fixtures();
+
+        store
+            .upsert_candidates(&[
+                VectorCandidateRecord::new(
+                    fixtures.episode.id,
+                    ObjectType::Episode,
+                    VectorSurface::Summary,
+                    vec![1.0, 0.0],
+                ),
+                VectorCandidateRecord::new(
+                    fixtures.salient_observation.id,
+                    ObjectType::Observation,
+                    VectorSurface::Text,
+                    vec![0.0, 1.0],
+                ),
+            ])
+            .await
+            .unwrap();
+
+        let query = VectorCandidateSearch::new(vec![1.0, 0.0], 10);
+        let first_result = store.search_candidates(&query).await.unwrap();
+        let second_result = store.search_candidates(&query).await.unwrap();
+
+        assert_eq!(first_result, second_result);
+        assert_eq!(first_result[0].object_id, fixtures.episode.id);
+        assert_eq!(first_result[0].object_type, ObjectType::Episode);
+        assert_eq!(first_result[0].surface, VectorSurface::Summary);
+
+        store
+            .delete_candidates(&[fixtures.episode.id])
+            .await
+            .unwrap();
+        let after_delete = store.search_candidates(&query).await.unwrap();
+
+        assert_eq!(after_delete.len(), 1);
+        assert_eq!(after_delete[0].object_id, fixtures.salient_observation.id);
+    }
+
+    #[tokio::test]
+    async fn graph_fake_preserves_objects_links_lifecycle_and_raw_refs() {
+        let store = FakeGraphAuthorityStore::new();
+        let fixtures = representative_fixtures();
+
+        store.upsert_objects(&fixtures.objects()).await.unwrap();
+        store.upsert_links(&fixtures.links()).await.unwrap();
+
+        let queried = store
+            .query_objects(&GraphObjectQuery::by_ids(vec![
+                fixtures.episode.id,
+                fixtures.suppressed_seed.id,
+            ]))
+            .await
+            .unwrap();
+
+        assert!(queried.contains(&MemoryObject::Episode(fixtures.episode.clone())));
+        assert!(queried.contains(&MemoryObject::DerivedMemory(
+            fixtures.suppressed_seed.clone()
+        )));
+        assert_eq!(
+            fixtures.episode.raw_ref.as_deref(),
+            Some("file:fixtures/raw/simple-episode.txt")
+        );
+        assert_eq!(
+            fixtures.suppressed_seed.retention_state,
+            RetentionState::Suppressed
+        );
+        assert!(!fixtures.suppressed_seed.is_current);
+
+        let expansion = store
+            .expand_bounded(&GraphExpansionQuery::new(
+                fixtures.hub_entity.id,
+                ObjectType::Entity,
+                1,
+                5,
+            ))
+            .await
+            .unwrap();
+
+        assert!(expansion
+            .objects
+            .contains(&MemoryObject::Entity(fixtures.hub_entity.clone())));
+        assert!(expansion
+            .objects
+            .contains(&MemoryObject::Episode(fixtures.episode.clone())));
+        assert!(expansion.links.contains(&fixtures.hub_links[0]));
+    }
+
+    #[tokio::test]
+    async fn deterministic_embedder_uses_explicit_text_without_external_services() {
+        let embedder = DeterministicMemoryEmbedder::new(8);
+        let input = EmbeddingInput::new(
+            Some(fixture_id(20)),
+            Some(ObjectType::Observation),
+            VectorSurface::Text,
+            "service-free deterministic embedding",
+        );
+
+        let first = embedder.embed(&input).await.unwrap();
+        let second = embedder.embed(&input).await.unwrap();
+        let different = embedder
+            .embed(&EmbeddingInput::new(
+                Some(fixture_id(20)),
+                Some(ObjectType::Observation),
+                VectorSurface::Text,
+                "different text",
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(first, second);
+        assert_ne!(first, different);
+        assert_eq!(first.len(), 8);
+    }
+
+    #[tokio::test]
+    async fn raw_reference_resolver_uses_fixture_backed_file_content() {
+        let resolver = FixtureRawReferenceResolver::new();
+        let path = std::env::temp_dir().join(format!("cmem-raw-ref-{}.txt", Uuid::new_v4()));
+        fs::write(&path, "raw fixture text").unwrap();
+
+        resolver
+            .insert_file("file:fixture/raw-reference.txt", &path)
+            .unwrap();
+        let resolved = resolver
+            .resolve("file:fixture/raw-reference.txt")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(resolved.reference, "file:fixture/raw-reference.txt");
+        assert_eq!(resolved.text, "raw fixture text");
+
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn representative_fixtures_cover_v0_1_scenarios() {
+        let fixtures = representative_fixtures();
+
+        assert_eq!(fixtures.episode.object_type, ObjectType::Episode);
+        assert_eq!(
+            fixtures.salient_observation.object_type,
+            ObjectType::Observation
+        );
+        assert_eq!(fixtures.user_entity.entity_type, EntityType::User);
+        assert_eq!(fixtures.soft_thread.object_type, ObjectType::MemoryThread);
+        assert_eq!(
+            fixtures.derived_reflection.derived_type,
+            DerivedType::Reflection
+        );
+        assert_eq!(
+            fixtures.user_preference.derived_type,
+            DerivedType::UserPreference
+        );
+        assert_eq!(fixtures.open_loop.derived_type, DerivedType::OpenLoop);
+        assert_eq!(fixtures.commitment.derived_type, DerivedType::Commitment);
+        assert_eq!(fixtures.correction.derived_type, DerivedType::Correction);
+        assert_eq!(
+            fixtures.suppressed_seed.retention_state,
+            RetentionState::Suppressed
+        );
+        assert_eq!(
+            fixtures.soft_thread_link.relation,
+            RelationType::PartOfThread
+        );
+        assert!(fixtures
+            .hub_links
+            .iter()
+            .any(|link| link.from_id == fixtures.hub_entity.id));
+    }
+}

--- a/src/internal/repositories/vector_candidate_store.rs
+++ b/src/internal/repositories/vector_candidate_store.rs
@@ -1,3 +1,6 @@
+// Transitional v0.1 repository contract: vector adapters and pipelines will
+// consume this after the contract chunk. Remove once production consumers use
+// the full surface, or prune unused methods.
 #![allow(dead_code)]
 
 use async_trait::async_trait;

--- a/src/internal/repositories/vector_candidate_store.rs
+++ b/src/internal/repositories/vector_candidate_store.rs
@@ -1,0 +1,45 @@
+#![allow(dead_code)]
+
+use async_trait::async_trait;
+
+use crate::api::types::MemoryId;
+use crate::errors::CustomError;
+use crate::internal::models::vector::{
+    VectorCandidateMatch, VectorCandidateRecord, VectorCandidateSearch,
+};
+
+#[async_trait]
+pub(crate) trait VectorCandidateStore: Send + Sync {
+    async fn upsert_candidates(
+        &self,
+        candidates: &[VectorCandidateRecord],
+    ) -> Result<(), CustomError>;
+
+    async fn search_candidates(
+        &self,
+        query: &VectorCandidateSearch,
+    ) -> Result<Vec<VectorCandidateMatch>, CustomError>;
+
+    async fn delete_candidates(&self, object_ids: &[MemoryId]) -> Result<(), CustomError>;
+}
+
+#[async_trait]
+impl<T: VectorCandidateStore + ?Sized> VectorCandidateStore for Box<T> {
+    async fn upsert_candidates(
+        &self,
+        candidates: &[VectorCandidateRecord],
+    ) -> Result<(), CustomError> {
+        (**self).upsert_candidates(candidates).await
+    }
+
+    async fn search_candidates(
+        &self,
+        query: &VectorCandidateSearch,
+    ) -> Result<Vec<VectorCandidateMatch>, CustomError> {
+        (**self).search_candidates(query).await
+    }
+
+    async fn delete_candidates(&self, object_ids: &[MemoryId]) -> Result<(), CustomError> {
+        (**self).delete_candidates(object_ids).await
+    }
+}


### PR DESCRIPTION
### Motivation and Context

This continues the v0.1 implementation after PR #26 by establishing the store-contract and deterministic test-harness layer before live adapter or pipeline work.

It enables later remember/retrieve/lifecycle tests to use service-free fakes around canonical v0.1 domain objects, while keeping Qdrant and Oxigraph adapter work in the next chunk.

### Description

- Added provider-neutral internal contracts for vector candidate storage, graph authority storage, deterministic embedding, and raw reference resolution.
- Added v0.1 vector candidate/search/match and embedding input model types around canonical `MemoryId` and `ObjectType` values.
- Added `cfg(test)` deterministic fake vector, graph, embedder, raw-reference resolver, and representative fixtures for v0.1 objects, lifecycle states, links, raw refs, and hub scenarios.
- Completed the store-contracts plan and drafted the next adapter-foundation plan.

### Checklist

- [x] Code builds with **no errors or warnings**
      `cargo check --all-targets`
- [x] **Unit tests pass**
      `cargo test --verbose`
- [x] **Clippy** passes with warnings denied
      `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt` has been run
- [x] Documentation updated where needed
- [x] BREAKING CHANGE? **No**
- [x] I didn’t break anyone 😊

### Additional Notes

Plan-specific validation also passed:

- `cargo fmt --check`
- `cargo check`
- `cargo test --no-run`
- `cargo test internal::repositories::test_support` (5 tests passed)

Final review remediation gate: APPROVED with `structured_findings: []` and `highest_severity: NONE`.