### PR TITLE
:construction_worker: Fix toolchain version

### DIFF
--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -16,8 +16,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
-          override: true
+          toolchain: 1.95.0
 
       - name: Run cargo check
         run: cargo check
@@ -33,8 +32,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
-          override: true
+          toolchain: 1.95.0
 
       - name: Compile tests without running them
         run: cargo test --no-run
@@ -50,8 +48,7 @@ jobs:
       - name: Setup Rust toolchain with clippy
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
-          override: true
+          toolchain: 1.95.0
           components: clippy
 
       - name: Run clippy with warnings denied
@@ -84,7 +81,6 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.95.0
-          override: true
 
       - name: Validate live integration configuration
         shell: bash


### PR DESCRIPTION
### Motivation and Context
<!--
1. Why is this change required?
2. What problem does it solve / scenario it enables?
3. If it fixes or closes an issue, add “Fixes #<num>”.
-->
Toolchain version overrides were in place that would make CI toolchain version not aligned with the rest of the project.

### Description
<!--
High-level overview of the approach and design.
If helpful, point to relevant modules / files / data flow.
-->
Fixed toolchain version to 1.95.0

### Checklist
<!-- Tick all that apply before requesting review -->

- [x] Service-free compile check passes
      `cargo check`
- [x] Service-free test target compilation passes
      `cargo test --no-run`
- [x] **Clippy** passes with warnings denied
      `cargo clippy --all-targets -- -D warnings`
- [x] Rust formatting check passes
      `cargo fmt --check`
- [x] Full Qdrant-backed integration tests pass in trusted same-repository CI or with local service configuration
      `cargo test --verbose`
- [x] Documentation updated where needed
- [x] BREAKING CHANGE? **No**
- [x] I didn’t break anyone 😊

### Additional Notes (optional)
<!-- Logs, screenshots, things reviewers should focus on, etc. -->
