### PR TITLE
✨ Add correction and forget lifecycle

### DIFF
--- a/docs/coding-agent/lessons.md
+++ b/docs/coding-agent/lessons.md
@@ -44,6 +44,35 @@ Prevention:
 Evidence:
 - Missed thread `PRRT_kwDONxNRBs5-Z49b` was found by searching the complete saved PR thread payload for `"isResolved": false`.
 
+## 2026-04-30 - Check Roadmap Functionality Before Narrowing Scope  [tags: planning, scope-owns, validation]
+
+Context:
+- Plan: `docs/coding-agent/plans/active/v0-1-correction-forget-lifecycle-plan.md`
+- Task/Wave: pre-implementation plan review
+- Roles involved: Orchestrator | Researcher | Reviewer
+
+Symptom:
+- Narrowed the lifecycle plan to derived-memory-only correction/forget behavior before fully reconciling the chunk with the development roadmap and v0.1 roadmap.
+- The narrowed plan would have left episode/observation forget cascades and correction-origin provenance under-specified despite roadmap expectations for `correct`, `forget`, suppression, and correction provenance.
+
+Root cause:
+- Overweighted current implementation convenience and code-shape constraints before checking the intended functional acceptance for the roadmap chunk.
+- Focused on which objects were easiest to mutate, not enough on whether forgotten source material could still influence generation through provenanced derived memories.
+
+Fix applied:
+- Rechecked the development roadmap, v0.1 design, backend-contract draft, ADR-D-0002, and ADR-D-0008.
+- Broadened the plan to include episode/observation suppression with default provenance-based cascade, source-object correction of affected derived memories, memory-thread archival, and explicit correction-origin provenance.
+
+Prevention:
+- Repo rule candidate:
+  - audience: orchestrator
+  - proposed rule: Before narrowing an implementation plan for feasibility, explicitly compare the narrowed scope against roadmap/design acceptance and record which intended features remain in scope, are deferred, or require user approval.
+- Dispatch/plan guardrail:
+  - For correction/forget plans, check both provenance chains before approval: original source provenance and correction-origin provenance.
+
+Evidence:
+- User correction on 2026-04-30 prompted roadmap recheck and plan revisions in `docs/coding-agent/plans/active/v0-1-correction-forget-lifecycle-plan.md`.
+
 ## 2026-04-29 - Keep Roadmap Versions Out Of Durable Code  [tags: code-quality, architecture, communication]
 
 Context:

--- a/docs/coding-agent/plans/active/v0-1-correction-forget-lifecycle-plan.md
+++ b/docs/coding-agent/plans/active/v0-1-correction-forget-lifecycle-plan.md
@@ -7,35 +7,36 @@
 
 ## Goal
 - Implement non-destructive correction and forget lifecycle behavior on top of the landed graph-authoritative remember/link/retrieve path.
-- Preserve provenance and source references while marking replaced derived memories non-current and suppressing forgotten memories by default.
+- Preserve original source provenance, correction-origin provenance, and source references while marking replaced derived memories non-current, suppressing forgotten source/derived memories by default, and preventing source-provenanced derived memories from continuing to influence retrieval after their source is forgotten.
 - Keep this chunk focused on lifecycle mutation and retrieval visibility; do not implement production raw storage, reflection scheduling, belief/evidence ontology, or broad legacy facade removal beyond necessary isolation.
 
 ## Definition of Done
 - Backend-free correction and forget request/outcome DTOs exist without Qdrant/Oxigraph/RDF types.
-- Correction creates replacement canonical objects/links, records supersession, marks replaced derived memories non-current where applicable, and preserves provenance/source references.
-- Supersession support is explicitly scoped by object type: v0.1 derived-memory correction records `new DerivedMemory supersedes old DerivedMemory`; lifecycle behavior for episodes, observations, threads, entities, and links is either object-type-specific or deferred by Task_1 before implementation.
-- Forget defaults to suppression rather than hard deletion, with explicit redaction/delete semantics reserved for deliberately named policy paths if included.
+- Correction creates replacement canonical derived-memory objects/links, records supersession through both `DerivedMemory.supersedes` and a typed `RelationType::Supersedes` link, marks replaced or source-affected derived memories non-current, and preserves both original source provenance and correction-origin provenance/source references.
+- Supersession support is explicitly scoped by object type: this chunk supports derived-memory correction where `new DerivedMemory supersedes old DerivedMemory`; episode/observation correction may create correction derived memories and supersede affected derived memories discovered through provenance, without rewriting historical source objects.
+- Forget defaults to soft lifecycle mutation rather than hard deletion. Derived memories, episodes, and observations can be suppressed; episode/observation suppression cascades by default to behavior-influencing derived memories provenanced to the forgotten source. Memory threads can be archived. Physical redaction/delete behavior is deferred from this chunk; the existing `RetentionState::Deleted` remains a soft lifecycle state that retrieval can filter.
 - Graph authority remains the source of truth for supersession, suppression, lifecycle, provenance, and currentness; Qdrant payloads/candidates are updated or removed only to keep candidate recall from surfacing stale hints.
 - Normal retrieve behavior excludes suppressed/deleted and non-current/superseded memories after correction/forget. Compact rationale summarizes omissions; detailed historical/included-by-policy inspection requires trace-enabled retrieval.
 - Retrieval correctness still holds if stale vector candidates remain after graph mutation or vector maintenance partially fails; graph authority must exclude stale lifecycle state from final normal retrieval.
-- Required Rust checks, deterministic lifecycle tests, embedded Oxigraph smoke, gated Qdrant candidate smoke, clippy, and Reviewer approval are complete, or blockers/required-check waivers are explicitly recorded.
+- Required Rust checks, deterministic lifecycle tests, `cargo test --lib`, embedded Oxigraph smoke, gated Qdrant candidate smoke, clippy, and Reviewer approval are complete, or blockers/required-check waivers are explicitly recorded.
 
 ## Scope / Non-goals
 - Scope:
   - Backend-free correction/forget request, policy, and outcome DTOs.
-  - Lifecycle target object-type boundary selected before implementation: `Episode`, `Observation`, and `DerivedMemory` have `retention_state`; `DerivedMemory` has `is_current` and derived-memory supersession; `MemoryThread` uses `ThreadStatus`; `Entity` and `MemoryLink` do not currently have retention/currentness fields.
-  - Provider-neutral graph lifecycle mutation support needed for currentness, supersession, suppression, and optional explicit hard deletion/redaction semantics.
-  - Vector candidate maintenance needed after correction/forget so Qdrant remains a candidate hint store rather than authority.
+  - Correction-origin provenance fields that can identify the episode/observation/source reference explaining why a correction was made, without requiring production raw transcript storage.
+  - Lifecycle target object-type boundary selected before implementation: derived-memory correction/supersession and derived-memory forget/suppression are in scope; episode/observation correction can supersede affected derived memories through provenance rather than rewriting the source object; episode/observation forget suppresses the source object and cascades to dependent behavior-influencing derived memories by default; `MemoryThread` forget archives the thread through `ThreadStatus::Archived`; `Entity` and `MemoryLink` do not currently have retention/currentness fields and are deferred.
+  - Provider-neutral graph lifecycle mutation support needed for derived-memory currentness, typed supersession, episode/observation/derived-memory suppression, and memory-thread archival, without adding physical hard-delete/redaction graph contracts.
+  - Vector candidate maintenance needed after correction/forget so Qdrant remains a candidate hint store rather than authority; the selected strategy is to delete affected old/suppressed/archived candidates and upsert replacement candidates after graph success.
   - Internal correction and forget pipelines over `GraphAuthorityStore`, `VectorCandidateStore`, and `MemoryEmbedder` where replacement objects need indexing.
-  - Injected `CharacterMemory::correct` / `CharacterMemory::forget` facade shape if selected by Task_1.
+  - Crate-visible injected `CharacterMemory::correct` / `CharacterMemory::forget` facade shape.
   - Deterministic fake-store tests plus embedded Oxigraph and gated Qdrant smoke evidence.
 - Non-goals:
   - Full belief/evidence ontology or contradiction-resolution system.
   - Reflection scheduling, background summarization, external LLM extraction, or LLM-based correction generation.
   - Production raw transcript storage.
   - Public production constructor rewiring unless narrowly required to keep lifecycle behavior testable.
-  - Generic cross-object supersession unless Task_1 deliberately defines object-type-specific semantics and retrieval consequences.
-  - Hard deletion/redaction by default; any such path must be named, opt-in, and validated separately for provenance preservation and user-control/privacy semantics.
+  - Generic cross-object supersession beyond source-provenanced derived-memory correction, or lifecycle mutation for object types without existing lifecycle/currentness fields.
+  - Physical hard deletion/redaction contracts or policy paths; these require separate raw/source, graph, vector, and privacy semantics.
   - UI/E2E/browser validation.
 
 ## Context (workspace)
@@ -70,13 +71,22 @@
   - `docs/decisions/implementation/ADR-I-0006-bounded-graph-expansion.md`
 
 ## Open Questions (max 3)
-- Q1: Should this chunk expose crate-visible injected `correct`/`forget` facades only, matching current `remember`/`link`/`retrieve`, or make any lifecycle method public now?
-- Q2: Should explicit hard deletion/redaction be modeled in this chunk as a backend-free policy path, or deferred until migration cleanup/release validation?
-- Q3: After graph-authoritative suppression/supersession, should vector candidates be deleted immediately for affected object IDs, or upserted with stale lifecycle hints plus graph verification still excluding them?
+- None pending plan approval.
+
+## Resolved Decisions Pending User Approval
+- Correction/forget facades should remain crate-visible injected surfaces in this chunk, matching the current `remember`/`link`/`retrieve` boundary. Public lifecycle API stabilization belongs to Documentation, Migration Cleanup, And Release Validation after production construction is graph-authoritative.
+- Supported lifecycle mutation targets are bounded to existing lifecycle fields: correction supersedes `DerivedMemory` records directly and can supersede source-affected derived memories discovered from corrected episodes/observations; forget suppresses `DerivedMemory`, `Episode`, and `Observation` records; forget archives `MemoryThread` records through `ThreadStatus::Archived`; entity and link lifecycle are deferred.
+- Correction requests must carry or reference correction-origin provenance when available, such as a correction episode ID, correction observation ID, and/or raw/source reference. Replacement correction memories must preserve both the old memory's original source chain and the correction event/source that explains the revision.
+- Forgetting an episode or observation defaults to cascade-suppressing behavior-influencing derived memories whose provenance references the forgotten source, because otherwise forgotten source material could still influence generation through derived memories.
+- Derived-memory supersession must persist both the replacement object's `supersedes` field and a typed `MemoryLink` with `RelationType::Supersedes` from the new derived memory to the old derived memory, because retrieval `superseded_by` evidence is relation-derived.
+- Physical hard deletion/redaction is deferred. This chunk may recognize the existing `RetentionState::Deleted` as a retrieval-filtered soft lifecycle state, but it must not add physical deletion/redaction behavior.
+- After graph success, vector maintenance deletes candidates for old/superseded/suppressed/archived object IDs and upserts replacement candidates. Vector failure after graph success returns explicit partial-success evidence and must not roll back graph truth.
+- Public DTOs stay backend-free; lifecycle pipelines depend on provider-neutral graph/vector/embedder contracts; Qdrant/Oxigraph/RDF remain infrastructure details.
+- Compact rationale should report aggregate lifecycle omissions; trace-enabled retrieval remains the detailed inspection path for corrected, superseded, suppressed, and historical opt-in behavior.
 
 ## Assumptions
-- A1: Correction is non-destructive by default: create replacement memory, preserve old provenance, and mark old derived memories non-current/superseded rather than overwriting them.
-- A2: Forget means suppression by default; hard deletion/redaction requires explicit policy naming and stronger validation.
+- A1: Correction is non-destructive by default: create replacement memory, preserve old provenance, and mark old or source-affected derived memories non-current/superseded rather than overwriting them.
+- A2: Forget means suppression by default; hard deletion/redaction requires a later dedicated policy and validation plan.
 - A3: Retrieval defaults from the completed retrieve plan remain the acceptance oracle for lifecycle visibility.
 - A4: Vector candidate maintenance should reduce stale recall noise and cost but must not become lifecycle authority or a correctness requirement.
 
@@ -88,13 +98,15 @@
   - `docs/coding-agent/plans/active/v0-1-correction-forget-lifecycle-plan.md`
 - depends_on: []
 - description: |
-  Decide correction/forget request names, facade visibility, suppression versus hard-delete policy, vector maintenance strategy, and failure semantics before implementation edits.
+  Decide correction/forget request names, facade visibility, suppression versus hard-delete policy, source-object cascade boundaries, thread archival behavior, vector maintenance strategy, and failure semantics before implementation edits.
 - acceptance:
   - Decision records whether correction/forget facades are crate-visible injected surfaces or public API in this chunk.
   - Decision records supported lifecycle target object types and defers unsupported object types explicitly.
-  - Decision records that derived-memory supersession direction is `new DerivedMemory supersedes old DerivedMemory`, and old memories appear as `superseded_by` in retrieval evidence.
-  - Decision records default suppression and supersession behavior plus any explicit redaction/delete policy boundaries.
-  - Decision records graph-authority lifecycle mutation semantics and Qdrant candidate maintenance strategy.
+  - Decision records source-target cascade rules for correcting or forgetting episodes/observations, including default cascade suppression for behavior-influencing derived memories provenanced to forgotten sources.
+  - Decision records how correction-origin provenance is represented separately from the superseded memory's original source provenance.
+  - Decision records that derived-memory supersession direction is `new DerivedMemory supersedes old DerivedMemory`, that persistence includes both `DerivedMemory.supersedes` and a typed `RelationType::Supersedes` link, and that old or source-affected derived memories appear as `superseded_by` in retrieval evidence.
+  - Decision records default suppression and supersession behavior, and records that physical hard deletion/redaction is deferred from this chunk.
+  - Decision records graph-authority lifecycle mutation semantics and Qdrant candidate maintenance strategy, including delete-old/delete-suppressed/delete-archived/upsert-replacement vector hygiene and graph-authoritative correctness when vector maintenance fails.
   - Decision records dependency direction: public DTOs stay backend-free; pipelines depend on provider-neutral graph/vector/embedder contracts; Qdrant/Oxigraph/RDF remain infrastructure details.
   - Decision records how compact rationale and optional trace should expose corrected, superseded, suppressed, and historical opt-in behavior without overpromising detailed history in always-on rationale.
 - validation:
@@ -117,11 +129,11 @@
 - description: |
   Add backend-free correction/forget request, policy, and outcome DTOs aligned with canonical domain objects and retrieval lifecycle vocabulary.
 - acceptance:
-  - DTOs can express replacement derived-memory data, optional selected object-type-specific lifecycle targets, superseded source IDs, rationale, lifecycle policy, suppression policy, and optional trace flags where selected.
-  - DTOs preserve `supersedes` direction and retrieval-facing `superseded_by` evidence semantics.
-  - DTOs preserve source/raw references without introducing raw transcript storage.
+  - DTOs can express typed lifecycle targets for `DerivedMemory`, `Episode`, `Observation`, and `MemoryThread`; replacement derived-memory data; superseded derived-memory IDs; source-object correction targets; correction-origin episode/observation/source references; rationale; lifecycle policy; cascade policy; suppression/archive policy; and optional trace flags where selected.
+  - DTOs preserve `supersedes` direction and retrieval-facing `superseded_by` evidence semantics without exposing backend graph/vector details.
+  - DTOs preserve original source/raw references and correction-origin source/raw references without introducing raw transcript storage.
   - Outcomes report graph-mutated object IDs, link IDs, vector-maintained object IDs, and partial vector maintenance failures where graph mutation succeeded.
-  - Pure DTO tests cover serialization, defaults, validation, non-destructive correction semantics, suppression defaults, and explicit hard-delete/redaction naming if included.
+  - Pure DTO tests cover serialization, defaults, validation, typed target boundaries, non-destructive correction semantics, source-target cascade defaults, original-source versus correction-origin provenance, suppression/archive defaults, and hard-delete/redaction deferral.
 - validation:
   - kind: command
     required: true
@@ -135,6 +147,10 @@
     required: true
     owner: worker
     detail: "cargo test --no-run"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --lib"
   - kind: command
     required: true
     owner: worker
@@ -149,13 +165,15 @@
   - `src/internal/infrastructures/graph/**`
 - depends_on: [Task_1]
 - description: |
-  Add provider-neutral graph authority behavior needed to mark supported lifecycle/currentness fields, record derived-memory supersession, and support suppression/default forget semantics.
+  Add provider-neutral graph authority behavior needed to mark supported lifecycle/currentness fields, record derived-memory supersession, support source-object cascade discovery, and support suppression/archive forget semantics.
 - acceptance:
-  - Graph authority can persist derived-memory correction supersession links and supported lifecycle/currentness updates without hard-deleting by default.
+  - Graph authority can persist derived-memory correction supersession links, episode/observation/derived-memory retention-state updates, memory-thread archive updates, and supported lifecycle/currentness updates without hard-deleting by default.
   - Graph lifecycle mutation may reuse whole-object `upsert_objects` and `upsert_links` where sufficient; new special mutation methods are optional and must be justified by adapter needs.
+  - Supersession persistence includes both replacement-object `supersedes` data and fake/Oxigraph parity for typed `RelationType::Supersedes` link evidence.
+  - Fake graph and embedded Oxigraph behavior can discover derived memories affected by an episode or observation through provenance fields and/or typed provenance links under bounded query rules.
   - Fake graph and embedded Oxigraph behavior keep old and replacement objects inspectable under explicit historical policy.
   - Normal retrieval after lifecycle mutation excludes suppressed/deleted and non-current/superseded records by default.
-  - Tests cover supersession directionality, suppression, optional historical inclusion, and no accidental traversal through suppressed/non-current records.
+  - Tests cover supersession directionality, episode/observation/derived-memory suppression, memory-thread archival, source-provenance cascade discovery, optional historical inclusion, and no accidental traversal through suppressed/non-current records.
 - validation:
   - kind: command
     required: true
@@ -169,6 +187,10 @@
     required: true
     owner: worker
     detail: "cargo test --no-run"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --lib"
   - kind: command
     required: true
     owner: worker
@@ -185,11 +207,13 @@
 - description: |
   Implement internal correction and forget pipelines with ordered graph mutation, vector candidate maintenance, and deterministic partial-failure behavior.
 - acceptance:
-  - Correction validates all inputs before graph mutation, writes replacement objects/links, records supersession, marks replaced derived memories non-current where applicable, and indexes replacement vector records when selected.
-  - Forget applies suppression by default and updates or deletes vector candidates according to Task_1 policy.
+  - Correction validates all inputs before graph mutation, writes replacement derived-memory objects/links, records typed supersession, marks directly replaced or source-affected derived memories non-current, and indexes replacement vector records when selected.
+  - Correction targeting an episode or observation discovers affected derived memories through provenance, creates a correction derived memory with both original-source and correction-origin provenance, and supersedes or marks non-current the affected derived memories without rewriting the historical episode/observation.
+  - Forget applies suppression to derived-memory, episode, and observation targets by default; episode/observation forget cascade-suppresses behavior-influencing derived memories provenanced to the forgotten source; memory-thread forget archives the thread.
   - Graph mutation failure prevents vector maintenance; vector maintenance failure after graph success returns explicit partial-success outcome.
-  - Tests cover ordering, graph-authoritative lifecycle changes, vector maintenance, partial failure, and retrieval-after-mutation defaults.
-  - Tests prove retrieval still excludes stale lifecycle state through graph authority when vector maintenance fails or stale candidates remain.
+  - After graph success, correction deletes vector candidates for old/superseded object IDs and upserts replacement candidates; forget deletes candidates for suppressed/archived object IDs; vector cleanup is hygiene and never lifecycle authority.
+  - Tests cover ordering, graph-authoritative lifecycle changes, correction-origin provenance preservation, vector maintenance, partial failure, and retrieval-after-mutation defaults.
+  - Tests prove retrieval still excludes stale lifecycle state through graph authority when vector maintenance fails or stale candidates remain, including source-object stale candidates and dependent derived-memory stale candidates.
 - validation:
   - kind: command
     required: true
@@ -203,6 +227,10 @@
     required: true
     owner: worker
     detail: "cargo test --no-run"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --lib"
   - kind: command
     required: true
     owner: worker
@@ -222,7 +250,8 @@
 - acceptance:
   - Selected `CharacterMemory::correct` / `CharacterMemory::forget` facade shape uses injected provider-neutral parts and returns selected backend-free outcomes.
   - Legacy flat `update_memory` / `delete_memory` remain isolated/deprecated and are not used by lifecycle pipelines.
-  - Deterministic facade tests cover correction, forget/suppression, retrieval exclusion, historical opt-in visibility if selected, and legacy isolation.
+  - Facade tests prove deprecated `update_memory` / `delete_memory` do not participate in lifecycle correction/forget behavior.
+  - Deterministic facade tests cover derived-memory correction, episode/observation correction of affected derived memories, correction-origin provenance inspectability, derived-memory forget/suppression, episode/observation forget cascade, memory-thread archive behavior, retrieval exclusion, historical opt-in visibility if selected, and legacy isolation.
   - README examples are updated only if the public runnable surface is production-usable enough to document without misleading users.
   - If correction/forget remains crate-visible like `remember`/`link`/`retrieve`, README updates avoid implying a public production lifecycle API exists.
 - validation:
@@ -238,6 +267,10 @@
     required: true
     owner: worker
     detail: "cargo test --no-run"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --lib"
   - kind: command
     required: true
     owner: worker
@@ -295,7 +328,9 @@
 
 ## Rollback / Safety
 - Keep correction/forget DTOs and facade backend-free.
-- Preserve non-destructive correction and suppression-by-default forget behavior unless Task_1 explicitly selects named hard-delete/redaction semantics.
+- Preserve non-destructive correction, suppression-by-default forget behavior, and source-provenance cascade behavior for forgotten episodes/observations.
+- Preserve both provenance chains for corrections: what the old memory came from and what correction event/source explains the revision.
+- Keep physical hard deletion/redaction deferred; do not add graph/vector/raw redaction contracts in this chunk.
 - Treat Qdrant lifecycle/supersession fields as hints; graph authority remains final truth.
 - Normal retrieval must exclude suppressed/deleted and non-current/superseded memories by default after lifecycle mutation.
 - Keep production raw storage, reflection scheduling, external LLM behavior, and belief/evidence ontology out of this plan.
@@ -306,7 +341,7 @@
 - Out-of-scope docs: UI/E2E, frontend/browser checks, production raw storage, reflection scheduling, external LLM extraction/reranking, full belief/evidence ontology.
 - Top risks: data-integrity lifecycle mutation, correction provenance, graph/vector drift, legacy update/delete drift, public API shape.
 - Risk profile: medium-high because this chunk mutates lifecycle/currentness state and must keep retrieval visibility correct across graph and vector stores.
-- Required checks: `cargo fmt --check`, `cargo check`, `cargo test --no-run`, `cargo clippy --all-targets -- -D warnings`, targeted DTO/graph/pipeline/facade/retrieval regression tests, embedded Oxigraph lifecycle smoke, live Qdrant candidate maintenance smoke or CI evidence/required-check waiver, Reviewer gate.
+- Required checks: `cargo fmt --check`, `cargo check`, `cargo test --no-run`, `cargo test --lib`, `cargo clippy --all-targets -- -D warnings`, targeted DTO/graph/pipeline/facade/retrieval regression tests, embedded Oxigraph lifecycle smoke, live Qdrant candidate maintenance smoke or CI evidence/required-check waiver, Reviewer gate.
 
 ## Progress Log
 
@@ -318,6 +353,18 @@
   - Summary: Updated lifecycle plan to reflect the final retrieval shape: compact omission rationale plus detailed trace, graph authority over vector maintenance, derived-memory supersession direction, object-type lifecycle boundaries, and required clippy validation.
   - Validation evidence: Documentation review against completed retrieve plan, project philosophy, ADR-D-0006, ADR-I-0005, and current retrieval DTO/pipeline behavior.
   - Notes: No lifecycle implementation performed; draft still requires user approval before execution.
+- 2026-04-30 Pre-implementation plan review tightened lifecycle target scope.
+  - Summary: Reviewed the draft against the overarching roadmap, v0.1 roadmap, ADR-D-0002, ADR-D-0006, ADR-D-0008, ADR-I-0004, ADR-I-0005, ADR-I-0006, and current domain/retrieval/repository code. Initially narrowed this chunk to derived-memory correction/supersession and derived-memory forget/suppression, deferred source-object cascades and physical redaction/delete, required typed supersession links plus object supersedes fields, selected delete-old/upsert-replacement vector hygiene, and added `cargo test --lib` as required evidence.
+  - Validation evidence: Researcher plan review plus direct source/doc inspection; no implementation performed.
+  - Notes: Draft still requires user approval before execution.
+- 2026-04-30 Roadmap scope recheck broadened lifecycle targets.
+  - Summary: Rechecked the development roadmap and v0.1 roadmap after user feedback. Broadened this plan so completion covers derived-memory correction, episode/observation correction of affected derived memories, derived-memory/episode/observation suppression, default source-provenance cascade for forgotten episodes/observations, memory-thread archival, and graph-authoritative retrieval exclusion.
+  - Validation evidence: Researcher scope reassessment plus direct roadmap/design/ADR review; no implementation performed.
+  - Notes: Draft still requires user approval before execution.
+- 2026-04-30 Reviewer requested explicit correction-origin provenance.
+  - Summary: Added requirements that correction requests and outcomes preserve correction-origin episode/observation/source references separately from original source provenance, and that tests prove correction-origin provenance remains inspectable.
+  - Validation evidence: Reviewer plan review requested changes; no implementation performed.
+  - Notes: Draft still requires user approval before execution.
 
 ## Decision Log
 
@@ -331,14 +378,32 @@
   - Plan delta: Clarified derived-memory supersession direction, object-type lifecycle boundaries, vector maintenance as non-authoritative hygiene, trace versus compact rationale expectations, and required clippy validation.
   - Tradeoffs considered: Keeping generic correction/forget wording would be shorter, but risks workers implementing lifecycle mutation for object types that lack canonical lifecycle fields or treating vector maintenance as correctness authority.
   - User approval: pending.
+- 2026-04-30 Decision: Constrain lifecycle implementation to derived-memory mutation first
+  - Trigger / new insight: Current code supports retention filtering for episodes/observations but has no source-object forget cascade semantics, no physical delete/redact graph contract, and retrieval supersession evidence is relation-derived from typed links.
+  - Plan delta: Resolved open questions toward crate-visible injected facades, derived-memory-only correction/forget mutation, hard-delete/redaction deferral, typed supersession link plus object field persistence, and vector deletion of stale candidates after graph success.
+  - Tradeoffs considered: Supporting episode/observation forget immediately would appear broader, but could leave behavior-influencing derived memories active unless cascade rules are designed and tested. Deferring physical redaction/delete avoids inventing incomplete graph/raw/vector privacy semantics in a lifecycle chunk.
+  - User approval: superseded before implementation by the source-object suppression and provenance cascade decision below.
+- 2026-04-30 Decision: Include source-object suppression with provenance cascade
+  - Trigger / new insight: The development roadmap and v0.1 design expect `forget` and suppression to prevent memories from being used for generation, and ADR-D-0002 says corrections must be able to find derived memories affected by a source episode or observation.
+  - Plan delta: Brought episode/observation suppression and correction-target provenance cascade into scope, while keeping entity/link lifecycle and physical redaction/delete deferred.
+  - Tradeoffs considered: Derived-memory-only lifecycle mutation is simpler but can leave forgotten source material influencing generation through derived memories. Cascade suppression increases implementation and test scope but better satisfies the roadmap's suppression and provenance goals.
+  - User approval: pending.
+- 2026-04-30 Decision: Preserve correction-origin provenance separately
+  - Trigger / new insight: The roadmap says a correction episode explains why and v0.1 acceptance requires provenance to the correction episode, while ADR-D-0008 requires source-reference auditability.
+  - Plan delta: Required correction DTOs, pipelines, and facade tests to represent and preserve correction-origin episode/observation/source references separately from the superseded memory's original provenance chain.
+  - Tradeoffs considered: Only carrying the old source chain would preserve where the outdated memory came from, but not why it changed. A separate correction-origin chain keeps correction history auditable without forcing raw transcript storage into core.
+  - User approval: pending.
 
 ## Notes
 - Risks:
   - Graph/vector drift can make stale candidates noisy even when graph authority excludes them correctly.
-  - Hard deletion/redaction semantics can accidentally bypass provenance preservation if not explicitly named and tested.
+  - Episode/observation forget cascades can accidentally leave behavior-influencing derived memories active unless dependency traversal and mutation rules are explicitly designed.
+  - Hard deletion/redaction semantics can accidentally bypass provenance preservation if implemented without dedicated raw/source, graph, vector, and privacy contracts.
   - Legacy flat update/delete methods may confuse users until the public replacement lifecycle surface and documentation cleanup land.
 - Edge cases:
   - Correcting a derived memory should not erase the old source-reference chain.
+  - Correcting a memory should preserve the correction event/source that explains why the replacement exists.
+  - Forgetting an episode or observation should cascade to behavior-influencing derived memories provenanced to that source by default.
   - Forget should suppress normal retrieval but preserve historical/audit visibility when policy explicitly includes it.
   - Supersession direction must remain clear: new memory supersedes old memory; old memory may be described as superseded_by the new memory in rationale/trace.
   - Vector candidates for suppressed/superseded objects must not become lifecycle authority even if they remain in Qdrant temporarily.

--- a/docs/coding-agent/plans/active/v0-1-documentation-migration-cleanup-release-validation-plan.md
+++ b/docs/coding-agent/plans/active/v0-1-documentation-migration-cleanup-release-validation-plan.md
@@ -41,7 +41,7 @@
   - `docs/coding-agent/plans/active/v0-1-starter-episodic-memory-roadmap.md`
   - `docs/coding-agent/plans/completed/v0-1-remember-and-link-pipelines-plan.md`
   - `docs/coding-agent/plans/completed/v0-1-retrieve-continuity-context-pack-plan.md`
-  - `docs/coding-agent/plans/active/v0-1-correction-forget-lifecycle-plan.md`
+  - `docs/coding-agent/plans/completed/v0-1-correction-forget-lifecycle-plan.md`
   - `src/lib.rs`
   - `src/internal/infrastructures/external_services/qdrant_vector_memory_repository.rs`
   - `src/internal/infrastructures/external_services/qdrant_vector_candidate_store.rs`

--- a/docs/coding-agent/plans/active/v0-1-documentation-migration-cleanup-release-validation-plan.md
+++ b/docs/coding-agent/plans/active/v0-1-documentation-migration-cleanup-release-validation-plan.md
@@ -1,0 +1,222 @@
+# Plan: v0.1 Documentation, Migration Cleanup, And Release Validation
+
+- status: draft
+- generated: 2026-04-30
+- last_updated: 2026-04-30
+- work_type: mixed
+
+## Goal
+- Document the landed v0.1 chat-native episodic memory shape after remember/link/retrieve and correction/forget lifecycle behavior are complete.
+- Remove or rewrite stale flat-memory examples and non-contributing legacy implementation paths that conflict with graph-authoritative lifecycle semantics.
+- Run final deterministic and gated service validation before v0.1 release readiness.
+
+## Definition of Done
+- README and roadmap docs describe `CharacterMemory` as graph-authoritative episodic continuity memory with Qdrant as vector candidate recall and Oxigraph as relationship/lifecycle authority.
+- Public docs avoid implying production raw transcript storage, reflection scheduling, external LLM extraction, belief/evidence ontology, or physical redaction/delete behavior exists in v0.1.
+- Old flat API examples are removed or clearly marked legacy if still present for transitional reasons.
+- Non-contributing legacy implementation paths are removed or isolated with explicit migration notes, without adding compatibility wrappers for v0.1.
+- Correction/forget lifecycle documentation reflects non-destructive supersession, suppression/archive defaults, provenance preservation, vector hygiene, rationale aggregates, and trace-enabled inspectability.
+- Final validation evidence includes deterministic Rust checks, embedded Oxigraph lifecycle/retrieve smoke, live Qdrant candidate maintenance smoke or CI evidence, and Reviewer approval.
+
+## Scope / Non-goals
+- Scope:
+  - README and planning/roadmap documentation cleanup.
+  - Migration notes for the old flat facade and legacy Qdrant vector-memory repository path.
+  - Source cleanup only where legacy code no longer contributes to the v0.1 graph/vector/embedder architecture.
+  - Release validation checklist and evidence collection.
+- Non-goals:
+  - New lifecycle semantics beyond the completed correction/forget plan.
+  - Production raw transcript storage.
+  - Reflection scheduling or background summarization.
+  - Belief/evidence ontology or contradiction-resolution engine.
+  - Physical hard deletion/redaction semantics.
+  - UI/browser/E2E validation.
+
+## Context (workspace)
+- Related files/areas:
+  - `README.md`
+  - `docs/roadmap/development_roadmap.md`
+  - `docs/design/roadmap-phases/v0_1_starter_episodic_memory.md`
+  - `docs/design/roadmap-phases/v0_1_storage_and_backend_contracts.md`
+  - `docs/coding-agent/plans/active/v0-1-starter-episodic-memory-roadmap.md`
+  - `docs/coding-agent/plans/completed/v0-1-remember-and-link-pipelines-plan.md`
+  - `docs/coding-agent/plans/completed/v0-1-retrieve-continuity-context-pack-plan.md`
+  - `docs/coding-agent/plans/active/v0-1-correction-forget-lifecycle-plan.md`
+  - `src/lib.rs`
+  - `src/internal/infrastructures/external_services/qdrant_vector_memory_repository.rs`
+  - `src/internal/infrastructures/external_services/qdrant_vector_candidate_store.rs`
+  - `tests/**`
+- Existing lifecycle shape to preserve:
+  - `remember`, `link`, `retrieve`, `correct`, and `forget` use injected graph/vector/embedder paths where currently exposed.
+  - Graph authority decides lifecycle/currentness/supersession/suppression/archive truth.
+  - Qdrant candidate maintenance is hygiene and recall reduction, not authority.
+  - Normal retrieval excludes suppressed/deleted and non-current/superseded records by default, with detailed inspectability through trace.
+
+## Open Questions (max 3)
+- Should the old flat public facade be removed in this chunk or kept as explicitly deprecated while production v0.1 constructors are finalized?
+- Should README document crate-visible injected lifecycle behavior only in architecture notes, or wait until a public production constructor exposes it safely?
+- Should release validation reuse the Task_6 local Qdrant candidate smoke evidence, or rerun the smoke as fresh release evidence before closing this plan?
+
+## Tasks
+
+### Task_1: Audit docs and legacy surface
+- type: review
+- owns:
+  - `README.md`
+  - `docs/**`
+  - `src/lib.rs`
+  - `src/internal/**`
+  - `tests/**`
+- depends_on: []
+- description: |
+  Identify stale flat-memory docs/examples, legacy implementation paths, and release-validation gaps after lifecycle behavior lands.
+- acceptance:
+  - Audit lists README/doc sections that still describe flat memory behavior as canonical.
+  - Audit lists legacy source/test paths that should be removed, rewritten, or explicitly isolated.
+  - Audit confirms no cleanup task requires adding compatibility wrappers.
+- validation:
+  - kind: review
+    required: true
+    owner: worker
+    detail: "Document migration cleanup findings before source/doc edits."
+
+### Task_2: Update user-facing docs and roadmap state
+- type: docs
+- owns:
+  - `README.md`
+  - `docs/roadmap/**`
+  - `docs/design/roadmap-phases/**`
+  - `docs/coding-agent/plans/active/**`
+- depends_on: [Task_1]
+- description: |
+  Rewrite documentation so v0.1 is described as graph-authoritative episodic continuity memory with backend-free DTOs and provider-specific stores kept behind infrastructure boundaries.
+- acceptance:
+  - README examples do not promote old flat `create/search/update/delete` behavior as the v0.1 path.
+  - Docs describe Qdrant and Oxigraph responsibilities accurately.
+  - Lifecycle docs preserve non-destructive correction, suppression/archive defaults, provenance preservation, and trace inspectability.
+  - Non-goals remain explicit for raw storage, reflection scheduling, belief ontology, and physical redaction/delete.
+- validation:
+  - kind: review
+    required: true
+    owner: worker
+    detail: "Review docs for stale flat examples and lifecycle overclaims."
+
+### Task_3: Remove or isolate non-contributing legacy implementation paths
+- type: impl
+- owns:
+  - `src/lib.rs`
+  - `src/internal/**`
+  - `tests/**`
+- depends_on: [Task_1]
+- description: |
+  Remove, rewrite, or explicitly isolate legacy flat facade and Qdrant vector-memory repository behavior that conflicts with the v0.1 graph-authoritative architecture.
+- acceptance:
+  - Legacy `update_memory` / `delete_memory` paths no longer imply hard update/delete lifecycle semantics for v0.1.
+  - Any retained legacy path has a clear transitional reason and test boundary.
+  - Tests are updated to validate the v0.1 path rather than preserving legacy behavior for compatibility alone.
+  - No production raw storage, reflection scheduling, belief ontology, or physical redaction/delete semantics are introduced.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo fmt --check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --no-run"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "Run targeted migration cleanup tests."
+
+### Task_4: Final release validation and plan lifecycle
+- type: review
+- owns:
+  - `docs/coding-agent/plans/active/**`
+  - `docs/coding-agent/plans/completed/**`
+- depends_on: [Task_2, Task_3]
+- description: |
+  Run final release validation, record evidence, and complete v0.1 planning lifecycle updates.
+- acceptance:
+  - Required deterministic validation evidence is recorded.
+  - Embedded Oxigraph lifecycle/retrieve smoke passes.
+  - Live Qdrant candidate maintenance smoke passes locally or via CI evidence before release validation closes.
+  - Reviewer approves docs/migration cleanup and confirms no lifecycle or non-goal scope creep.
+  - Active roadmap links point to completed plans or the next explicitly drafted plan.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo fmt --check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --no-run"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo clippy --all-targets -- -D warnings"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "Run embedded Oxigraph lifecycle/retrieve smoke."
+  - kind: command
+    required: true
+    owner: worker
+    detail: "Run live Qdrant candidate maintenance smoke locally or record CI evidence before release validation closes."
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Review final docs, migration cleanup, validation evidence, and non-goals."
+
+## Task Waves (explicit parallel dispatch sets)
+- Wave 1 (audit): [Task_1]
+- Wave 2 (parallel cleanup): [Task_2, Task_3]
+- Wave 3 (release validation): [Task_4]
+
+## E2E / Visual Validation Spec
+- Not applicable. This is Rust library documentation, migration cleanup, and release validation with no UI/user-flow surface.
+
+## Rollback / Safety
+- Do not preserve old flat API behavior for compatibility alone.
+- Do not document crate-visible injected surfaces as stable public production APIs.
+- Keep Qdrant lifecycle payloads as candidate hints and Oxigraph/graph authority as lifecycle truth.
+- Keep raw inputs consumer-owned; do not introduce raw transcript storage.
+
+## Progress Log
+- 2026-04-30 Plan drafted.
+  - Summary: Drafted the next concrete plan from the lifecycle implementation shape and remaining roadmap cleanup needs.
+  - Validation evidence: Documentation-only plan draft by Task_6; no source edits performed.
+  - Notes: This plan should start after the correction/forget lifecycle plan receives final Reviewer and Orchestrator closeout and moves to completed.
+
+## Decision Log
+- 2026-04-30 Decision: Draft cleanup/release validation after lifecycle behavior lands.
+  - Trigger / new insight: Correction/forget lifecycle behavior introduces the replacement semantics needed before retiring old flat update/delete examples.
+  - Plan delta: Added a concrete plan for documentation, migration cleanup, and release validation.
+  - Tradeoffs considered: Starting cleanup before lifecycle closeout would risk documenting unstable behavior; drafting now preserves the next-step shape while leaving execution gated on lifecycle completion.
+  - User approval: directed by approved roadmap sequence.
+
+## Notes
+- Risks:
+  - Removing legacy code may reveal integration tests that still depend on old flat Qdrant behavior.
+  - Documentation can overstate crate-visible injected lifecycle surfaces if production constructors are not yet graph-authoritative.
+  - Live Qdrant validation remains environment-sensitive and must be captured before release validation closes.
+- Edge cases:
+  - Retained legacy paths need explicit transitional ownership and should not be described as canonical v0.1 behavior.
+  - Examples should preserve source references without embedding raw transcript content into Qdrant or Oxigraph.

--- a/docs/coding-agent/plans/active/v0-1-documentation-migration-cleanup-release-validation-plan.md
+++ b/docs/coding-agent/plans/active/v0-1-documentation-migration-cleanup-release-validation-plan.md
@@ -30,6 +30,7 @@
   - Reflection scheduling or background summarization.
   - Belief/evidence ontology or contradiction-resolution engine.
   - Physical hard deletion/redaction semantics.
+  - New durable schema fields for structured external correction-origin/source refs; those require a separate domain/schema decision before docs can describe them as graph-persisted provenance.
   - UI/browser/E2E validation.
 
 ## Context (workspace)
@@ -49,8 +50,10 @@
 - Existing lifecycle shape to preserve:
   - `remember`, `link`, `retrieve`, `correct`, and `forget` use injected graph/vector/embedder paths where currently exposed.
   - Graph authority decides lifecycle/currentness/supersession/suppression/archive truth.
+  - Episode correction/forget cascades include derived memories provenanced directly to the episode and derived memories provenanced only to observations in that episode.
   - Qdrant candidate maintenance is hygiene and recall reduction, not authority.
   - Normal retrieval excludes suppressed/deleted and non-current/superseded records by default, with detailed inspectability through trace.
+  - Correction-origin and original-source external refs exist in lifecycle DTOs, but durable `DerivedMemory` provenance currently persists episode/observation IDs; do not document structured external correction-origin refs as graph-persisted unless the schema is extended.
 
 ## Open Questions (max 3)
 - Should the old flat public facade be removed in this chunk or kept as explicitly deprecated while production v0.1 constructors are finalized?
@@ -73,6 +76,7 @@
 - acceptance:
   - Audit lists README/doc sections that still describe flat memory behavior as canonical.
   - Audit lists legacy source/test paths that should be removed, rewritten, or explicitly isolated.
+  - Audit records lifecycle DTO external correction-origin/source refs as deferred from durable graph persistence in this plan unless a separate user-approved schema plan supersedes that boundary.
   - Audit confirms no cleanup task requires adding compatibility wrappers.
 - validation:
   - kind: review
@@ -94,6 +98,7 @@
   - README examples do not promote old flat `create/search/update/delete` behavior as the v0.1 path.
   - Docs describe Qdrant and Oxigraph responsibilities accurately.
   - Lifecycle docs preserve non-destructive correction, suppression/archive defaults, provenance preservation, and trace inspectability.
+  - Lifecycle docs describe episode cascades through observations and document structured external correction-origin/source refs as request metadata/deferred schema work rather than graph-persisted provenance.
   - Non-goals remain explicit for raw storage, reflection scheduling, belief ontology, and physical redaction/delete.
 - validation:
   - kind: review
@@ -112,6 +117,7 @@
   Remove, rewrite, or explicitly isolate legacy flat facade and Qdrant vector-memory repository behavior that conflicts with the v0.1 graph-authoritative architecture.
 - acceptance:
   - Legacy `update_memory` / `delete_memory` paths no longer imply hard update/delete lifecycle semantics for v0.1.
+  - Durable correction-origin/source external-ref schema work is not introduced in this cleanup chunk; retained docs and tests describe episode/observation provenance as the persisted correction trail.
   - Any retained legacy path has a clear transitional reason and test boundary.
   - Tests are updated to validate the v0.1 path rather than preserving legacy behavior for compatibility alone.
   - No production raw storage, reflection scheduling, belief ontology, or physical redaction/delete semantics are introduced.
@@ -216,7 +222,9 @@
 - Risks:
   - Removing legacy code may reveal integration tests that still depend on old flat Qdrant behavior.
   - Documentation can overstate crate-visible injected lifecycle surfaces if production constructors are not yet graph-authoritative.
+  - Documentation can overstate correction-origin/source external-ref persistence if it does not distinguish DTO request metadata from durable episode/observation provenance and source refs.
   - Live Qdrant validation remains environment-sensitive and must be captured before release validation closes.
 - Edge cases:
   - Retained legacy paths need explicit transitional ownership and should not be described as canonical v0.1 behavior.
   - Examples should preserve source references without embedding raw transcript content into Qdrant or Oxigraph.
+  - Episode-level correction/forget examples should include observation-only derived memories so source cascades do not depend on duplicate episode IDs on every derived memory.

--- a/docs/coding-agent/plans/active/v0-1-starter-episodic-memory-roadmap.md
+++ b/docs/coding-agent/plans/active/v0-1-starter-episodic-memory-roadmap.md
@@ -2,7 +2,7 @@
 
 - status: draft
 - generated: 2026-04-27
-- last_updated: 2026-04-29
+- last_updated: 2026-04-30
 - work_type: mixed
 - roadmap_scope: full v0.1 implementation phase
 - concrete_plan_policy: draft one separate implementation plan per chunk when that chunk is reached
@@ -18,7 +18,7 @@
 - The old flat live persistence path remains legacy-shaped: `MemoryRepository` delegates to `VectorMemoryRepository`, and `QdrantVectorMemoryRepository` still serves the old flat facade.
 - The v0.1 vector foundation now has provider-neutral `VectorRecord` and natural-language embedding surfaces, plus Qdrant v0.1 payload mapping and `VectorCandidateStore::upsert_vector_records` support for full record payloads.
 - The v0.1 graph foundation now has RDF vocabulary/mapping and an embedded/in-memory `OxigraphGraphAuthorityStore` implementing `GraphAuthorityStore` for canonical objects, typed links, query, and bounded expansion foundation.
-- The current tests cover Qdrant-backed legacy behavior, v0.1 domain model behavior, draft DTO conversion, retrieval DTOs, deterministic fake-store support, v0.1 vector surfaces, Qdrant payload/candidate-store mapping, RDF/Oxigraph mapping, embedded Oxigraph retrieve/expansion smoke, bounded graph expansion, internal remember/link/retrieve pipelines, injected facade-level remember/link/retrieve behavior, and live Qdrant candidate smoke. Correction supersession and forget lifecycle pipelines remain future chunks.
+- The current tests cover Qdrant-backed legacy behavior, v0.1 domain model behavior, draft DTO conversion, lifecycle DTOs, retrieval DTOs, deterministic fake-store support, v0.1 vector surfaces, Qdrant payload/candidate-store mapping, RDF/Oxigraph mapping, embedded Oxigraph retrieve/expansion/lifecycle smoke, bounded graph expansion, internal remember/link/retrieve/correction/forget pipelines, injected facade-level remember/link/retrieve/correction/forget behavior, lifecycle retrieval regression behavior, and live Qdrant candidate smoke when the service prerequisite is available.
 - `Cargo.toml` includes the selected Qdrant and Oxigraph dependencies for the adapter foundation.
 
 ## Resolved Decisions
@@ -58,14 +58,14 @@
 
 ### Correction And Forget Lifecycle
 - Purpose: implement non-destructive correction through supersession and lifecycle updates, plus `forget` with suppression as the default.
-- Expected outcome: corrections preserve provenance, old derived memories become non-current, and suppressed memories are hidden from normal retrieval.
+- Expected outcome: corrections preserve original and correction-origin provenance, old or source-affected derived memories become non-current/suppressed or superseded, source-object forget cascades to behavior-influencing derived memories, archived threads are excluded, and suppressed/non-current/superseded memories are hidden from normal retrieval unless historical policy opts in.
 - Deferred review findings to carry forward: hard delete/update behavior in the legacy flat facade conflicts with the v0.1 lifecycle direction. Correction/forget work should preserve supersession/suppression as default behavior and reserve hard deletion for explicit redaction/delete semantics.
-- Concrete plan: [docs/coding-agent/plans/active/v0-1-correction-forget-lifecycle-plan.md](v0-1-correction-forget-lifecycle-plan.md)
+- Concrete plan: completed in [docs/coding-agent/plans/completed/v0-1-correction-forget-lifecycle-plan.md](../completed/v0-1-correction-forget-lifecycle-plan.md)
 
 ### Documentation, Migration Cleanup, And Release Validation
 - Purpose: update README and roadmap docs, remove or rewrite old flat memory examples, remove non-contributing legacy implementations, and run final deterministic plus gated integration validation.
 - Expected outcome: v0.1 is documented as chat-native episodic continuity memory, with Qdrant/Oxigraph responsibilities and old flat concepts clearly retired or removed.
-- Concrete plan: draft after implementation behavior is substantially complete.
+- Concrete plan: active draft in [docs/coding-agent/plans/active/v0-1-documentation-migration-cleanup-release-validation-plan.md](v0-1-documentation-migration-cleanup-release-validation-plan.md)
 
 ## Cross-Cutting Validation Expectations
 - Every concrete implementation plan should include `cargo fmt --check`, `cargo check`, and `cargo test --no-run` unless explicitly waived.
@@ -113,6 +113,10 @@
   - Summary: Completed backend-free retrieval DTOs, bounded graph expansion hardening, vector candidate prefilters, provider-neutral retrieve pipeline, crate-visible injected `CharacterMemory::retrieve`, rationale/trace behavior, and the next active correction/forget lifecycle plan.
   - Validation evidence: `cargo fmt --check`, `cargo check`, `cargo test --no-run`, `cargo test --lib`, embedded Oxigraph retrieve smoke, live Qdrant candidate smoke, `cargo clippy --all-targets -- -D warnings`, and final Reviewer approval passed.
   - Notes: Correction/forget planning now starts from graph-authoritative retrieval defaults that exclude suppressed/deleted and non-current/superseded records.
+- 2026-04-30 Correction/forget lifecycle completed; cleanup plan drafted.
+  - Summary: Completed backend-free lifecycle DTOs, graph-authoritative correction/forget pipelines, source-provenance cascade, correction-origin provenance, injected crate-visible lifecycle facades, retrieval lifecycle regressions, and the next documentation/migration cleanup/release validation plan.
+  - Validation evidence: `cargo fmt --check`, `cargo check`, `cargo test --no-run`, `cargo test --lib`, embedded Oxigraph lifecycle/retrieve smoke, `cargo clippy --all-targets -- -D warnings`, local live Qdrant candidate smoke, and final Reviewer approval passed; `cargo test --lib` reported 180 passed, 0 failed, 1 ignored, and the Qdrant smoke reported 1 passed, 0 failed.
+  - Notes: The cleanup plan is active as a draft only; lifecycle plan has moved to completed.
 
 ## Decision Log
 

--- a/docs/coding-agent/plans/completed/v0-1-correction-forget-lifecycle-plan.md
+++ b/docs/coding-agent/plans/completed/v0-1-correction-forget-lifecycle-plan.md
@@ -1,6 +1,6 @@
 # Plan: v0.1 Correction And Forget Lifecycle
 
-- status: draft
+- status: done
 - generated: 2026-04-29
 - last_updated: 2026-04-30
 - work_type: mixed
@@ -19,6 +19,10 @@
 - Normal retrieve behavior excludes suppressed/deleted and non-current/superseded memories after correction/forget. Compact rationale summarizes omissions; detailed historical/included-by-policy inspection requires trace-enabled retrieval.
 - Retrieval correctness still holds if stale vector candidates remain after graph mutation or vector maintenance partially fails; graph authority must exclude stale lifecycle state from final normal retrieval.
 - Required Rust checks, deterministic lifecycle tests, `cargo test --lib`, embedded Oxigraph smoke, gated Qdrant candidate smoke, clippy, and Reviewer approval are complete, or blockers/required-check waivers are explicitly recorded.
+
+## Current Blockers
+- None. Prior Task_6 closeout blockers are resolved: clippy passes after `ForgetLifecyclePolicy` derived `Default`, and the local Qdrant live smoke passed with a prepared service environment.
+- Final Reviewer approved and Orchestrator closeout confirmed evidence completeness before moving this plan to completed.
 
 ## Scope / Non-goals
 - Scope:
@@ -71,18 +75,40 @@
   - `docs/decisions/implementation/ADR-I-0006-bounded-graph-expansion.md`
 
 ## Open Questions (max 3)
-- None pending plan approval.
+- None.
 
-## Resolved Decisions Pending User Approval
-- Correction/forget facades should remain crate-visible injected surfaces in this chunk, matching the current `remember`/`link`/`retrieve` boundary. Public lifecycle API stabilization belongs to Documentation, Migration Cleanup, And Release Validation after production construction is graph-authoritative.
-- Supported lifecycle mutation targets are bounded to existing lifecycle fields: correction supersedes `DerivedMemory` records directly and can supersede source-affected derived memories discovered from corrected episodes/observations; forget suppresses `DerivedMemory`, `Episode`, and `Observation` records; forget archives `MemoryThread` records through `ThreadStatus::Archived`; entity and link lifecycle are deferred.
-- Correction requests must carry or reference correction-origin provenance when available, such as a correction episode ID, correction observation ID, and/or raw/source reference. Replacement correction memories must preserve both the old memory's original source chain and the correction event/source that explains the revision.
-- Forgetting an episode or observation defaults to cascade-suppressing behavior-influencing derived memories whose provenance references the forgotten source, because otherwise forgotten source material could still influence generation through derived memories.
-- Derived-memory supersession must persist both the replacement object's `supersedes` field and a typed `MemoryLink` with `RelationType::Supersedes` from the new derived memory to the old derived memory, because retrieval `superseded_by` evidence is relation-derived.
-- Physical hard deletion/redaction is deferred. This chunk may recognize the existing `RetentionState::Deleted` as a retrieval-filtered soft lifecycle state, but it must not add physical deletion/redaction behavior.
-- After graph success, vector maintenance deletes candidates for old/superseded/suppressed/archived object IDs and upserts replacement candidates. Vector failure after graph success returns explicit partial-success evidence and must not roll back graph truth.
-- Public DTOs stay backend-free; lifecycle pipelines depend on provider-neutral graph/vector/embedder contracts; Qdrant/Oxigraph/RDF remain infrastructure details.
-- Compact rationale should report aggregate lifecycle omissions; trace-enabled retrieval remains the detailed inspection path for corrected, superseded, suppressed, and historical opt-in behavior.
+## Required-Check Waivers
+
+- None active.
+
+## Resolved Required-Check Evidence
+
+- 2026-04-30 Deterministic closeout validation passed after clippy remediation.
+  - Check: `cargo fmt --check && cargo check && cargo test --no-run && cargo test --lib && cargo clippy --all-targets -- -D warnings`
+  - Local result: passed; `cargo test --lib` reported 180 passed, 0 failed, 1 ignored, and final clippy finished the dev profile successfully.
+  - Notes: The prior `clippy::derivable_impls` failure on `ForgetLifecyclePolicy` was resolved by deriving `Default`; a final policy-toggle remediation added two pipeline tests before the passing rerun.
+- 2026-04-30 Live Qdrant candidate maintenance smoke passed locally.
+  - Check: `docker compose -f docker-compose.qdrant.yml up -d && QDRANT_CONNECTION_STRING=http://localhost:6334 cargo test --lib qdrant_candidate_store_live_smoke_upserts_filters_searches_and_deletes -- --ignored`
+  - Local result: passed, 1 passed, 0 failed.
+  - Notes: This closes the prior missing-`QDRANT_CONNECTION_STRING` waiver for Task_6 lifecycle closeout evidence.
+
+## Review Placeholders
+
+- Reviewer-owned: approve no production raw-storage, reflection scheduling, external LLM extraction, physical hard-delete/redaction, or belief/evidence ontology scope creep was introduced by the lifecycle implementation.
+- Reviewer-owned: confirm normal retrieval lifecycle behavior remains inspectable through compact rationale aggregates and trace-enabled lifecycle/candidate omission details.
+- Orchestrator-owned: confirm Task_6 blocker resolution, waiver closure, evidence completeness, and independence of the next Documentation, Migration Cleanup, And Release Validation plan before moving this plan to completed.
+
+## Resolved Decisions
+- User approval for the revised lifecycle plan is recorded as of 2026-04-30. Task_1 selects the implementation boundary before Rust edits; later implementation tasks must treat these decisions as their dependency contract.
+- Correction/forget facades remain crate-visible injected surfaces in this chunk, matching the current `remember`/`link`/`retrieve` boundary. Public lifecycle API stabilization belongs to Documentation, Migration Cleanup, And Release Validation after production construction is graph-authoritative.
+- Supported lifecycle mutation targets are bounded to existing lifecycle fields: correction supersedes `DerivedMemory` records directly; episode/observation correction does not rewrite historical source objects but can create correction derived memories and supersede or mark non-current affected derived memories discovered through provenance; forget suppresses `DerivedMemory`, `Episode`, and `Observation` records; forget archives `MemoryThread` records through `ThreadStatus::Archived`; entity and link lifecycle are deferred.
+- Source-target cascade rules are defaulted now: correcting an episode or observation discovers behavior-influencing derived memories provenanced to that source and supersedes or marks those derived memories non-current through replacement correction memories; forgetting an episode or observation suppresses the source and cascade-suppresses behavior-influencing derived memories whose provenance references the forgotten source, so forgotten source material does not continue influencing normal retrieval.
+- Correction requests must carry or reference correction-origin provenance when available, such as a correction episode ID, correction observation ID, and/or raw/source reference. Replacement correction memories must preserve both the superseded memory's original source chain and the distinct correction event/source that explains the revision.
+- Derived-memory supersession direction is `new DerivedMemory supersedes old DerivedMemory`. Persistence must include both the replacement object's `DerivedMemory.supersedes` field and a typed `MemoryLink` with `RelationType::Supersedes` from the new derived memory to the old derived memory; retrieval evidence should present old or source-affected derived memories as `superseded_by` the replacement where relation evidence exists.
+- Default lifecycle behavior is non-destructive supersession for correction and suppression/archive for forget. Physical hard deletion/redaction is deferred; this chunk may recognize the existing `RetentionState::Deleted` as a retrieval-filtered soft lifecycle state, but it must not add physical deletion/redaction behavior.
+- Graph authority is the source of truth for lifecycle mutation semantics: currentness, retention state, thread archival, provenance, and typed supersession links are graph-authoritative. After graph success, vector maintenance deletes candidates for old/superseded/suppressed/archived object IDs and upserts replacement candidates; vector failure after graph success returns explicit partial-success evidence and must not roll back graph truth or compromise final retrieval correctness.
+- Public DTOs stay backend-free; lifecycle pipelines depend on provider-neutral `GraphAuthorityStore`, `VectorCandidateStore`, and `MemoryEmbedder` contracts; Qdrant/Oxigraph/RDF remain infrastructure details.
+- Compact rationale should report aggregate lifecycle omissions for corrected, superseded, suppressed, and historical opt-in behavior without promising full history in always-on output. Trace-enabled retrieval remains the detailed inspection path for per-object correction, supersession, suppression, vector-candidate, and historical-policy evidence.
 
 ## Assumptions
 - A1: Correction is non-destructive by default: create replacement memory, preserve old provenance, and mark old or source-affected derived memories non-current/superseded rather than overwriting them.
@@ -348,23 +374,43 @@
 - 2026-04-29 Plan drafted.
   - Summary: Created the next concrete plan for correction and forget lifecycle behavior from the landed retrieve/context-pack implementation.
   - Validation evidence: Documentation-only draft after completed retrieve plan validation and final Reviewer approval.
-  - Notes: Draft status; requires user approval before execution.
+  - Notes: Initial draft state; user approval was later recorded by Task_1.
 - 2026-04-30 Final PR #33 closeout review tightened plan boundaries.
   - Summary: Updated lifecycle plan to reflect the final retrieval shape: compact omission rationale plus detailed trace, graph authority over vector maintenance, derived-memory supersession direction, object-type lifecycle boundaries, and required clippy validation.
   - Validation evidence: Documentation review against completed retrieve plan, project philosophy, ADR-D-0006, ADR-I-0005, and current retrieval DTO/pipeline behavior.
-  - Notes: No lifecycle implementation performed; draft still requires user approval before execution.
+  - Notes: No lifecycle implementation performed; user approval was later recorded by Task_1.
 - 2026-04-30 Pre-implementation plan review tightened lifecycle target scope.
   - Summary: Reviewed the draft against the overarching roadmap, v0.1 roadmap, ADR-D-0002, ADR-D-0006, ADR-D-0008, ADR-I-0004, ADR-I-0005, ADR-I-0006, and current domain/retrieval/repository code. Initially narrowed this chunk to derived-memory correction/supersession and derived-memory forget/suppression, deferred source-object cascades and physical redaction/delete, required typed supersession links plus object supersedes fields, selected delete-old/upsert-replacement vector hygiene, and added `cargo test --lib` as required evidence.
   - Validation evidence: Researcher plan review plus direct source/doc inspection; no implementation performed.
-  - Notes: Draft still requires user approval before execution.
+  - Notes: User approval was later recorded by Task_1.
 - 2026-04-30 Roadmap scope recheck broadened lifecycle targets.
   - Summary: Rechecked the development roadmap and v0.1 roadmap after user feedback. Broadened this plan so completion covers derived-memory correction, episode/observation correction of affected derived memories, derived-memory/episode/observation suppression, default source-provenance cascade for forgotten episodes/observations, memory-thread archival, and graph-authoritative retrieval exclusion.
   - Validation evidence: Researcher scope reassessment plus direct roadmap/design/ADR review; no implementation performed.
-  - Notes: Draft still requires user approval before execution.
+  - Notes: User approval was later recorded by Task_1.
 - 2026-04-30 Reviewer requested explicit correction-origin provenance.
   - Summary: Added requirements that correction requests and outcomes preserve correction-origin episode/observation/source references separately from original source provenance, and that tests prove correction-origin provenance remains inspectable.
   - Validation evidence: Reviewer plan review requested changes; no implementation performed.
-  - Notes: Draft still requires user approval before execution.
+  - Notes: User approval was later recorded by Task_1.
+- 2026-04-30 Task_1 completed: lifecycle API and policy boundary selected.
+  - Summary: Recorded user approval of the revised lifecycle plan and selected crate-visible injected correction/forget facades, supported lifecycle targets, source-object correction/forget cascade rules, separate correction-origin provenance, derived-memory supersession direction and persistence shape, non-destructive suppression/default supersession behavior, graph-authoritative mutation semantics, vector hygiene/failure policy, backend-free dependency direction, and rationale/trace exposure boundaries.
+  - Validation evidence: Manual Worker review of the plan's lifecycle API, policy, vector-maintenance, failure-policy, provenance, graph-authority, and retrieval-evidence decisions before implementation edits; documentation-only Task_1 edit, no Rust checks required.
+  - Notes: No source files, lessons, or git state were changed by this task. Task_2 and later implementation tasks remain bound by this design gate and their own validation/reviewer requirements.
+- 2026-04-30 Tasks_2 through Task_5 implementation evidence consolidated by Task_6.
+  - Summary: Working tree contains backend-free lifecycle DTOs, provider-neutral correction/forget pipeline behavior, graph-authoritative lifecycle mutation support, crate-visible injected `CharacterMemory::correct` / `CharacterMemory::forget`, and deterministic retrieval regression coverage for supersession, suppression, archival, vector-maintenance failure, legacy isolation, and trace inspectability.
+  - Validation evidence: Final deterministic validation reran `cargo fmt --check` (pass), `cargo check` (pass), `cargo test --no-run` (pass), `cargo test --lib` (180 passed, 0 failed, 1 ignored), and `cargo clippy --all-targets -- -D warnings` (pass). The library suite includes lifecycle DTO tests, fake graph/vector pipeline tests, embedded Oxigraph graph lifecycle tests, injected facade lifecycle tests, retrieval stale-candidate/lifecycle omission tests, and policy-toggle regression tests.
+  - Notes: This is evidence consolidation only; Task_6 did not edit source, README, tests, rules, lessons, or git state.
+- 2026-04-30 Task_6 blocked during final validation.
+  - Summary: Embedded Oxigraph lifecycle/retrieve smoke passed and the next Documentation, Migration Cleanup, And Release Validation plan was drafted, but lifecycle closeout was paused at that point because clippy failed in source outside Task_6 owns.
+  - Validation evidence: Historical result: `cargo test --lib oxigraph_retrieval_after_lifecycle_mutation_excludes_stale_records_by_default` passed (1 passed, 0 failed); `cargo clippy --all-targets -- -D warnings` failed with `clippy::derivable_impls` on `ForgetLifecyclePolicy`; live Qdrant smoke failed before service exercise because `QDRANT_CONNECTION_STRING` was missing.
+  - Notes: This entry is superseded by the follow-up evidence below, which records clippy remediation, successful deterministic validation, successful live Qdrant smoke, and final gates pending.
+- 2026-04-30 Task_6 follow-up cleared validation blockers.
+  - Summary: Orchestrator remediated the clippy source issue by deriving `Default` for `ForgetLifecyclePolicy`, reran the deterministic validation suite successfully, started local Qdrant, and reran the live Qdrant candidate smoke successfully. The lifecycle plan remains active in pending review state rather than being moved to completed.
+  - Validation evidence: `cargo fmt --check && cargo test correction_forget_pipeline --lib && cargo test --lib && cargo check && cargo test --no-run && cargo clippy --all-targets -- -D warnings` passed; `cargo test correction_forget_pipeline --lib` reported 11 passed, 0 failed; `cargo test --lib` reported 180 passed, 0 failed, 1 ignored; `docker compose -f docker-compose.qdrant.yml up -d && QDRANT_CONNECTION_STRING=http://localhost:6334 cargo test --lib qdrant_candidate_store_live_smoke_upserts_filters_searches_and_deletes -- --ignored` passed with 1 passed, 0 failed.
+  - Notes: Reviewer and Orchestrator final gates remain pending before moving this plan to completed. The next Documentation, Migration Cleanup, And Release Validation plan remains drafted and preserved.
+- 2026-04-30 Final Reviewer and Orchestrator closeout approved lifecycle completion.
+  - Summary: Reviewer approved the completed lifecycle implementation after policy-toggle remediation, with no blocking findings. Orchestrator confirmed required evidence completeness, live Qdrant smoke evidence, retrieval lifecycle behavior, and next-plan independence.
+  - Validation evidence: Final Reviewer approval plus deterministic validation, embedded Oxigraph smoke, live Qdrant smoke, and clippy evidence recorded above.
+  - Notes: This plan is ready to move from active to completed. The Documentation, Migration Cleanup, And Release Validation plan remains active as the next independent concrete plan.
 
 ## Decision Log
 
@@ -372,12 +418,12 @@
   - Trigger / new insight: Retrieval now exposes graph-authoritative lifecycle/currentness omission behavior, rationale, trace, and fail-closed bounded expansion policy, making correction and forget lifecycle mutation the next roadmap chunk.
   - Plan delta: Added this active concrete plan for non-destructive correction, suppression-by-default forget, vector candidate maintenance, retrieval regression tests, and final lifecycle review.
   - Tradeoffs considered: Implementing lifecycle mutation before documentation cleanup keeps retrieval behavior grounded in actual graph state before retiring or rewriting legacy flat update/delete examples.
-  - User approval: pending.
+  - User approval: approved on 2026-04-30 via revised lifecycle plan approval.
 - 2026-04-30 Decision: Lifecycle plan must not overgeneralize supersession or vector maintenance authority
   - Trigger / new insight: Final retrieve PR review added compact omission rationale, relation-derived supersession evidence, and stronger Qdrant/fake hint parity; next-phase lifecycle work must align with that landed behavior.
   - Plan delta: Clarified derived-memory supersession direction, object-type lifecycle boundaries, vector maintenance as non-authoritative hygiene, trace versus compact rationale expectations, and required clippy validation.
   - Tradeoffs considered: Keeping generic correction/forget wording would be shorter, but risks workers implementing lifecycle mutation for object types that lack canonical lifecycle fields or treating vector maintenance as correctness authority.
-  - User approval: pending.
+  - User approval: approved on 2026-04-30 via revised lifecycle plan approval.
 - 2026-04-30 Decision: Constrain lifecycle implementation to derived-memory mutation first
   - Trigger / new insight: Current code supports retention filtering for episodes/observations but has no source-object forget cascade semantics, no physical delete/redact graph contract, and retrieval supersession evidence is relation-derived from typed links.
   - Plan delta: Resolved open questions toward crate-visible injected facades, derived-memory-only correction/forget mutation, hard-delete/redaction deferral, typed supersession link plus object field persistence, and vector deletion of stale candidates after graph success.
@@ -387,12 +433,22 @@
   - Trigger / new insight: The development roadmap and v0.1 design expect `forget` and suppression to prevent memories from being used for generation, and ADR-D-0002 says corrections must be able to find derived memories affected by a source episode or observation.
   - Plan delta: Brought episode/observation suppression and correction-target provenance cascade into scope, while keeping entity/link lifecycle and physical redaction/delete deferred.
   - Tradeoffs considered: Derived-memory-only lifecycle mutation is simpler but can leave forgotten source material influencing generation through derived memories. Cascade suppression increases implementation and test scope but better satisfies the roadmap's suppression and provenance goals.
-  - User approval: pending.
+  - User approval: approved on 2026-04-30 via revised lifecycle plan approval.
 - 2026-04-30 Decision: Preserve correction-origin provenance separately
   - Trigger / new insight: The roadmap says a correction episode explains why and v0.1 acceptance requires provenance to the correction episode, while ADR-D-0008 requires source-reference auditability.
   - Plan delta: Required correction DTOs, pipelines, and facade tests to represent and preserve correction-origin episode/observation/source references separately from the superseded memory's original provenance chain.
   - Tradeoffs considered: Only carrying the old source chain would preserve where the outdated memory came from, but not why it changed. A separate correction-origin chain keeps correction history auditable without forcing raw transcript storage into core.
-  - User approval: pending.
+  - User approval: approved on 2026-04-30 via revised lifecycle plan approval.
+- 2026-04-30 Decision: Honor non-default lifecycle policy toggles consistently
+  - Trigger / new insight: Final Reviewer noted that non-default DTO policy knobs were expressible but not fully honored by the pipeline.
+  - Plan delta: Correction now suppresses typed supersession links and `superseded_by` trace evidence when `supersede_replaced_derived_memories` is disabled; source-object forget cascade now requires both the cascade policy and suppression policy to allow derived-memory suppression.
+  - Tradeoffs considered: Defaults already satisfied the roadmap behavior, but honoring non-default policy toggles keeps the backend-free DTO contract honest before later public API stabilization.
+  - User approval: implementation refinement within approved lifecycle scope.
+- 2026-04-30 Decision: Approve Task_1 lifecycle boundary for implementation dependencies
+  - Trigger / new insight: User approved the revised lifecycle plan after roadmap-scope corrections and requested Task_1 record the lifecycle API and policy boundary before code implementation.
+  - Plan delta: Moved the plan to `in_progress`, renamed resolved decisions from pending approval to approved decisions, expanded the design-gate decisions to cover supported object types, cascade defaults, correction-origin provenance, supersession persistence/evidence, non-destructive lifecycle defaults, graph/vector failure semantics, backend-free dependency direction, and rationale/trace behavior, and recorded Task_1 completion in the progress log.
+  - Tradeoffs considered: Keeping these details only in task acceptance would make later Workers re-derive policy from scattered bullets; recording them as resolved decisions gives Task_2+ a single dependency contract without changing Rust code.
+  - User approval: approved on 2026-04-30; reviewer gates for later implementation tasks remain as listed in task validation.
 
 ## Notes
 - Risks:

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -1,4 +1,5 @@
 pub mod domain;
+pub mod lifecycle;
 pub mod retrieval;
 
 mod draft;
@@ -18,6 +19,14 @@ pub use draft::{
     DerivedMemoryDraft, DraftDefaults, EntityDraft, EpisodeDraft, MemoryLinkDraft,
     MemoryObjectDraft, MemoryThreadDraft, ObservationDraft, RememberDraft, RememberOutcome,
     VectorIndexingFailure,
+};
+pub use lifecycle::{
+    ArchivePolicy, CorrectMemoryDraft, CorrectionCascadePolicy, CorrectionLifecyclePolicy,
+    CorrectionTarget, DeferredDestructiveLifecyclePolicy, DeferredLifecycleAction,
+    ExternalSourceReference, ForgetCascadePolicy, ForgetLifecyclePolicy, ForgetMemoryDraft,
+    LifecycleDtoValidationError, LifecycleMutationOutcome, LifecycleMutationTrace,
+    LifecycleTargetRef, ReplacementDerivedMemoryDraft, SourceObjectCorrectionTarget,
+    SourceProvenanceReference, SupersededByEvidence, SuppressionPolicy, VectorMaintenanceFailure,
 };
 pub use memory::Memory;
 pub use memory_filters::MemoryFilters;

--- a/src/api/types/lifecycle.rs
+++ b/src/api/types/lifecycle.rs
@@ -103,8 +103,11 @@ impl ExternalSourceReference {
     pub fn has_reference(&self) -> bool {
         self.source_ref
             .as_ref()
-            .is_some_and(|value| !value.is_empty())
-            || self.raw_ref.as_ref().is_some_and(|value| !value.is_empty())
+            .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .raw_ref
+                .as_ref()
+                .is_some_and(|value| !value.trim().is_empty())
     }
 }
 
@@ -675,6 +678,23 @@ mod tests {
         assert_eq!(
             replacement.validate(),
             Err(LifecycleDtoValidationError::MissingReplacementSource)
+        );
+    }
+
+    #[test]
+    fn validation_rejects_whitespace_only_external_refs() {
+        assert!(!ExternalSourceReference::raw("   ").has_reference());
+        assert!(!ExternalSourceReference::source("\t\n").has_reference());
+
+        let mut correction = correction_draft();
+        correction.correction_origin = SourceProvenanceReference {
+            episode_ids: Vec::new(),
+            observation_ids: Vec::new(),
+            external_refs: vec![ExternalSourceReference::raw("  ")],
+        };
+        assert_eq!(
+            correction.validate(),
+            Err(LifecycleDtoValidationError::EmptyCorrectionOrigin)
         );
     }
 

--- a/src/api/types/lifecycle.rs
+++ b/src/api/types/lifecycle.rs
@@ -1,0 +1,864 @@
+use serde::{Deserialize, Serialize};
+
+use super::domain::{DerivedType, MemoryId, ObjectType, RetentionState, Stability, ThreadStatus};
+use super::retrieval::MemoryObjectRef;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifecycleDtoValidationError {
+    EmptyRationale,
+    EmptyCorrectionOrigin,
+    EmptyReplacementText,
+    MissingReplacementSource,
+    MissingCorrectionTarget,
+    MissingForgetTarget,
+    UnsupportedLifecycleTarget(ObjectType),
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "object_type", content = "id", rename_all = "snake_case")]
+pub enum LifecycleTargetRef {
+    DerivedMemory(MemoryId),
+    Episode(MemoryId),
+    Observation(MemoryId),
+    MemoryThread(MemoryId),
+}
+
+impl LifecycleTargetRef {
+    pub const fn derived_memory(id: MemoryId) -> Self {
+        Self::DerivedMemory(id)
+    }
+
+    pub const fn episode(id: MemoryId) -> Self {
+        Self::Episode(id)
+    }
+
+    pub const fn observation(id: MemoryId) -> Self {
+        Self::Observation(id)
+    }
+
+    pub const fn memory_thread(id: MemoryId) -> Self {
+        Self::MemoryThread(id)
+    }
+
+    pub const fn object_type(self) -> ObjectType {
+        match self {
+            Self::DerivedMemory(_) => ObjectType::DerivedMemory,
+            Self::Episode(_) => ObjectType::Episode,
+            Self::Observation(_) => ObjectType::Observation,
+            Self::MemoryThread(_) => ObjectType::MemoryThread,
+        }
+    }
+
+    pub const fn id(self) -> MemoryId {
+        match self {
+            Self::DerivedMemory(id)
+            | Self::Episode(id)
+            | Self::Observation(id)
+            | Self::MemoryThread(id) => id,
+        }
+    }
+
+    pub const fn as_memory_object_ref(self) -> MemoryObjectRef {
+        MemoryObjectRef::new(self.object_type(), self.id())
+    }
+}
+
+impl TryFrom<MemoryObjectRef> for LifecycleTargetRef {
+    type Error = LifecycleDtoValidationError;
+
+    fn try_from(value: MemoryObjectRef) -> Result<Self, Self::Error> {
+        match value.object_type {
+            ObjectType::DerivedMemory => Ok(Self::DerivedMemory(value.id)),
+            ObjectType::Episode => Ok(Self::Episode(value.id)),
+            ObjectType::Observation => Ok(Self::Observation(value.id)),
+            ObjectType::MemoryThread => Ok(Self::MemoryThread(value.id)),
+            unsupported => Err(LifecycleDtoValidationError::UnsupportedLifecycleTarget(
+                unsupported,
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExternalSourceReference {
+    pub source_ref: Option<String>,
+    pub raw_ref: Option<String>,
+}
+
+impl ExternalSourceReference {
+    pub fn source(source_ref: impl Into<String>) -> Self {
+        Self {
+            source_ref: Some(source_ref.into()),
+            raw_ref: None,
+        }
+    }
+
+    pub fn raw(raw_ref: impl Into<String>) -> Self {
+        Self {
+            source_ref: None,
+            raw_ref: Some(raw_ref.into()),
+        }
+    }
+
+    pub fn has_reference(&self) -> bool {
+        self.source_ref
+            .as_ref()
+            .is_some_and(|value| !value.is_empty())
+            || self.raw_ref.as_ref().is_some_and(|value| !value.is_empty())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceProvenanceReference {
+    pub episode_ids: Vec<MemoryId>,
+    pub observation_ids: Vec<MemoryId>,
+    pub external_refs: Vec<ExternalSourceReference>,
+}
+
+impl SourceProvenanceReference {
+    pub fn episode(episode_id: MemoryId) -> Self {
+        Self {
+            episode_ids: vec![episode_id],
+            observation_ids: Vec::new(),
+            external_refs: Vec::new(),
+        }
+    }
+
+    pub fn observation(observation_id: MemoryId) -> Self {
+        Self {
+            episode_ids: Vec::new(),
+            observation_ids: vec![observation_id],
+            external_refs: Vec::new(),
+        }
+    }
+
+    pub fn with_external_ref(mut self, external_ref: ExternalSourceReference) -> Self {
+        self.external_refs.push(external_ref);
+        self
+    }
+
+    pub fn has_reference(&self) -> bool {
+        !self.episode_ids.is_empty()
+            || !self.observation_ids.is_empty()
+            || self
+                .external_refs
+                .iter()
+                .any(ExternalSourceReference::has_reference)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "object_type", rename_all = "snake_case")]
+pub enum SourceObjectCorrectionTarget {
+    Episode {
+        id: MemoryId,
+        original_raw_ref: Option<String>,
+        original_source_ref: Option<String>,
+    },
+    Observation {
+        id: MemoryId,
+        original_raw_ref: Option<String>,
+        original_source_ref: Option<String>,
+    },
+}
+
+impl SourceObjectCorrectionTarget {
+    pub const fn id(&self) -> MemoryId {
+        match self {
+            Self::Episode { id, .. } | Self::Observation { id, .. } => *id,
+        }
+    }
+
+    pub const fn object_type(&self) -> ObjectType {
+        match self {
+            Self::Episode { .. } => ObjectType::Episode,
+            Self::Observation { .. } => ObjectType::Observation,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CorrectionTarget {
+    DerivedMemory {
+        id: MemoryId,
+    },
+    SourceObject {
+        target: SourceObjectCorrectionTarget,
+    },
+}
+
+impl CorrectionTarget {
+    pub const fn derived_memory(id: MemoryId) -> Self {
+        Self::DerivedMemory { id }
+    }
+
+    pub fn source_object(target: SourceObjectCorrectionTarget) -> Self {
+        Self::SourceObject { target }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReplacementDerivedMemoryDraft {
+    pub id: Option<MemoryId>,
+    pub derived_type: DerivedType,
+    pub text: String,
+    pub derived_from_episode_ids: Vec<MemoryId>,
+    pub derived_from_observation_ids: Vec<MemoryId>,
+    pub thread_ids: Vec<MemoryId>,
+    pub entity_ids: Vec<MemoryId>,
+    pub confidence: f32,
+    pub salience_score: f32,
+    pub stability: Stability,
+    pub supersedes: Vec<MemoryId>,
+    pub original_source_provenance: SourceProvenanceReference,
+    pub correction_origin_provenance: SourceProvenanceReference,
+}
+
+impl ReplacementDerivedMemoryDraft {
+    pub fn new(derived_type: DerivedType, text: impl Into<String>) -> Self {
+        Self {
+            id: None,
+            derived_type,
+            text: text.into(),
+            derived_from_episode_ids: Vec::new(),
+            derived_from_observation_ids: Vec::new(),
+            thread_ids: Vec::new(),
+            entity_ids: Vec::new(),
+            confidence: 1.0,
+            salience_score: 0.5,
+            stability: Stability::Medium,
+            supersedes: Vec::new(),
+            original_source_provenance: SourceProvenanceReference {
+                episode_ids: Vec::new(),
+                observation_ids: Vec::new(),
+                external_refs: Vec::new(),
+            },
+            correction_origin_provenance: SourceProvenanceReference {
+                episode_ids: Vec::new(),
+                observation_ids: Vec::new(),
+                external_refs: Vec::new(),
+            },
+        }
+    }
+
+    pub fn with_source_episode(mut self, episode_id: MemoryId) -> Self {
+        self.derived_from_episode_ids.push(episode_id);
+        self
+    }
+
+    pub fn with_source_observation(mut self, observation_id: MemoryId) -> Self {
+        self.derived_from_observation_ids.push(observation_id);
+        self
+    }
+
+    pub fn with_superseded_memory(mut self, superseded_memory_id: MemoryId) -> Self {
+        self.supersedes.push(superseded_memory_id);
+        self
+    }
+
+    pub fn validate(&self) -> Result<(), LifecycleDtoValidationError> {
+        if self.text.trim().is_empty() {
+            return Err(LifecycleDtoValidationError::EmptyReplacementText);
+        }
+
+        if self.derived_from_episode_ids.is_empty() && self.derived_from_observation_ids.is_empty()
+        {
+            return Err(LifecycleDtoValidationError::MissingReplacementSource);
+        }
+
+        if !self.correction_origin_provenance.has_reference() {
+            return Err(LifecycleDtoValidationError::EmptyCorrectionOrigin);
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CorrectionLifecyclePolicy {
+    pub supersede_replaced_derived_memories: bool,
+    pub suppress_superseded_derived_memories: bool,
+    pub retain_original_source_objects: bool,
+    pub destructive_actions: DeferredDestructiveLifecyclePolicy,
+}
+
+impl Default for CorrectionLifecyclePolicy {
+    fn default() -> Self {
+        Self {
+            supersede_replaced_derived_memories: true,
+            suppress_superseded_derived_memories: true,
+            retain_original_source_objects: true,
+            destructive_actions: DeferredDestructiveLifecyclePolicy::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CorrectionCascadePolicy {
+    pub apply_to_provenanced_derived_memories: bool,
+    pub require_original_source_match: bool,
+    pub cascade_to_threads: bool,
+}
+
+impl Default for CorrectionCascadePolicy {
+    fn default() -> Self {
+        Self {
+            apply_to_provenanced_derived_memories: true,
+            require_original_source_match: true,
+            cascade_to_threads: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeferredDestructiveLifecyclePolicy {
+    pub hard_delete: DeferredLifecycleAction,
+    pub redaction: DeferredLifecycleAction,
+}
+
+impl Default for DeferredDestructiveLifecyclePolicy {
+    fn default() -> Self {
+        Self {
+            hard_delete: DeferredLifecycleAction::UnsupportedDeferred,
+            redaction: DeferredLifecycleAction::UnsupportedDeferred,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DeferredLifecycleAction {
+    UnsupportedDeferred,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CorrectMemoryDraft {
+    pub targets: Vec<CorrectionTarget>,
+    pub replacement_derived_memories: Vec<ReplacementDerivedMemoryDraft>,
+    pub superseded_derived_memory_ids: Vec<MemoryId>,
+    pub correction_origin: SourceProvenanceReference,
+    pub rationale: String,
+    pub lifecycle_policy: CorrectionLifecyclePolicy,
+    pub cascade_policy: CorrectionCascadePolicy,
+    pub include_trace: bool,
+}
+
+impl CorrectMemoryDraft {
+    pub fn new(target: CorrectionTarget, rationale: impl Into<String>) -> Self {
+        Self {
+            targets: vec![target],
+            replacement_derived_memories: Vec::new(),
+            superseded_derived_memory_ids: Vec::new(),
+            correction_origin: SourceProvenanceReference {
+                episode_ids: Vec::new(),
+                observation_ids: Vec::new(),
+                external_refs: Vec::new(),
+            },
+            rationale: rationale.into(),
+            lifecycle_policy: CorrectionLifecyclePolicy::default(),
+            cascade_policy: CorrectionCascadePolicy::default(),
+            include_trace: false,
+        }
+    }
+
+    pub fn with_replacement(mut self, replacement: ReplacementDerivedMemoryDraft) -> Self {
+        self.replacement_derived_memories.push(replacement);
+        self
+    }
+
+    pub fn with_superseded_derived_memory(mut self, memory_id: MemoryId) -> Self {
+        self.superseded_derived_memory_ids.push(memory_id);
+        self
+    }
+
+    pub fn with_trace(mut self) -> Self {
+        self.include_trace = true;
+        self
+    }
+
+    pub fn validate(&self) -> Result<(), LifecycleDtoValidationError> {
+        if self.targets.is_empty() {
+            return Err(LifecycleDtoValidationError::MissingCorrectionTarget);
+        }
+
+        if self.rationale.trim().is_empty() {
+            return Err(LifecycleDtoValidationError::EmptyRationale);
+        }
+
+        if !self.correction_origin.has_reference() {
+            return Err(LifecycleDtoValidationError::EmptyCorrectionOrigin);
+        }
+
+        for replacement in &self.replacement_derived_memories {
+            replacement.validate()?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SuppressionPolicy {
+    pub suppress_target: bool,
+    pub suppress_derived_from_target: bool,
+    pub preserve_original_raw_refs: bool,
+}
+
+impl Default for SuppressionPolicy {
+    fn default() -> Self {
+        Self {
+            suppress_target: true,
+            suppress_derived_from_target: true,
+            preserve_original_raw_refs: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArchivePolicy {
+    pub archive_thread: bool,
+    pub archive_thread_derived_memories: bool,
+    pub preserve_original_raw_refs: bool,
+}
+
+impl Default for ArchivePolicy {
+    fn default() -> Self {
+        Self {
+            archive_thread: true,
+            archive_thread_derived_memories: false,
+            preserve_original_raw_refs: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForgetCascadePolicy {
+    pub apply_to_derived_from_target: bool,
+    pub apply_to_thread_members: bool,
+}
+
+impl Default for ForgetCascadePolicy {
+    fn default() -> Self {
+        Self {
+            apply_to_derived_from_target: true,
+            apply_to_thread_members: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ForgetLifecyclePolicy {
+    pub suppression: SuppressionPolicy,
+    pub archive: ArchivePolicy,
+    pub destructive_actions: DeferredDestructiveLifecyclePolicy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForgetMemoryDraft {
+    pub targets: Vec<LifecycleTargetRef>,
+    pub rationale: String,
+    pub lifecycle_policy: ForgetLifecyclePolicy,
+    pub cascade_policy: ForgetCascadePolicy,
+    pub target_retention_state: RetentionState,
+    pub target_thread_status: Option<ThreadStatus>,
+    pub include_trace: bool,
+}
+
+impl ForgetMemoryDraft {
+    pub fn suppress(target: LifecycleTargetRef, rationale: impl Into<String>) -> Self {
+        Self {
+            targets: vec![target],
+            rationale: rationale.into(),
+            lifecycle_policy: ForgetLifecyclePolicy::default(),
+            cascade_policy: ForgetCascadePolicy::default(),
+            target_retention_state: RetentionState::Suppressed,
+            target_thread_status: None,
+            include_trace: false,
+        }
+    }
+
+    pub fn archive_thread(thread_id: MemoryId, rationale: impl Into<String>) -> Self {
+        Self {
+            targets: vec![LifecycleTargetRef::MemoryThread(thread_id)],
+            rationale: rationale.into(),
+            lifecycle_policy: ForgetLifecyclePolicy::default(),
+            cascade_policy: ForgetCascadePolicy::default(),
+            target_retention_state: RetentionState::Archived,
+            target_thread_status: Some(ThreadStatus::Archived),
+            include_trace: false,
+        }
+    }
+
+    pub fn with_trace(mut self) -> Self {
+        self.include_trace = true;
+        self
+    }
+
+    pub fn validate(&self) -> Result<(), LifecycleDtoValidationError> {
+        if self.targets.is_empty() {
+            return Err(LifecycleDtoValidationError::MissingForgetTarget);
+        }
+
+        if self.rationale.trim().is_empty() {
+            return Err(LifecycleDtoValidationError::EmptyRationale);
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SupersededByEvidence {
+    pub superseded_memory_id: MemoryId,
+    pub superseded_by_memory_id: MemoryId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LifecycleMutationTrace {
+    pub requested_targets: Vec<LifecycleTargetRef>,
+    pub superseded_by: Vec<SupersededByEvidence>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LifecycleMutationOutcome {
+    pub graph_mutated_object_ids: Vec<MemoryObjectRef>,
+    pub graph_mutated_link_ids: Vec<MemoryId>,
+    pub vector_maintained_object_ids: Vec<MemoryObjectRef>,
+    pub vector_maintenance_failure: Option<VectorMaintenanceFailure>,
+    pub trace: Option<LifecycleMutationTrace>,
+}
+
+impl LifecycleMutationOutcome {
+    pub fn empty() -> Self {
+        Self {
+            graph_mutated_object_ids: Vec::new(),
+            graph_mutated_link_ids: Vec::new(),
+            vector_maintained_object_ids: Vec::new(),
+            vector_maintenance_failure: None,
+            trace: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct VectorMaintenanceFailure {
+    pub unmaintained_object_ids: Vec<MemoryObjectRef>,
+    pub error_message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use uuid::Uuid;
+
+    fn memory_id(value: &str) -> MemoryId {
+        Uuid::parse_str(value).unwrap()
+    }
+
+    fn episode_id() -> MemoryId {
+        memory_id("550e8400-e29b-41d4-a716-446655441000")
+    }
+
+    fn observation_id() -> MemoryId {
+        memory_id("550e8400-e29b-41d4-a716-446655441001")
+    }
+
+    fn old_memory_id() -> MemoryId {
+        memory_id("550e8400-e29b-41d4-a716-446655441002")
+    }
+
+    fn new_memory_id() -> MemoryId {
+        memory_id("550e8400-e29b-41d4-a716-446655441003")
+    }
+
+    fn correction_origin() -> SourceProvenanceReference {
+        SourceProvenanceReference::observation(observation_id())
+            .with_external_ref(ExternalSourceReference::raw("raw://corrections/1#message"))
+    }
+
+    fn replacement() -> ReplacementDerivedMemoryDraft {
+        let mut replacement = ReplacementDerivedMemoryDraft::new(
+            DerivedType::Correction,
+            "The corrected derived memory text.",
+        )
+        .with_source_episode(episode_id())
+        .with_source_observation(observation_id())
+        .with_superseded_memory(old_memory_id());
+        replacement.id = Some(new_memory_id());
+        replacement.original_source_provenance = SourceProvenanceReference::episode(episode_id())
+            .with_external_ref(ExternalSourceReference::raw("raw://original/episode"));
+        replacement.correction_origin_provenance = correction_origin();
+        replacement
+    }
+
+    fn correction_draft() -> CorrectMemoryDraft {
+        let mut draft = CorrectMemoryDraft::new(
+            CorrectionTarget::derived_memory(old_memory_id()),
+            "User corrected the earlier derived memory.",
+        )
+        .with_replacement(replacement())
+        .with_superseded_derived_memory(old_memory_id())
+        .with_trace();
+        draft.correction_origin = correction_origin();
+        draft
+    }
+
+    #[test]
+    fn correction_and_forget_dtos_round_trip_through_serde() {
+        let correction = correction_draft();
+        let forget = ForgetMemoryDraft::suppress(
+            LifecycleTargetRef::observation(observation_id()),
+            "Hide this observation from recall.",
+        )
+        .with_trace();
+
+        let correction_json = serde_json::to_string(&correction).unwrap();
+        let forget_json = serde_json::to_string(&forget).unwrap();
+
+        assert_eq!(
+            serde_json::from_str::<CorrectMemoryDraft>(&correction_json).unwrap(),
+            correction
+        );
+        assert_eq!(
+            serde_json::from_str::<ForgetMemoryDraft>(&forget_json).unwrap(),
+            forget
+        );
+    }
+
+    #[test]
+    fn lifecycle_defaults_are_non_destructive_and_trace_is_opt_in() {
+        let correction = CorrectMemoryDraft::new(
+            CorrectionTarget::derived_memory(old_memory_id()),
+            "Correct stale memory.",
+        );
+        let forget = ForgetMemoryDraft::suppress(
+            LifecycleTargetRef::derived_memory(old_memory_id()),
+            "Suppress stale memory.",
+        );
+
+        assert!(
+            correction
+                .lifecycle_policy
+                .supersede_replaced_derived_memories
+        );
+        assert!(correction.lifecycle_policy.retain_original_source_objects);
+        assert_eq!(
+            correction.lifecycle_policy.destructive_actions.hard_delete,
+            DeferredLifecycleAction::UnsupportedDeferred
+        );
+        assert_eq!(
+            forget.lifecycle_policy.destructive_actions.redaction,
+            DeferredLifecycleAction::UnsupportedDeferred
+        );
+        assert!(!correction.include_trace);
+        assert!(!forget.include_trace);
+    }
+
+    #[test]
+    fn validation_rejects_empty_correction_origin_and_replacement_sources() {
+        let mut correction = correction_draft();
+        correction.correction_origin = SourceProvenanceReference {
+            episode_ids: Vec::new(),
+            observation_ids: Vec::new(),
+            external_refs: Vec::new(),
+        };
+        assert_eq!(
+            correction.validate(),
+            Err(LifecycleDtoValidationError::EmptyCorrectionOrigin)
+        );
+
+        let mut replacement = replacement();
+        replacement.derived_from_episode_ids.clear();
+        replacement.derived_from_observation_ids.clear();
+        assert_eq!(
+            replacement.validate(),
+            Err(LifecycleDtoValidationError::MissingReplacementSource)
+        );
+    }
+
+    #[test]
+    fn validation_requires_targets_and_rationale() {
+        let mut correction = correction_draft();
+        correction.targets.clear();
+        assert_eq!(
+            correction.validate(),
+            Err(LifecycleDtoValidationError::MissingCorrectionTarget)
+        );
+
+        let mut forget =
+            ForgetMemoryDraft::suppress(LifecycleTargetRef::episode(episode_id()), "  \n\t  ");
+        assert_eq!(
+            forget.validate(),
+            Err(LifecycleDtoValidationError::EmptyRationale)
+        );
+
+        forget.rationale = "Suppress episode.".to_owned();
+        forget.targets.clear();
+        assert_eq!(
+            forget.validate(),
+            Err(LifecycleDtoValidationError::MissingForgetTarget)
+        );
+    }
+
+    #[test]
+    fn typed_target_boundaries_accept_supported_lifecycle_objects_only() {
+        for object_type in [
+            ObjectType::DerivedMemory,
+            ObjectType::Episode,
+            ObjectType::Observation,
+            ObjectType::MemoryThread,
+        ] {
+            let target =
+                LifecycleTargetRef::try_from(MemoryObjectRef::new(object_type, episode_id()));
+            assert!(target.is_ok());
+        }
+
+        assert_eq!(
+            LifecycleTargetRef::try_from(MemoryObjectRef::new(ObjectType::Entity, episode_id())),
+            Err(LifecycleDtoValidationError::UnsupportedLifecycleTarget(
+                ObjectType::Entity
+            ))
+        );
+        assert_eq!(
+            LifecycleTargetRef::try_from(MemoryObjectRef::new(
+                ObjectType::MemoryLink,
+                episode_id()
+            )),
+            Err(LifecycleDtoValidationError::UnsupportedLifecycleTarget(
+                ObjectType::MemoryLink
+            ))
+        );
+    }
+
+    #[test]
+    fn correction_semantics_supersede_without_requesting_destruction() {
+        let draft = correction_draft();
+        let replacement = draft.replacement_derived_memories.first().unwrap();
+
+        assert_eq!(replacement.supersedes, vec![old_memory_id()]);
+        assert_eq!(draft.superseded_derived_memory_ids, vec![old_memory_id()]);
+        assert!(draft.lifecycle_policy.suppress_superseded_derived_memories);
+        assert_eq!(
+            draft.lifecycle_policy.destructive_actions,
+            DeferredDestructiveLifecyclePolicy::default()
+        );
+        assert_eq!(draft.validate(), Ok(()));
+    }
+
+    #[test]
+    fn source_target_cascade_defaults_follow_provenanced_derived_memories() {
+        let draft = CorrectMemoryDraft::new(
+            CorrectionTarget::source_object(SourceObjectCorrectionTarget::Episode {
+                id: episode_id(),
+                original_raw_ref: Some("raw://original/episode".to_owned()),
+                original_source_ref: Some("conversation://original".to_owned()),
+            }),
+            "Correct source episode summary and derived claims.",
+        );
+
+        assert!(draft.cascade_policy.apply_to_provenanced_derived_memories);
+        assert!(draft.cascade_policy.require_original_source_match);
+        assert!(!draft.cascade_policy.cascade_to_threads);
+    }
+
+    #[test]
+    fn original_source_and_correction_origin_provenance_are_distinct_refs() {
+        let replacement = replacement();
+        let serialized = serde_json::to_string(&replacement).unwrap();
+
+        assert_eq!(
+            replacement.original_source_provenance.external_refs[0]
+                .raw_ref
+                .as_deref(),
+            Some("raw://original/episode")
+        );
+        assert_eq!(
+            replacement.correction_origin_provenance.external_refs[0]
+                .raw_ref
+                .as_deref(),
+            Some("raw://corrections/1#message")
+        );
+        assert!(!serialized.contains("verbatim transcript payload"));
+    }
+
+    #[test]
+    fn suppression_and_archive_defaults_match_supported_lifecycle_boundary() {
+        let suppression = SuppressionPolicy::default();
+        let archive = ArchivePolicy::default();
+        let thread_forget =
+            ForgetMemoryDraft::archive_thread(episode_id(), "Archive finished thread.");
+
+        assert!(suppression.suppress_target);
+        assert!(suppression.suppress_derived_from_target);
+        assert!(suppression.preserve_original_raw_refs);
+        assert!(archive.archive_thread);
+        assert!(!archive.archive_thread_derived_memories);
+        assert_eq!(
+            thread_forget.target_retention_state,
+            RetentionState::Archived
+        );
+        assert_eq!(
+            thread_forget.target_thread_status,
+            Some(ThreadStatus::Archived)
+        );
+    }
+
+    #[test]
+    fn hard_delete_and_redaction_are_deferred_not_selectable_behaviors() {
+        let policy = DeferredDestructiveLifecyclePolicy::default();
+        let serialized = serde_json::to_string(&policy).unwrap();
+
+        assert_eq!(
+            policy.hard_delete,
+            DeferredLifecycleAction::UnsupportedDeferred
+        );
+        assert_eq!(
+            policy.redaction,
+            DeferredLifecycleAction::UnsupportedDeferred
+        );
+        assert!(serialized.contains("unsupported_deferred"));
+    }
+
+    #[test]
+    fn outcome_reports_graph_vector_and_partial_vector_failures() {
+        let outcome = LifecycleMutationOutcome {
+            graph_mutated_object_ids: vec![MemoryObjectRef::new(
+                ObjectType::DerivedMemory,
+                new_memory_id(),
+            )],
+            graph_mutated_link_ids: vec![memory_id("550e8400-e29b-41d4-a716-446655441004")],
+            vector_maintained_object_ids: vec![MemoryObjectRef::new(
+                ObjectType::DerivedMemory,
+                new_memory_id(),
+            )],
+            vector_maintenance_failure: Some(VectorMaintenanceFailure {
+                unmaintained_object_ids: vec![MemoryObjectRef::new(
+                    ObjectType::DerivedMemory,
+                    old_memory_id(),
+                )],
+                error_message: "vector maintenance timed out after graph mutation".to_owned(),
+            }),
+            trace: Some(LifecycleMutationTrace {
+                requested_targets: vec![LifecycleTargetRef::derived_memory(old_memory_id())],
+                superseded_by: vec![SupersededByEvidence {
+                    superseded_memory_id: old_memory_id(),
+                    superseded_by_memory_id: new_memory_id(),
+                }],
+            }),
+        };
+
+        let round_tripped: LifecycleMutationOutcome =
+            serde_json::from_str(&serde_json::to_string(&outcome).unwrap()).unwrap();
+
+        assert_eq!(round_tripped, outcome);
+        assert_eq!(
+            round_tripped.trace.unwrap().superseded_by[0],
+            SupersededByEvidence {
+                superseded_memory_id: old_memory_id(),
+                superseded_by_memory_id: new_memory_id(),
+            }
+        );
+    }
+}

--- a/src/api/types/lifecycle.rs
+++ b/src/api/types/lifecycle.rs
@@ -1,16 +1,26 @@
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use super::domain::{DerivedType, MemoryId, ObjectType, RetentionState, Stability, ThreadStatus};
 use super::retrieval::MemoryObjectRef;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum LifecycleDtoValidationError {
+    #[error("rationale must not be empty")]
     EmptyRationale,
+    #[error("correction origin provenance is required")]
     EmptyCorrectionOrigin,
+    #[error("replacement derived memory text must not be empty")]
     EmptyReplacementText,
+    #[error(
+        "replacement derived memory must reference at least one source episode or observation"
+    )]
     MissingReplacementSource,
+    #[error("correction requires at least one target")]
     MissingCorrectionTarget,
+    #[error("forget requires at least one target")]
     MissingForgetTarget,
+    #[error("unsupported lifecycle target: {0:?}")]
     UnsupportedLifecycleTarget(ObjectType),
 }
 
@@ -719,6 +729,18 @@ mod tests {
         assert_eq!(
             forget.validate(),
             Err(LifecycleDtoValidationError::MissingForgetTarget)
+        );
+    }
+
+    #[test]
+    fn validation_errors_have_actionable_display_messages() {
+        assert_eq!(
+            LifecycleDtoValidationError::MissingForgetTarget.to_string(),
+            "forget requires at least one target"
+        );
+        assert_eq!(
+            LifecycleDtoValidationError::UnsupportedLifecycleTarget(ObjectType::Entity).to_string(),
+            "unsupported lifecycle target: Entity"
         );
     }
 

--- a/src/internal/infrastructures/graph/oxigraph_authority_store.rs
+++ b/src/internal/infrastructures/graph/oxigraph_authority_store.rs
@@ -49,14 +49,34 @@ impl OxigraphGraphAuthorityStore {
         triples: &[RdfTriple],
     ) -> Result<(), CustomError> {
         let quads = quads_for_triples(&owner_graph_uri, triples)?;
-        let mut inserted_quads = lock(&self.inserted_quads)?;
+        self.replace_triples_batch(vec![(owner_graph_uri, quads)])
+    }
 
-        if let Some(previous_quads) = inserted_quads.remove(&owner_graph_uri) {
-            self.remove_quads(&previous_quads)?;
+    fn replace_triples_batch(
+        &self,
+        replacements: Vec<(String, Vec<Quad>)>,
+    ) -> Result<(), CustomError> {
+        let mut inserted_quads = lock(&self.inserted_quads)?;
+        let mut transaction = self.store.start_transaction().map_err(oxigraph_error)?;
+
+        for (owner_graph_uri, _) in &replacements {
+            if let Some(previous_quads) = inserted_quads.get(owner_graph_uri) {
+                for quad in previous_quads {
+                    transaction.remove(quad.as_ref());
+                }
+            }
         }
 
-        self.insert_quads(&quads)?;
-        inserted_quads.insert(owner_graph_uri, quads);
+        for (_, quads) in &replacements {
+            for quad in quads {
+                transaction.insert(quad.as_ref());
+            }
+        }
+
+        transaction.commit().map_err(oxigraph_error)?;
+        for (owner_graph_uri, quads) in replacements {
+            inserted_quads.insert(owner_graph_uri, quads);
+        }
         Ok(())
     }
 
@@ -163,31 +183,30 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
         objects: &[MemoryObject],
         links: &[MemoryLink],
     ) -> Result<(), CustomError> {
-        let mut object_triples = Vec::new();
+        let mut replacements = Vec::new();
         for object in objects {
             object
                 .validate()
                 .map_err(|error| CustomError::MemoryValidation(error.to_string()))?;
             let (object_id, object_type) = object_identity(object);
-            object_triples.push((
-                graph_uri(object_type, object_id),
-                rdf_triples_for_object(object),
+            let owner_graph_uri = graph_uri(object_type, object_id);
+            replacements.push((
+                owner_graph_uri.clone(),
+                quads_for_triples(&owner_graph_uri, &rdf_triples_for_object(object))?,
             ));
         }
 
-        let mut link_triples = Vec::new();
         for link in links {
             link.validate()
                 .map_err(|error| CustomError::MemoryValidation(error.to_string()))?;
-            link_triples.push((
-                graph_uri(ObjectType::MemoryLink, link.id),
-                rdf_triples_for_link(link),
+            let owner_graph_uri = graph_uri(ObjectType::MemoryLink, link.id);
+            replacements.push((
+                owner_graph_uri.clone(),
+                quads_for_triples(&owner_graph_uri, &rdf_triples_for_link(link))?,
             ));
         }
 
-        for (owner_graph_uri, triples) in object_triples.iter().chain(link_triples.iter()) {
-            self.replace_triples(owner_graph_uri.clone(), triples)?;
-        }
+        self.replace_triples_batch(replacements)?;
 
         let mut stored_objects = lock(&self.objects)?;
         for object in objects {
@@ -412,6 +431,87 @@ mod tests {
                 .await
                 .unwrap(),
             vec![MemoryObject::Episode(updated_episode)]
+        );
+    }
+
+    #[tokio::test]
+    async fn oxigraph_upsert_objects_and_links_replaces_rdf_and_caches_atomically() {
+        let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
+        let fixtures = representative_fixtures();
+        let mut updated_memory = fixtures.derived_reflection.clone();
+        updated_memory.text = "Updated reflection text replaces stale RDF.".to_owned();
+        let mut updated_link = fixtures.soft_thread_link.clone();
+        updated_link.to_id = fixtures.episode.id;
+        updated_link.to_type = ObjectType::Episode;
+        updated_link.relation = RelationType::DerivedFrom;
+
+        let memory_subject = graph_uri(ObjectType::DerivedMemory, fixtures.derived_reflection.id);
+        let stale_text = RdfTriple {
+            subject: memory_subject.clone(),
+            predicate: vocab::TEXT.to_owned(),
+            object: RdfObject::Literal(fixtures.derived_reflection.text.clone()),
+        };
+        let replacement_text = RdfTriple {
+            subject: memory_subject,
+            predicate: vocab::TEXT.to_owned(),
+            object: RdfObject::Literal(updated_memory.text.clone()),
+        };
+        let stale_relation = RdfTriple {
+            subject: graph_uri(
+                fixtures.soft_thread_link.from_type,
+                fixtures.soft_thread_link.from_id,
+            ),
+            predicate: vocab::relation_predicate("part_of_thread"),
+            object: RdfObject::Resource(graph_uri(
+                fixtures.soft_thread_link.to_type,
+                fixtures.soft_thread_link.to_id,
+            )),
+        };
+        let replacement_relation = RdfTriple {
+            subject: graph_uri(updated_link.from_type, updated_link.from_id),
+            predicate: vocab::relation_predicate("derived_from"),
+            object: RdfObject::Resource(graph_uri(updated_link.to_type, updated_link.to_id)),
+        };
+
+        store.upsert_objects(&fixtures.objects()).await.unwrap();
+        store
+            .upsert_links(std::slice::from_ref(&fixtures.soft_thread_link))
+            .await
+            .unwrap();
+        assert!(store.contains_triple(&stale_text).unwrap());
+        assert!(store.contains_triple(&stale_relation).unwrap());
+
+        store
+            .upsert_objects_and_links(
+                &[MemoryObject::DerivedMemory(updated_memory.clone())],
+                &[updated_link.clone()],
+            )
+            .await
+            .unwrap();
+
+        assert!(!store.contains_triple(&stale_text).unwrap());
+        assert!(!store.contains_triple(&stale_relation).unwrap());
+        assert!(store.contains_triple(&replacement_text).unwrap());
+        assert!(store.contains_triple(&replacement_relation).unwrap());
+        assert_eq!(
+            store
+                .query_objects(&GraphObjectQuery::by_ids(vec![updated_memory.id]))
+                .await
+                .unwrap(),
+            vec![MemoryObject::DerivedMemory(updated_memory)]
+        );
+        assert_eq!(
+            store
+                .expand_bounded(&GraphExpansionQuery::new(
+                    updated_link.from_id,
+                    updated_link.from_type,
+                    1,
+                    4,
+                ))
+                .await
+                .unwrap()
+                .links,
+            vec![updated_link]
         );
     }
 

--- a/src/internal/infrastructures/graph/oxigraph_authority_store.rs
+++ b/src/internal/infrastructures/graph/oxigraph_authority_store.rs
@@ -11,10 +11,11 @@ use async_trait::async_trait;
 use oxigraph::model::{GraphName, Literal, NamedNode, NamedOrBlankNode, Quad, Term};
 use oxigraph::store::Store;
 
-use crate::api::types::{graph_uri, MemoryId, MemoryLink, MemoryObject, ObjectType};
+use crate::api::types::{graph_uri, DerivedMemory, MemoryId, MemoryLink, MemoryObject, ObjectType};
 use crate::errors::CustomError;
 use crate::internal::repositories::{
-    bounded_expansion, GraphAuthorityStore, GraphExpansion, GraphExpansionQuery, GraphObjectQuery,
+    bounded_expansion, derived_memories_by_provenance, GraphAuthorityStore,
+    GraphDerivedMemoryProvenanceQuery, GraphExpansion, GraphExpansionQuery, GraphObjectQuery,
 };
 
 use super::rdf_mapping::{rdf_triples_for_link, rdf_triples_for_object, RdfObject, RdfTriple};
@@ -181,6 +182,19 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
         Ok(objects)
     }
 
+    async fn query_derived_memories_by_provenance(
+        &self,
+        query: &GraphDerivedMemoryProvenanceQuery,
+    ) -> Result<Vec<DerivedMemory>, CustomError> {
+        let objects = lock(&self.objects)?.clone();
+        let links = lock(&self.links)?.clone();
+        Ok(derived_memories_by_provenance(
+            query,
+            objects.into_values(),
+            links.into_values(),
+        ))
+    }
+
     async fn expand_bounded(
         &self,
         query: &GraphExpansionQuery,
@@ -261,7 +275,8 @@ mod tests {
     use super::super::vocabulary as vocab;
     use super::*;
     use crate::api::types::{
-        graph_uri, ContextPackSection, LifecycleFilterAction, RelationType, RetrievalContext,
+        graph_uri, ContextPackSection, LifecycleFilterAction, LifecycleFilterReason, RelationType,
+        RetentionState, RetrievalContext, ThreadStatus,
     };
     use crate::internal::models::vector::{
         EmbeddingInput, VectorCandidateMatch, VectorCandidateSearch, VectorRecordEmbedding,
@@ -271,8 +286,9 @@ mod tests {
         high_fanout_graph_fixture, representative_fixtures,
     };
     use crate::internal::repositories::{
-        GraphExpansionBoundedFailureReason, GraphExpansionFailurePolicy,
-        GraphExpansionFilteredReason, GraphExpansionLifecyclePolicy, GraphObjectRef,
+        GraphDerivedMemoryProvenanceQuery, GraphExpansionBoundedFailureReason,
+        GraphExpansionFailurePolicy, GraphExpansionFilteredReason, GraphExpansionLifecyclePolicy,
+        GraphObjectRef,
     };
     use crate::internal::repositories::{MemoryEmbedder, RetrievePipeline, VectorCandidateStore};
 
@@ -556,6 +572,269 @@ mod tests {
             timed_out.bounded_failure.unwrap().reason,
             GraphExpansionBoundedFailureReason::Timeout
         );
+    }
+
+    #[tokio::test]
+    async fn oxigraph_lifecycle_upserts_support_supersession_and_provenance_discovery() {
+        let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
+        let fixtures = representative_fixtures();
+        let superseded_memory = fixtures.user_preference.clone();
+        let mut non_current_memory = fixtures.open_loop.clone();
+        let mut replacement = fixtures.correction.clone();
+        let mut archived_thread = fixtures.soft_thread.clone();
+        non_current_memory.is_current = false;
+        replacement.supersedes = vec![superseded_memory.id];
+        archived_thread.status = ThreadStatus::Archived;
+        let supersedes_link = crate::api::types::MemoryLink {
+            id: MemoryId::from_u128(0x550e_8400_e29b_41d4_a716_4466_5600_0001),
+            object_type: ObjectType::MemoryLink,
+            from_id: replacement.id,
+            from_type: ObjectType::DerivedMemory,
+            to_id: superseded_memory.id,
+            to_type: ObjectType::DerivedMemory,
+            relation: RelationType::Supersedes,
+            confidence: 1.0,
+            rationale: Some("Replacement supersedes historical derived memory.".to_owned()),
+            created_at: replacement.created_at,
+            schema_version: replacement.schema_version.clone(),
+        };
+
+        store
+            .upsert_objects(&[
+                MemoryObject::Episode(fixtures.episode.clone()),
+                MemoryObject::Observation(fixtures.salient_observation.clone()),
+                MemoryObject::MemoryThread(archived_thread.clone()),
+                MemoryObject::DerivedMemory(fixtures.derived_reflection.clone()),
+                MemoryObject::DerivedMemory(superseded_memory.clone()),
+                MemoryObject::DerivedMemory(non_current_memory.clone()),
+                MemoryObject::DerivedMemory(replacement.clone()),
+            ])
+            .await
+            .unwrap();
+        store
+            .upsert_links(&[fixtures.soft_thread_link.clone(), supersedes_link.clone()])
+            .await
+            .unwrap();
+
+        let default_matches = store
+            .query_derived_memories_by_provenance(
+                &GraphDerivedMemoryProvenanceQuery::by_sources(
+                    vec![fixtures.episode.id],
+                    vec![fixtures.salient_observation.id],
+                )
+                .with_limit(10),
+            )
+            .await
+            .unwrap();
+        assert!(default_matches
+            .iter()
+            .any(|memory| memory.id == fixtures.derived_reflection.id));
+        assert!(default_matches
+            .iter()
+            .any(|memory| memory.id == replacement.id));
+        assert!(!default_matches
+            .iter()
+            .any(|memory| memory.id == superseded_memory.id));
+        assert!(!default_matches
+            .iter()
+            .any(|memory| memory.id == non_current_memory.id));
+
+        let historical_matches = store
+            .query_derived_memories_by_provenance(
+                &GraphDerivedMemoryProvenanceQuery::by_sources(
+                    vec![fixtures.episode.id],
+                    vec![fixtures.salient_observation.id],
+                )
+                .with_lifecycle_policy(GraphExpansionLifecyclePolicy {
+                    include_non_current: true,
+                    include_superseded: true,
+                    ..GraphExpansionLifecyclePolicy::default()
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(historical_matches
+            .iter()
+            .any(|memory| memory.id == superseded_memory.id));
+        assert!(historical_matches
+            .iter()
+            .any(|memory| memory.id == non_current_memory.id));
+
+        let default_expansion = store
+            .expand_bounded(
+                &GraphExpansionQuery::new(replacement.id, ObjectType::DerivedMemory, 1, 5)
+                    .with_allowed_relation_types(vec![RelationType::Supersedes]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            default_expansion.objects,
+            vec![MemoryObject::DerivedMemory(replacement.clone())]
+        );
+        assert!(default_expansion.links.is_empty());
+        assert!(default_expansion.filtered_nodes.iter().any(|filtered| {
+            filtered.object_ref
+                == GraphObjectRef::new(superseded_memory.id, ObjectType::DerivedMemory)
+                && filtered.reason == GraphExpansionFilteredReason::Superseded
+        }));
+
+        let historical_expansion = store
+            .expand_bounded(
+                &GraphExpansionQuery::new(replacement.id, ObjectType::DerivedMemory, 1, 5)
+                    .with_allowed_relation_types(vec![RelationType::Supersedes])
+                    .with_lifecycle_policy(GraphExpansionLifecyclePolicy {
+                        include_superseded: true,
+                        ..GraphExpansionLifecyclePolicy::default()
+                    }),
+            )
+            .await
+            .unwrap();
+        assert!(historical_expansion
+            .objects
+            .contains(&MemoryObject::DerivedMemory(superseded_memory.clone())));
+        assert_eq!(historical_expansion.links, vec![supersedes_link]);
+        assert_eq!(replacement.supersedes, vec![superseded_memory.id]);
+
+        let thread_expansion = store
+            .expand_bounded(
+                &GraphExpansionQuery::new(
+                    fixtures.salient_observation.id,
+                    ObjectType::Observation,
+                    1,
+                    5,
+                )
+                .with_allowed_relation_types(vec![RelationType::PartOfThread]),
+            )
+            .await
+            .unwrap();
+        assert!(thread_expansion.filtered_nodes.iter().any(|filtered| {
+            filtered.object_ref == GraphObjectRef::new(archived_thread.id, ObjectType::MemoryThread)
+                && filtered.reason == GraphExpansionFilteredReason::Archived
+        }));
+    }
+
+    #[tokio::test]
+    async fn oxigraph_retrieval_after_lifecycle_mutation_excludes_stale_records_by_default() {
+        let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
+        let fixtures = representative_fixtures();
+        let mut superseded_memory = fixtures.user_preference.clone();
+        let mut suppressed_memory = fixtures.suppressed_seed.clone();
+        let mut non_current_memory = fixtures.open_loop.clone();
+        let mut replacement = fixtures.correction.clone();
+        let mut archived_thread = fixtures.soft_thread.clone();
+        superseded_memory.retention_state = RetentionState::Active;
+        superseded_memory.is_current = true;
+        suppressed_memory.retention_state = RetentionState::Suppressed;
+        non_current_memory.is_current = false;
+        replacement.supersedes = vec![superseded_memory.id];
+        archived_thread.status = ThreadStatus::Archived;
+        let supersedes_link = crate::api::types::MemoryLink {
+            id: MemoryId::from_u128(0x550e_8400_e29b_41d4_a716_4466_5600_0002),
+            object_type: ObjectType::MemoryLink,
+            from_id: replacement.id,
+            from_type: ObjectType::DerivedMemory,
+            to_id: superseded_memory.id,
+            to_type: ObjectType::DerivedMemory,
+            relation: RelationType::Supersedes,
+            confidence: 1.0,
+            rationale: Some("Replacement supersedes stale retrieval candidate.".to_owned()),
+            created_at: replacement.created_at,
+            schema_version: replacement.schema_version.clone(),
+        };
+        store
+            .upsert_objects(&[
+                MemoryObject::Episode(fixtures.episode.clone()),
+                MemoryObject::Observation(fixtures.salient_observation.clone()),
+                MemoryObject::MemoryThread(archived_thread.clone()),
+                MemoryObject::DerivedMemory(superseded_memory.clone()),
+                MemoryObject::DerivedMemory(suppressed_memory.clone()),
+                MemoryObject::DerivedMemory(non_current_memory.clone()),
+                MemoryObject::DerivedMemory(replacement.clone()),
+            ])
+            .await
+            .unwrap();
+        store
+            .upsert_links(&[fixtures.soft_thread_link.clone(), supersedes_link])
+            .await
+            .unwrap();
+
+        let vector = FixedVectorStore::new(vec![
+            VectorCandidateMatch::new(
+                replacement.id,
+                ObjectType::DerivedMemory,
+                VectorSurface::DerivedText,
+                0.99,
+            ),
+            VectorCandidateMatch::new(
+                superseded_memory.id,
+                ObjectType::DerivedMemory,
+                VectorSurface::DerivedText,
+                0.98,
+            ),
+            VectorCandidateMatch::new(
+                suppressed_memory.id,
+                ObjectType::DerivedMemory,
+                VectorSurface::DerivedText,
+                0.97,
+            ),
+            VectorCandidateMatch::new(
+                non_current_memory.id,
+                ObjectType::DerivedMemory,
+                VectorSurface::DerivedText,
+                0.96,
+            ),
+            VectorCandidateMatch::new(
+                archived_thread.id,
+                ObjectType::MemoryThread,
+                VectorSurface::Summary,
+                0.95,
+            ),
+        ]);
+        let embedder = FixedEmbedder::new(vec![1.0, 0.0]);
+        let pipeline = RetrievePipeline::new(&store, &vector, &embedder);
+        let outcome = pipeline
+            .retrieve(RetrievalContext::new("lifecycle graph truth").with_trace())
+            .await
+            .unwrap();
+        let trace = outcome.trace.as_ref().unwrap();
+
+        assert!(outcome
+            .pack
+            .derived_memories
+            .iter()
+            .any(|included| included.memory.id == replacement.id));
+        assert!(!outcome
+            .pack
+            .preferences
+            .iter()
+            .any(|included| included.memory.id == superseded_memory.id));
+        assert!(!outcome
+            .pack
+            .preferences
+            .iter()
+            .any(|included| included.memory.id == suppressed_memory.id));
+        assert!(!outcome
+            .pack
+            .open_loops
+            .iter()
+            .any(|included| included.memory.id == non_current_memory.id));
+        assert!(outcome.pack.active_threads.is_empty());
+        assert!(trace.lifecycle_filter_decisions.iter().any(|decision| {
+            decision.object.id == superseded_memory.id
+                && decision.reason == LifecycleFilterReason::SupersededOmitted
+        }));
+        assert!(trace.lifecycle_filter_decisions.iter().any(|decision| {
+            decision.object.id == suppressed_memory.id
+                && decision.reason == LifecycleFilterReason::SuppressedOmitted
+        }));
+        assert!(trace.lifecycle_filter_decisions.iter().any(|decision| {
+            decision.object.id == non_current_memory.id
+                && decision.reason == LifecycleFilterReason::NonCurrentOmitted
+        }));
+        assert!(trace.lifecycle_filter_decisions.iter().any(|decision| {
+            decision.object.id == archived_thread.id
+                && decision.reason == LifecycleFilterReason::ArchivedOmitted
+        }));
     }
 
     #[tokio::test]

--- a/src/internal/infrastructures/graph/oxigraph_authority_store.rs
+++ b/src/internal/infrastructures/graph/oxigraph_authority_store.rs
@@ -158,6 +158,49 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
         Ok(())
     }
 
+    async fn upsert_objects_and_links(
+        &self,
+        objects: &[MemoryObject],
+        links: &[MemoryLink],
+    ) -> Result<(), CustomError> {
+        let mut object_triples = Vec::new();
+        for object in objects {
+            object
+                .validate()
+                .map_err(|error| CustomError::MemoryValidation(error.to_string()))?;
+            let (object_id, object_type) = object_identity(object);
+            object_triples.push((
+                graph_uri(object_type, object_id),
+                rdf_triples_for_object(object),
+            ));
+        }
+
+        let mut link_triples = Vec::new();
+        for link in links {
+            link.validate()
+                .map_err(|error| CustomError::MemoryValidation(error.to_string()))?;
+            link_triples.push((
+                graph_uri(ObjectType::MemoryLink, link.id),
+                rdf_triples_for_link(link),
+            ));
+        }
+
+        for (owner_graph_uri, triples) in object_triples.iter().chain(link_triples.iter()) {
+            self.replace_triples(owner_graph_uri.clone(), triples)?;
+        }
+
+        let mut stored_objects = lock(&self.objects)?;
+        for object in objects {
+            stored_objects.insert(object_identity(object), object.clone());
+        }
+        let mut stored_links = lock(&self.links)?;
+        for link in links {
+            stored_links.insert(link.id, link.clone());
+        }
+
+        Ok(())
+    }
+
     async fn query_objects(
         &self,
         query: &GraphObjectQuery,

--- a/src/internal/infrastructures/graph/oxigraph_authority_store.rs
+++ b/src/internal/infrastructures/graph/oxigraph_authority_store.rs
@@ -14,8 +14,9 @@ use oxigraph::store::Store;
 use crate::api::types::{graph_uri, DerivedMemory, MemoryId, MemoryLink, MemoryObject, ObjectType};
 use crate::errors::CustomError;
 use crate::internal::repositories::{
-    bounded_expansion, derived_memories_by_provenance, GraphAuthorityStore,
-    GraphDerivedMemoryProvenanceQuery, GraphExpansion, GraphExpansionQuery, GraphObjectQuery,
+    bounded_expansion, derived_memories_by_provenance, derived_memories_by_thread,
+    GraphAuthorityStore, GraphDerivedMemoryProvenanceQuery, GraphDerivedMemoryThreadQuery,
+    GraphExpansion, GraphExpansionQuery, GraphObjectQuery,
 };
 
 use super::rdf_mapping::{rdf_triples_for_link, rdf_triples_for_object, RdfObject, RdfTriple};
@@ -189,6 +190,19 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
         let objects = lock(&self.objects)?.clone();
         let links = lock(&self.links)?.clone();
         Ok(derived_memories_by_provenance(
+            query,
+            objects.into_values(),
+            links.into_values(),
+        ))
+    }
+
+    async fn query_derived_memories_by_thread(
+        &self,
+        query: &GraphDerivedMemoryThreadQuery,
+    ) -> Result<Vec<DerivedMemory>, CustomError> {
+        let objects = lock(&self.objects)?.clone();
+        let links = lock(&self.links)?.clone();
+        Ok(derived_memories_by_thread(
             query,
             objects.into_values(),
             links.into_values(),

--- a/src/internal/repositories.rs
+++ b/src/internal/repositories.rs
@@ -1,3 +1,4 @@
+mod correction_forget_pipeline;
 mod embedder;
 mod graph_authority_store;
 mod link_pipeline;
@@ -15,12 +16,18 @@ mod vector_memory_repository;
 #[allow(unused_imports)]
 pub(crate) use embedder::MemoryEmbedder;
 
+// Transitional contract surface: remove this allow once facade wiring
+// consumes lifecycle mutation pipelines directly, or prune unused outcome types.
+#[allow(unused_imports)]
+pub(crate) use correction_forget_pipeline::{CorrectionForgetPipeline, LifecyclePipelineOutcome};
+
 // Transitional contract surface: remove this allow once adapter or
 // pipeline code consumes the graph authority contract directly, or prune unused
 // exports.
 #[allow(unused_imports)]
 pub(crate) use graph_authority_store::{
-    bounded_expansion, bounded_expansion_node_set, GraphAuthorityStore, GraphExpansion,
+    bounded_expansion, bounded_expansion_node_set, derived_memories_by_provenance,
+    GraphAuthorityStore, GraphDerivedMemoryProvenanceQuery, GraphExpansion,
     GraphExpansionBoundedFailure, GraphExpansionBoundedFailureReason, GraphExpansionFailurePolicy,
     GraphExpansionFilteredNode, GraphExpansionFilteredReason, GraphExpansionLifecyclePolicy,
     GraphExpansionQuery, GraphExpansionRelation, GraphObjectQuery, GraphObjectRef,

--- a/src/internal/repositories.rs
+++ b/src/internal/repositories.rs
@@ -27,10 +27,11 @@ pub(crate) use correction_forget_pipeline::{CorrectionForgetPipeline, LifecycleP
 #[allow(unused_imports)]
 pub(crate) use graph_authority_store::{
     bounded_expansion, bounded_expansion_node_set, derived_memories_by_provenance,
-    GraphAuthorityStore, GraphDerivedMemoryProvenanceQuery, GraphExpansion,
-    GraphExpansionBoundedFailure, GraphExpansionBoundedFailureReason, GraphExpansionFailurePolicy,
-    GraphExpansionFilteredNode, GraphExpansionFilteredReason, GraphExpansionLifecyclePolicy,
-    GraphExpansionQuery, GraphExpansionRelation, GraphObjectQuery, GraphObjectRef,
+    derived_memories_by_thread, GraphAuthorityStore, GraphDerivedMemoryProvenanceQuery,
+    GraphDerivedMemoryThreadQuery, GraphExpansion, GraphExpansionBoundedFailure,
+    GraphExpansionBoundedFailureReason, GraphExpansionFailurePolicy, GraphExpansionFilteredNode,
+    GraphExpansionFilteredReason, GraphExpansionLifecyclePolicy, GraphExpansionQuery,
+    GraphExpansionRelation, GraphObjectQuery, GraphObjectRef,
 };
 
 // Transitional contract surface: remove this allow once facade wiring

--- a/src/internal/repositories/correction_forget_pipeline.rs
+++ b/src/internal/repositories/correction_forget_pipeline.rs
@@ -104,7 +104,8 @@ where
                 }
                 CorrectionTarget::SourceObject { target } => {
                     requested_targets.push(source_correction_lifecycle_ref(target));
-                    self.ensure_source_object_exists(target).await?;
+                    self.ensure_source_object_matches_original_refs(target)
+                        .await?;
                     match target {
                         SourceObjectCorrectionTarget::Episode { id, .. } => {
                             push_unique(&mut source_episode_ids, *id)
@@ -453,12 +454,63 @@ where
             .ok_or_else(|| missing_object_error(object_ref.object_type, object_ref.object_id))
     }
 
-    async fn ensure_source_object_exists(
+    async fn ensure_source_object_matches_original_refs(
         &self,
         target: &SourceObjectCorrectionTarget,
     ) -> Result<(), CustomError> {
-        let object_ref = GraphObjectRef::new(target.id(), target.object_type());
-        self.fetch_one(object_ref).await.map(|_| ())
+        let has_raw_ref =
+            source_target_original_raw_ref(target).is_some_and(|value| !value.trim().is_empty());
+        let has_source_ref =
+            source_target_original_source_ref(target).is_some_and(|value| !value.trim().is_empty());
+        if !has_raw_ref && !has_source_ref {
+            return Err(validation_error(
+                "source-object correction requires an original raw or source reference",
+            ));
+        }
+
+        match target {
+            SourceObjectCorrectionTarget::Episode {
+                id,
+                original_raw_ref,
+                original_source_ref,
+            } => {
+                let episode = self.fetch_episode(*id).await?;
+                validate_optional_original_ref(
+                    "episode original raw reference",
+                    original_raw_ref.as_deref(),
+                    episode.raw_ref.as_deref(),
+                )?;
+                validate_optional_original_ref(
+                    "episode original source reference",
+                    original_source_ref.as_deref(),
+                    episode.source_conversation_id.as_deref(),
+                )
+            }
+            SourceObjectCorrectionTarget::Observation {
+                id,
+                original_raw_ref,
+                original_source_ref,
+            } => {
+                let observation = self.fetch_observation(*id).await?;
+                validate_optional_original_ref(
+                    "observation original raw reference",
+                    original_raw_ref.as_deref(),
+                    observation.raw_ref.as_deref(),
+                )?;
+                if original_source_ref
+                    .as_deref()
+                    .is_some_and(|value| !value.trim().is_empty())
+                {
+                    let episode = self.fetch_episode(observation.episode_id).await?;
+                    validate_optional_original_ref(
+                        "observation original source reference",
+                        original_source_ref.as_deref(),
+                        episode.source_conversation_id.as_deref(),
+                    )?;
+                }
+                Ok(())
+            }
+        }
     }
 
     async fn query_current_derived_by_provenance(
@@ -840,6 +892,48 @@ fn source_correction_lifecycle_ref(target: &SourceObjectCorrectionTarget) -> Lif
     }
 }
 
+fn source_target_original_raw_ref(target: &SourceObjectCorrectionTarget) -> Option<&str> {
+    match target {
+        SourceObjectCorrectionTarget::Episode {
+            original_raw_ref, ..
+        }
+        | SourceObjectCorrectionTarget::Observation {
+            original_raw_ref, ..
+        } => original_raw_ref.as_deref(),
+    }
+}
+
+fn source_target_original_source_ref(target: &SourceObjectCorrectionTarget) -> Option<&str> {
+    match target {
+        SourceObjectCorrectionTarget::Episode {
+            original_source_ref,
+            ..
+        }
+        | SourceObjectCorrectionTarget::Observation {
+            original_source_ref,
+            ..
+        } => original_source_ref.as_deref(),
+    }
+}
+
+fn validate_optional_original_ref(
+    label: &str,
+    provided: Option<&str>,
+    stored: Option<&str>,
+) -> Result<(), CustomError> {
+    let Some(provided) = provided.filter(|value| !value.trim().is_empty()) else {
+        return Ok(());
+    };
+
+    if stored == Some(provided) {
+        Ok(())
+    } else {
+        Err(validation_error(format!(
+            "{label} does not match current graph object"
+        )))
+    }
+}
+
 fn absorb_sources(
     episode_ids: &mut Vec<MemoryId>,
     observation_ids: &mut Vec<MemoryId>,
@@ -973,7 +1067,8 @@ mod tests {
     use std::sync::{Arc, Mutex, MutexGuard};
 
     use crate::api::types::{
-        ExternalSourceReference, RetrievalContext, StaleCandidateReason, VectorCandidateTrace,
+        Episode, ExternalSourceReference, Modality, Observation, RetrievalContext,
+        StaleCandidateReason, VectorCandidateTrace,
     };
     use crate::internal::models::vector::{
         EmbeddingInput, VectorCandidateMatch, VectorCandidateSearch,
@@ -1249,6 +1344,94 @@ mod tests {
             evidence.superseded_memory_id == fixtures.user_preference.id
                 && evidence.superseded_by_memory_id == replacement_id
         }));
+    }
+
+    #[tokio::test]
+    async fn source_object_correction_requires_original_refs_before_writes() {
+        let ids = fixed_ids();
+        let graph = RecordingGraphStore::new(vec![MemoryObject::Episode(source_episode(&ids))]);
+        let vector = RecordingVectorStore::default();
+        let embedder = RecordingEmbedder::default();
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+        let mut draft = CorrectMemoryDraft::new(
+            CorrectionTarget::source_object(SourceObjectCorrectionTarget::Episode {
+                id: ids.episode,
+                original_raw_ref: None,
+                original_source_ref: None,
+            }),
+            "Correct source episode.",
+        );
+        draft.correction_origin = SourceProvenanceReference::episode(ids.episode);
+
+        let error = pipeline.correct(draft).await.unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("original raw or source reference"));
+        assert!(graph.calls().is_empty());
+        assert!(vector.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn source_object_correction_rejects_mismatched_episode_refs_before_writes() {
+        let ids = fixed_ids();
+        let graph = RecordingGraphStore::new(vec![MemoryObject::Episode(source_episode(&ids))]);
+        let vector = RecordingVectorStore::default();
+        let embedder = RecordingEmbedder::default();
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+        let mut draft = CorrectMemoryDraft::new(
+            CorrectionTarget::source_object(SourceObjectCorrectionTarget::Episode {
+                id: ids.episode,
+                original_raw_ref: Some("raw://wrong".to_owned()),
+                original_source_ref: Some("conversation://original".to_owned()),
+            }),
+            "Correct source episode.",
+        );
+        draft.correction_origin = SourceProvenanceReference::episode(ids.episode);
+
+        let error = pipeline.correct(draft).await.unwrap_err();
+
+        assert!(error.to_string().contains("episode original raw reference"));
+        assert_eq!(
+            graph.calls(),
+            vec![StoreCall::GraphQuery(vec![ids.episode])]
+        );
+        assert!(vector.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn source_object_correction_rejects_mismatched_observation_source_ref_before_writes() {
+        let ids = fixed_ids();
+        let graph = RecordingGraphStore::new(vec![
+            MemoryObject::Episode(source_episode(&ids)),
+            MemoryObject::Observation(source_observation(&ids)),
+        ]);
+        let vector = RecordingVectorStore::default();
+        let embedder = RecordingEmbedder::default();
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+        let mut draft = CorrectMemoryDraft::new(
+            CorrectionTarget::source_object(SourceObjectCorrectionTarget::Observation {
+                id: ids.observation,
+                original_raw_ref: Some("raw://original/observation".to_owned()),
+                original_source_ref: Some("conversation://wrong".to_owned()),
+            }),
+            "Correct source observation.",
+        );
+        draft.correction_origin = SourceProvenanceReference::observation(ids.observation);
+
+        let error = pipeline.correct(draft).await.unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("observation original source reference"));
+        assert_eq!(
+            graph.calls(),
+            vec![
+                StoreCall::GraphQuery(vec![ids.observation]),
+                StoreCall::GraphQuery(vec![ids.episode]),
+            ]
+        );
+        assert!(vector.calls().is_empty());
     }
 
     #[tokio::test]
@@ -1646,6 +1829,41 @@ mod tests {
             retention_state: RetentionState::Active,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+        }
+    }
+
+    fn source_episode(ids: &FixedIds) -> Episode {
+        Episode {
+            id: ids.episode,
+            object_type: ObjectType::Episode,
+            modality: Modality::Chat,
+            source_conversation_id: Some("conversation://original".to_owned()),
+            started_at: None,
+            ended_at: None,
+            participant_entity_ids: Vec::new(),
+            summary: "Original source episode.".to_owned(),
+            raw_ref: Some("raw://original/episode".to_owned()),
+            salience_score: 0.8,
+            retention_state: RetentionState::Active,
+            created_at: Utc::now(),
+            schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+        }
+    }
+
+    fn source_observation(ids: &FixedIds) -> Observation {
+        Observation {
+            id: ids.observation,
+            object_type: ObjectType::Observation,
+            episode_id: ids.episode,
+            speaker_entity_id: None,
+            observed_at: None,
+            modality: Modality::Chat,
+            text: "Original source observation.".to_owned(),
+            raw_ref: Some("raw://original/observation".to_owned()),
+            salience_score: 0.8,
+            retention_state: RetentionState::Active,
+            created_at: Utc::now(),
             schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
         }
     }

--- a/src/internal/repositories/correction_forget_pipeline.rs
+++ b/src/internal/repositories/correction_forget_pipeline.rs
@@ -233,18 +233,24 @@ where
             match target {
                 LifecycleTargetRef::DerivedMemory(id) => {
                     let memory = self.fetch_derived_memory(*id).await?;
-                    let suppressed = suppress_derived_memory(memory, draft.target_retention_state);
-                    push_object_unique(&mut graph_objects, MemoryObject::DerivedMemory(suppressed));
-                    push_ref_unique(&mut vector_delete_refs, target.as_memory_object_ref());
+                    if draft.lifecycle_policy.suppression.suppress_target {
+                        let suppressed =
+                            suppress_derived_memory(memory, draft.target_retention_state);
+                        push_object_unique(
+                            &mut graph_objects,
+                            MemoryObject::DerivedMemory(suppressed),
+                        );
+                        push_ref_unique(&mut vector_delete_refs, target.as_memory_object_ref());
+                    }
                 }
                 LifecycleTargetRef::Episode(id) => {
                     let episode = self.fetch_episode(*id).await?;
-                    let mut suppressed = episode;
                     if draft.lifecycle_policy.suppression.suppress_target {
+                        let mut suppressed = episode;
                         suppressed.retention_state = draft.target_retention_state;
+                        push_object_unique(&mut graph_objects, MemoryObject::Episode(suppressed));
+                        push_ref_unique(&mut vector_delete_refs, target.as_memory_object_ref());
                     }
-                    push_object_unique(&mut graph_objects, MemoryObject::Episode(suppressed));
-                    push_ref_unique(&mut vector_delete_refs, target.as_memory_object_ref());
                     if draft.cascade_policy.apply_to_derived_from_target
                         && draft
                             .lifecycle_policy
@@ -263,12 +269,15 @@ where
                 }
                 LifecycleTargetRef::Observation(id) => {
                     let observation = self.fetch_observation(*id).await?;
-                    let mut suppressed = observation;
                     if draft.lifecycle_policy.suppression.suppress_target {
+                        let mut suppressed = observation;
                         suppressed.retention_state = draft.target_retention_state;
+                        push_object_unique(
+                            &mut graph_objects,
+                            MemoryObject::Observation(suppressed),
+                        );
+                        push_ref_unique(&mut vector_delete_refs, target.as_memory_object_ref());
                     }
-                    push_object_unique(&mut graph_objects, MemoryObject::Observation(suppressed));
-                    push_ref_unique(&mut vector_delete_refs, target.as_memory_object_ref());
                     if draft.cascade_policy.apply_to_derived_from_target
                         && draft
                             .lifecycle_policy
@@ -287,13 +296,16 @@ where
                 }
                 LifecycleTargetRef::MemoryThread(id) => {
                     let thread = self.fetch_thread(*id).await?;
-                    let mut archived = thread;
                     if draft.lifecycle_policy.archive.archive_thread {
+                        let mut archived = thread;
                         archived.status =
                             draft.target_thread_status.unwrap_or(ThreadStatus::Archived);
+                        push_object_unique(
+                            &mut graph_objects,
+                            MemoryObject::MemoryThread(archived),
+                        );
+                        push_ref_unique(&mut vector_delete_refs, target.as_memory_object_ref());
                     }
-                    push_object_unique(&mut graph_objects, MemoryObject::MemoryThread(archived));
-                    push_ref_unique(&mut vector_delete_refs, target.as_memory_object_ref());
                     if draft
                         .lifecycle_policy
                         .archive
@@ -624,6 +636,21 @@ fn validate_correction_request(draft: &CorrectMemoryDraft) -> Result<(), CustomE
     }
     if !draft.correction_origin.has_reference() {
         return Err(validation_error("correction origin provenance is required"));
+    }
+    if !draft.lifecycle_policy.retain_original_source_objects {
+        return Err(validation_error(
+            "correction cannot rewrite or remove original source objects in this lifecycle chunk",
+        ));
+    }
+    if !draft.cascade_policy.require_original_source_match {
+        return Err(validation_error(
+            "correction cascade requires original source provenance matching in this lifecycle chunk",
+        ));
+    }
+    if draft.cascade_policy.cascade_to_threads {
+        return Err(validation_error(
+            "correction cascade to threads is not supported in this lifecycle chunk",
+        ));
     }
     for replacement in &draft.replacement_derived_memories {
         if replacement.text.trim().is_empty() {
@@ -1029,6 +1056,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unsupported_correction_policy_knobs_fail_before_writes() {
+        let ids = fixed_ids();
+        for mut draft in [
+            {
+                let mut draft = correction_draft(&ids);
+                draft.lifecycle_policy.retain_original_source_objects = false;
+                draft
+            },
+            {
+                let mut draft = correction_draft(&ids);
+                draft.cascade_policy.require_original_source_match = false;
+                draft
+            },
+            {
+                let mut draft = correction_draft(&ids);
+                draft.cascade_policy.cascade_to_threads = true;
+                draft
+            },
+        ] {
+            draft.rationale = format!("{} {}", draft.rationale, Uuid::new_v4());
+            let graph =
+                RecordingGraphStore::new(vec![MemoryObject::DerivedMemory(old_memory(&ids))]);
+            let vector = RecordingVectorStore::default();
+            let embedder = RecordingEmbedder::default();
+            let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+
+            let error = pipeline.correct(draft).await.unwrap_err();
+
+            assert!(error.to_string().contains("lifecycle chunk"));
+            assert!(graph.calls().is_empty());
+            assert!(vector.calls().is_empty());
+        }
+    }
+
+    #[tokio::test]
     async fn graph_failure_prevents_vector_maintenance() {
         let ids = fixed_ids();
         let graph = RecordingGraphStore::new(vec![MemoryObject::DerivedMemory(old_memory(&ids))])
@@ -1296,6 +1358,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn forget_policy_can_skip_source_suppression_without_vector_deleting_source() {
+        let fixtures = representative_fixtures();
+        let graph = FakeGraphAuthorityStore::new();
+        graph.upsert_objects(&fixtures.objects()).await.unwrap();
+        graph.upsert_links(&fixtures.links()).await.unwrap();
+        let vector = FakeVectorCandidateStore::new();
+        let embedder = DeterministicMemoryEmbedder::new(4);
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+        let mut draft = ForgetMemoryDraft::suppress(
+            LifecycleTargetRef::Episode(fixtures.episode.id),
+            "Do not hide source object.",
+        );
+        draft.lifecycle_policy.suppression.suppress_target = false;
+        draft
+            .lifecycle_policy
+            .suppression
+            .suppress_derived_from_target = false;
+
+        let outcome = pipeline.forget(draft).await.unwrap();
+
+        assert!(outcome.graph_mutated_object_ids.is_empty());
+        assert!(outcome.vector_maintained_object_ids.is_empty());
+        let objects = graph
+            .query_objects(&GraphObjectQuery::by_refs(vec![GraphObjectRef::new(
+                fixtures.episode.id,
+                ObjectType::Episode,
+            )]))
+            .await
+            .unwrap();
+        assert!(matches!(
+            &objects[0],
+            MemoryObject::Episode(episode)
+                if episode.retention_state == RetentionState::Active
+        ));
+    }
+
+    #[tokio::test]
     async fn forget_archives_memory_thread() {
         let fixtures = representative_fixtures();
         let graph = FakeGraphAuthorityStore::new();
@@ -1330,6 +1429,35 @@ mod tests {
             panic!("expected memory thread");
         };
         assert_eq!(thread.status, ThreadStatus::Archived);
+    }
+
+    #[tokio::test]
+    async fn forget_policy_can_skip_thread_archive_without_vector_deleting_thread() {
+        let fixtures = representative_fixtures();
+        let graph = FakeGraphAuthorityStore::new();
+        graph.upsert_objects(&fixtures.objects()).await.unwrap();
+        let vector = FakeVectorCandidateStore::new();
+        let embedder = DeterministicMemoryEmbedder::new(4);
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+        let mut draft =
+            ForgetMemoryDraft::archive_thread(fixtures.soft_thread.id, "Do not archive thread.");
+        draft.lifecycle_policy.archive.archive_thread = false;
+
+        let outcome = pipeline.forget(draft).await.unwrap();
+
+        assert!(outcome.graph_mutated_object_ids.is_empty());
+        assert!(outcome.vector_maintained_object_ids.is_empty());
+        let objects = graph
+            .query_objects(&GraphObjectQuery::by_refs(vec![GraphObjectRef::new(
+                fixtures.soft_thread.id,
+                ObjectType::MemoryThread,
+            )]))
+            .await
+            .unwrap();
+        assert!(matches!(
+            &objects[0],
+            MemoryObject::MemoryThread(thread) if thread.status == ThreadStatus::Active
+        ));
     }
 
     #[tokio::test]

--- a/src/internal/repositories/correction_forget_pipeline.rs
+++ b/src/internal/repositories/correction_forget_pipeline.rs
@@ -658,9 +658,7 @@ fn validate_correction_request(draft: &CorrectMemoryDraft) -> Result<(), CustomE
                 "replacement derived memory text must not be empty",
             ));
         }
-        if !replacement.correction_origin_provenance.has_reference()
-            && !draft.correction_origin.has_reference()
-        {
+        if !replacement.correction_origin_provenance.has_reference() {
             return Err(validation_error(
                 "replacement correction origin provenance is required",
             ));

--- a/src/internal/repositories/correction_forget_pipeline.rs
+++ b/src/internal/repositories/correction_forget_pipeline.rs
@@ -55,8 +55,9 @@ where
         validate_correction_request(&draft)?;
         let plan = self.correction_plan(draft).await?;
 
-        self.graph_store.upsert_objects(&plan.graph_objects).await?;
-        self.graph_store.upsert_links(&plan.graph_links).await?;
+        self.graph_store
+            .upsert_objects_and_links(&plan.graph_objects, &plan.graph_links)
+            .await?;
 
         let mut outcome = plan.outcome_after_graph_success();
         let vector_result = self
@@ -719,7 +720,22 @@ fn validate_correction_request(draft: &CorrectMemoryDraft) -> Result<(), CustomE
 fn validate_forget_request(draft: &ForgetMemoryDraft) -> Result<(), CustomError> {
     draft
         .validate()
-        .map_err(|error| validation_error(error_string(error)))
+        .map_err(|error| validation_error(error_string(error)))?;
+    if !draft
+        .lifecycle_policy
+        .suppression
+        .preserve_original_raw_refs
+    {
+        return Err(validation_error(
+            "forget cannot remove original raw/source references in this lifecycle chunk",
+        ));
+    }
+    if !draft.lifecycle_policy.archive.preserve_original_raw_refs {
+        return Err(validation_error(
+            "thread archive cannot remove original raw/source references in this lifecycle chunk",
+        ));
+    }
+    Ok(())
 }
 
 fn replacement_drafts_or_default(
@@ -1181,6 +1197,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unsupported_forget_policy_knobs_fail_before_writes() {
+        let ids = fixed_ids();
+        for mut draft in [
+            {
+                let mut draft = ForgetMemoryDraft::suppress(
+                    LifecycleTargetRef::DerivedMemory(ids.old),
+                    "Suppress without dropping refs.",
+                );
+                draft
+                    .lifecycle_policy
+                    .suppression
+                    .preserve_original_raw_refs = false;
+                draft
+            },
+            {
+                let mut draft =
+                    ForgetMemoryDraft::archive_thread(ids.thread, "Archive without dropping refs.");
+                draft.lifecycle_policy.archive.preserve_original_raw_refs = false;
+                draft
+            },
+        ] {
+            draft.rationale = format!("{} {}", draft.rationale, Uuid::new_v4());
+            let graph =
+                RecordingGraphStore::new(vec![MemoryObject::DerivedMemory(old_memory(&ids))]);
+            let vector = RecordingVectorStore::default();
+            let embedder = RecordingEmbedder::default();
+            let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+
+            let error = pipeline.forget(draft).await.unwrap_err();
+
+            assert!(error.to_string().contains("lifecycle chunk"));
+            assert!(graph.calls().is_empty());
+            assert!(vector.calls().is_empty());
+        }
+    }
+
+    #[tokio::test]
     async fn graph_failure_prevents_vector_maintenance() {
         let ids = fixed_ids();
         let graph = RecordingGraphStore::new(vec![MemoryObject::DerivedMemory(old_memory(&ids))])
@@ -1192,6 +1245,33 @@ mod tests {
         let error = pipeline.correct(correction_draft(&ids)).await.unwrap_err();
 
         assert!(error.to_string().contains("object write failed"));
+        assert!(vector.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn graph_link_failure_prevents_partial_object_mutation_and_vector_maintenance() {
+        let ids = fixed_ids();
+        let graph = RecordingGraphStore::new(vec![MemoryObject::DerivedMemory(old_memory(&ids))])
+            .fail_links();
+        let vector = RecordingVectorStore::default();
+        let embedder = RecordingEmbedder::default();
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+
+        let error = pipeline.correct(correction_draft(&ids)).await.unwrap_err();
+
+        assert!(error.to_string().contains("link write failed"));
+        assert_eq!(
+            graph.calls(),
+            vec![
+                StoreCall::GraphQuery(vec![ids.old]),
+                StoreCall::GraphObjects(vec![ids.old, ids.replacement]),
+                StoreCall::GraphLinks(vec![(ids.replacement, ids.old)]),
+            ]
+        );
+        assert_eq!(
+            graph.object_refs(),
+            vec![MemoryObjectRef::new(ObjectType::DerivedMemory, ids.old)]
+        );
         assert!(vector.calls().is_empty());
     }
 
@@ -1928,6 +2008,7 @@ mod tests {
         links: Mutex<Vec<MemoryLink>>,
         calls: Arc<Mutex<Vec<StoreCall>>>,
         fail_objects: bool,
+        fail_links: bool,
     }
 
     impl RecordingGraphStore {
@@ -1943,8 +2024,22 @@ mod tests {
             self
         }
 
+        fn fail_links(mut self) -> Self {
+            self.fail_links = true;
+            self
+        }
+
         fn calls(&self) -> Vec<StoreCall> {
             lock(&self.calls).clone()
+        }
+
+        fn object_refs(&self) -> Vec<MemoryObjectRef> {
+            let mut refs = lock(&self.objects)
+                .iter()
+                .map(memory_object_ref)
+                .collect::<Vec<_>>();
+            sort_refs(&mut refs);
+            refs
         }
     }
 
@@ -1976,6 +2071,42 @@ mod tests {
                     .map(|link| (link.from_id, link.to_id))
                     .collect(),
             ));
+            if self.fail_links {
+                return Err(CustomError::DatabaseError("link write failed".to_owned()));
+            }
+            lock(&self.links).extend_from_slice(links);
+            Ok(())
+        }
+
+        async fn upsert_objects_and_links(
+            &self,
+            objects: &[MemoryObject],
+            links: &[MemoryLink],
+        ) -> Result<(), CustomError> {
+            lock(&self.calls).push(StoreCall::GraphObjects(
+                objects
+                    .iter()
+                    .map(|object| memory_object_ref(object).id)
+                    .collect(),
+            ));
+            if self.fail_objects {
+                return Err(CustomError::DatabaseError("object write failed".to_owned()));
+            }
+            lock(&self.calls).push(StoreCall::GraphLinks(
+                links
+                    .iter()
+                    .map(|link| (link.from_id, link.to_id))
+                    .collect(),
+            ));
+            if self.fail_links {
+                return Err(CustomError::DatabaseError("link write failed".to_owned()));
+            }
+            let mut stored = lock(&self.objects);
+            for object in objects {
+                let object_ref = memory_object_ref(object);
+                stored.retain(|existing| memory_object_ref(existing) != object_ref);
+                stored.push(object.clone());
+            }
             lock(&self.links).extend_from_slice(links);
             Ok(())
         }

--- a/src/internal/repositories/correction_forget_pipeline.rs
+++ b/src/internal/repositories/correction_forget_pipeline.rs
@@ -15,8 +15,9 @@ use crate::internal::models::vector::{
     memory_object_vector_record, VectorRecord, VectorRecordEmbedding,
 };
 use crate::internal::repositories::{
-    GraphAuthorityStore, GraphDerivedMemoryProvenanceQuery, GraphExpansionLifecyclePolicy,
-    GraphObjectQuery, GraphObjectRef, MemoryEmbedder, VectorCandidateStore,
+    GraphAuthorityStore, GraphDerivedMemoryProvenanceQuery, GraphDerivedMemoryThreadQuery,
+    GraphExpansionLifecyclePolicy, GraphObjectQuery, GraphObjectRef, MemoryEmbedder,
+    VectorCandidateStore,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -372,30 +373,26 @@ where
         thread_id: MemoryId,
         target_retention_state: RetentionState,
     ) -> Result<(), CustomError> {
-        let objects = self
+        let matches = self
             .graph_store
-            .query_objects(&GraphObjectQuery::by_types(
-                vec![ObjectType::DerivedMemory],
-                None,
-            ))
+            .query_derived_memories_by_thread(
+                &GraphDerivedMemoryThreadQuery::by_threads(vec![thread_id])
+                    .with_lifecycle_policy(GraphExpansionLifecyclePolicy::default()),
+            )
             .await?;
-        for object in objects {
-            if let MemoryObject::DerivedMemory(memory) = object {
-                if memory.thread_ids.contains(&thread_id) {
-                    let id = memory.id;
-                    push_object_unique(
-                        graph_objects,
-                        MemoryObject::DerivedMemory(suppress_derived_memory(
-                            memory,
-                            target_retention_state,
-                        )),
-                    );
-                    push_ref_unique(
-                        vector_delete_refs,
-                        MemoryObjectRef::new(ObjectType::DerivedMemory, id),
-                    );
-                }
-            }
+        for memory in matches {
+            let id = memory.id;
+            push_object_unique(
+                graph_objects,
+                MemoryObject::DerivedMemory(suppress_derived_memory(
+                    memory,
+                    target_retention_state,
+                )),
+            );
+            push_ref_unique(
+                vector_delete_refs,
+                MemoryObjectRef::new(ObjectType::DerivedMemory, id),
+            );
         }
         Ok(())
     }
@@ -1459,6 +1456,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn forget_thread_cascade_uses_thread_membership_query() {
+        let ids = fixed_ids();
+        let mut thread = representative_fixtures().soft_thread;
+        thread.id = ids.thread;
+        let graph = RecordingGraphStore::new(vec![
+            MemoryObject::MemoryThread(thread),
+            MemoryObject::DerivedMemory(old_memory(&ids)),
+        ]);
+        let vector = RecordingVectorStore::default();
+        let embedder = RecordingEmbedder::default();
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+        let mut draft = ForgetMemoryDraft::archive_thread(ids.thread, "Archive thread members.");
+        draft
+            .lifecycle_policy
+            .archive
+            .archive_thread_derived_memories = true;
+
+        let outcome = pipeline.forget(draft).await.unwrap();
+
+        assert_eq!(
+            graph.calls(),
+            vec![
+                StoreCall::GraphQuery(vec![ids.thread]),
+                StoreCall::GraphThreadQuery(vec![ids.thread]),
+                StoreCall::GraphObjects(vec![ids.old, ids.thread]),
+            ]
+        );
+        assert_eq!(
+            outcome.graph_mutated_object_ids,
+            vec![
+                MemoryObjectRef::new(ObjectType::DerivedMemory, ids.old),
+                MemoryObjectRef::new(ObjectType::MemoryThread, ids.thread),
+            ]
+        );
+        assert_eq!(
+            outcome.vector_maintained_object_ids,
+            vec![
+                MemoryObjectRef::new(ObjectType::DerivedMemory, ids.old),
+                MemoryObjectRef::new(ObjectType::MemoryThread, ids.thread),
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn retrieval_excludes_stale_superseded_candidate_when_vector_cleanup_fails() {
         let ids = fixed_ids();
         let graph = FakeGraphAuthorityStore::new();
@@ -1655,6 +1696,7 @@ mod tests {
     #[derive(Debug, Clone, PartialEq, Eq)]
     enum StoreCall {
         GraphQuery(Vec<MemoryId>),
+        GraphThreadQuery(Vec<MemoryId>),
         GraphObjects(Vec<MemoryId>),
         GraphLinks(Vec<(MemoryId, MemoryId)>),
         EmbedBatch(Vec<MemoryId>),
@@ -1754,6 +1796,26 @@ mod tests {
             _query: &GraphDerivedMemoryProvenanceQuery,
         ) -> Result<Vec<DerivedMemory>, CustomError> {
             Ok(Vec::new())
+        }
+
+        async fn query_derived_memories_by_thread(
+            &self,
+            query: &GraphDerivedMemoryThreadQuery,
+        ) -> Result<Vec<DerivedMemory>, CustomError> {
+            lock(&self.calls).push(StoreCall::GraphThreadQuery(query.thread_ids.clone()));
+            Ok(lock(&self.objects)
+                .iter()
+                .filter_map(|object| match object {
+                    MemoryObject::DerivedMemory(memory) => Some(memory.clone()),
+                    _ => None,
+                })
+                .filter(|memory| {
+                    memory
+                        .thread_ids
+                        .iter()
+                        .any(|thread_id| query.thread_ids.contains(thread_id))
+                })
+                .collect())
         }
 
         async fn expand_bounded(

--- a/src/internal/repositories/correction_forget_pipeline.rs
+++ b/src/internal/repositories/correction_forget_pipeline.rs
@@ -718,9 +718,7 @@ fn validate_correction_request(draft: &CorrectMemoryDraft) -> Result<(), CustomE
 }
 
 fn validate_forget_request(draft: &ForgetMemoryDraft) -> Result<(), CustomError> {
-    draft
-        .validate()
-        .map_err(|error| validation_error(error_string(error)))?;
+    draft.validate().map_err(validation_error)?;
     if !draft
         .lifecycle_policy
         .suppression
@@ -820,9 +818,7 @@ fn replacement_drafts_or_default(
         sort_dedup(&mut replacement.thread_ids);
         sort_dedup(&mut replacement.entity_ids);
         sort_dedup(&mut replacement.supersedes);
-        replacement
-            .validate()
-            .map_err(|error| validation_error(error_string(error)))?;
+        replacement.validate().map_err(validation_error)?;
     }
 
     Ok(replacements)
@@ -1059,10 +1055,6 @@ fn missing_object_error(object_type: ObjectType, id: MemoryId) -> CustomError {
         object_type,
         object_id: id,
     }
-}
-
-fn error_string(error: impl std::fmt::Debug) -> String {
-    format!("{error:?}")
 }
 
 fn object_type_rank(object_type: ObjectType) -> u8 {

--- a/src/internal/repositories/correction_forget_pipeline.rs
+++ b/src/internal/repositories/correction_forget_pipeline.rs
@@ -517,8 +517,10 @@ where
     async fn query_current_derived_by_provenance(
         &self,
         episode_ids: Vec<MemoryId>,
-        observation_ids: Vec<MemoryId>,
+        mut observation_ids: Vec<MemoryId>,
     ) -> Result<Vec<DerivedMemory>, CustomError> {
+        observation_ids.extend(self.observation_ids_for_episodes(&episode_ids).await?);
+        sort_dedup(&mut observation_ids);
         let mut matches = self
             .graph_store
             .query_derived_memories_by_provenance(
@@ -528,6 +530,35 @@ where
             .await?;
         sort_derived_memories(&mut matches);
         Ok(matches)
+    }
+
+    async fn observation_ids_for_episodes(
+        &self,
+        episode_ids: &[MemoryId],
+    ) -> Result<Vec<MemoryId>, CustomError> {
+        if episode_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let objects = self
+            .graph_store
+            .query_objects(&GraphObjectQuery::by_types(
+                vec![ObjectType::Observation],
+                None,
+            ))
+            .await?;
+        let mut observation_ids = objects
+            .into_iter()
+            .filter_map(|object| match object {
+                MemoryObject::Observation(observation)
+                    if episode_ids.contains(&observation.episode_id) =>
+                {
+                    Some(observation.id)
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        sort_dedup(&mut observation_ids);
+        Ok(observation_ids)
     }
 
     async fn maintain_vectors(
@@ -1419,6 +1450,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn episode_correction_supersedes_observation_only_derived_memories() {
+        let fixtures = representative_fixtures();
+        let mut observation_only = fixtures.user_preference.clone();
+        observation_only.id = Uuid::from_u128(0x550e_8400_e29b_41d4_a716_4466_5544_9101);
+        observation_only.derived_from_episode_ids.clear();
+        observation_only.derived_from_observation_ids = vec![fixtures.salient_observation.id];
+        let graph = FakeGraphAuthorityStore::new();
+        let mut objects = fixtures.objects();
+        objects.push(MemoryObject::DerivedMemory(observation_only.clone()));
+        graph.upsert_objects(&objects).await.unwrap();
+        graph.upsert_links(&fixtures.links()).await.unwrap();
+        let vector = FakeVectorCandidateStore::new();
+        let embedder = DeterministicMemoryEmbedder::new(4);
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+        let replacement_id = Uuid::from_u128(0x550e_8400_e29b_41d4_a716_4466_5544_9102);
+        let mut replacement = ReplacementDerivedMemoryDraft::new(
+            DerivedType::Correction,
+            "The corrected episode supersedes observation-only behavior.",
+        )
+        .with_source_episode(fixtures.episode.id);
+        replacement.id = Some(replacement_id);
+        replacement.original_source_provenance =
+            SourceProvenanceReference::episode(fixtures.episode.id);
+        replacement.correction_origin_provenance =
+            SourceProvenanceReference::observation(fixtures.salient_observation.id);
+        let mut draft = CorrectMemoryDraft::new(
+            CorrectionTarget::source_object(SourceObjectCorrectionTarget::Episode {
+                id: fixtures.episode.id,
+                original_raw_ref: fixtures.episode.raw_ref.clone(),
+                original_source_ref: fixtures.episode.source_conversation_id.clone(),
+            }),
+            "Correct episode-derived observation-only behavior.",
+        )
+        .with_replacement(replacement);
+        draft.correction_origin =
+            SourceProvenanceReference::observation(fixtures.salient_observation.id);
+
+        let outcome = pipeline.correct(draft).await.unwrap();
+
+        assert!(outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::DerivedMemory,
+                observation_only.id,
+            )));
+        let objects = graph
+            .query_objects(&GraphObjectQuery::by_refs(vec![
+                GraphObjectRef::new(observation_only.id, ObjectType::DerivedMemory),
+                GraphObjectRef::new(replacement_id, ObjectType::DerivedMemory),
+            ]))
+            .await
+            .unwrap();
+        let old = objects
+            .iter()
+            .find_map(|object| match object {
+                MemoryObject::DerivedMemory(memory) if memory.id == observation_only.id => {
+                    Some(memory)
+                }
+                _ => None,
+            })
+            .unwrap();
+        assert!(!old.is_current);
+        let replacement = objects
+            .iter()
+            .find_map(|object| match object {
+                MemoryObject::DerivedMemory(memory) if memory.id == replacement_id => Some(memory),
+                _ => None,
+            })
+            .unwrap();
+        assert!(replacement.supersedes.contains(&observation_only.id));
+    }
+
+    #[tokio::test]
     async fn source_object_correction_requires_original_refs_before_writes() {
         let ids = fixed_ids();
         let graph = RecordingGraphStore::new(vec![MemoryObject::Episode(source_episode(&ids))]);
@@ -1556,6 +1660,50 @@ mod tests {
             }
             _ => false,
         }));
+    }
+
+    #[tokio::test]
+    async fn episode_forget_suppresses_observation_only_derived_memories() {
+        let fixtures = representative_fixtures();
+        let mut observation_only = fixtures.user_preference.clone();
+        observation_only.id = Uuid::from_u128(0x550e_8400_e29b_41d4_a716_4466_5544_9103);
+        observation_only.derived_from_episode_ids.clear();
+        observation_only.derived_from_observation_ids = vec![fixtures.salient_observation.id];
+        let graph = FakeGraphAuthorityStore::new();
+        let mut objects = fixtures.objects();
+        objects.push(MemoryObject::DerivedMemory(observation_only.clone()));
+        graph.upsert_objects(&objects).await.unwrap();
+        graph.upsert_links(&fixtures.links()).await.unwrap();
+        let vector = FakeVectorCandidateStore::new();
+        let embedder = DeterministicMemoryEmbedder::new(4);
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+
+        let outcome = pipeline
+            .forget(ForgetMemoryDraft::suppress(
+                LifecycleTargetRef::Episode(fixtures.episode.id),
+                "Forget source episode.",
+            ))
+            .await
+            .unwrap();
+
+        assert!(outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::DerivedMemory,
+                observation_only.id,
+            )));
+        let objects = graph
+            .query_objects(&GraphObjectQuery::by_refs(vec![GraphObjectRef::new(
+                observation_only.id,
+                ObjectType::DerivedMemory,
+            )]))
+            .await
+            .unwrap();
+        let MemoryObject::DerivedMemory(memory) = &objects[0] else {
+            panic!("expected observation-only derived memory");
+        };
+        assert_eq!(memory.retention_state, RetentionState::Suppressed);
+        assert!(!memory.is_current);
     }
 
     #[tokio::test]

--- a/src/internal/repositories/correction_forget_pipeline.rs
+++ b/src/internal/repositories/correction_forget_pipeline.rs
@@ -1,0 +1,1758 @@
+#![allow(dead_code)]
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::api::types::{
+    CorrectMemoryDraft, CorrectionTarget, DerivedMemory, DerivedType, ForgetMemoryDraft,
+    LifecycleMutationOutcome, LifecycleMutationTrace, LifecycleTargetRef, MemoryId, MemoryLink,
+    MemoryObject, MemoryObjectRef, ObjectType, RelationType, ReplacementDerivedMemoryDraft,
+    RetentionState, SourceObjectCorrectionTarget, SourceProvenanceReference, Stability,
+    SupersededByEvidence, ThreadStatus, VectorMaintenanceFailure, DEFAULT_SCHEMA_VERSION,
+};
+use crate::errors::CustomError;
+use crate::internal::models::vector::{
+    memory_object_vector_record, VectorRecord, VectorRecordEmbedding,
+};
+use crate::internal::repositories::{
+    GraphAuthorityStore, GraphDerivedMemoryProvenanceQuery, GraphExpansionLifecyclePolicy,
+    GraphObjectQuery, GraphObjectRef, MemoryEmbedder, VectorCandidateStore,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LifecyclePipelineOutcome(pub(crate) LifecycleMutationOutcome);
+
+pub(crate) struct CorrectionForgetPipeline<'a, G, V, E>
+where
+    G: GraphAuthorityStore + ?Sized,
+    V: VectorCandidateStore + ?Sized,
+    E: MemoryEmbedder + ?Sized,
+{
+    graph_store: &'a G,
+    vector_store: &'a V,
+    embedder: &'a E,
+}
+
+impl<'a, G, V, E> CorrectionForgetPipeline<'a, G, V, E>
+where
+    G: GraphAuthorityStore + ?Sized,
+    V: VectorCandidateStore + ?Sized,
+    E: MemoryEmbedder + ?Sized,
+{
+    pub(crate) fn new(graph_store: &'a G, vector_store: &'a V, embedder: &'a E) -> Self {
+        Self {
+            graph_store,
+            vector_store,
+            embedder,
+        }
+    }
+
+    pub(crate) async fn correct(
+        &self,
+        draft: CorrectMemoryDraft,
+    ) -> Result<LifecycleMutationOutcome, CustomError> {
+        validate_correction_request(&draft)?;
+        let plan = self.correction_plan(draft).await?;
+
+        self.graph_store.upsert_objects(&plan.graph_objects).await?;
+        self.graph_store.upsert_links(&plan.graph_links).await?;
+
+        let mut outcome = plan.outcome_after_graph_success();
+        let vector_result = self
+            .maintain_vectors(&plan.vector_delete_refs, &plan.vector_upsert_objects)
+            .await;
+        apply_vector_result(&mut outcome, vector_result);
+        Ok(outcome)
+    }
+
+    pub(crate) async fn forget(
+        &self,
+        draft: ForgetMemoryDraft,
+    ) -> Result<LifecycleMutationOutcome, CustomError> {
+        validate_forget_request(&draft)?;
+        let plan = self.forget_plan(draft).await?;
+
+        self.graph_store.upsert_objects(&plan.graph_objects).await?;
+
+        let mut outcome = plan.outcome_after_graph_success();
+        let vector_result = self.maintain_vectors(&plan.vector_delete_refs, &[]).await;
+        apply_vector_result(&mut outcome, vector_result);
+        Ok(outcome)
+    }
+
+    async fn correction_plan(
+        &self,
+        draft: CorrectMemoryDraft,
+    ) -> Result<MutationPlan, CustomError> {
+        let mut superseded = Vec::new();
+        let mut source_episode_ids = Vec::new();
+        let mut source_observation_ids = Vec::new();
+        let mut requested_targets = Vec::new();
+
+        for target in &draft.targets {
+            match target {
+                CorrectionTarget::DerivedMemory { id } => {
+                    requested_targets.push(LifecycleTargetRef::DerivedMemory(*id));
+                    let memory = self.fetch_derived_memory(*id).await?;
+                    absorb_sources(
+                        &mut source_episode_ids,
+                        &mut source_observation_ids,
+                        &memory,
+                    );
+                    superseded.push(memory);
+                }
+                CorrectionTarget::SourceObject { target } => {
+                    requested_targets.push(source_correction_lifecycle_ref(target));
+                    self.ensure_source_object_exists(target).await?;
+                    match target {
+                        SourceObjectCorrectionTarget::Episode { id, .. } => {
+                            push_unique(&mut source_episode_ids, *id)
+                        }
+                        SourceObjectCorrectionTarget::Observation { id, .. } => {
+                            push_unique(&mut source_observation_ids, *id)
+                        }
+                    }
+                    if draft.cascade_policy.apply_to_provenanced_derived_memories {
+                        let affected = self
+                            .query_current_derived_by_provenance(
+                                source_episode_ids.clone(),
+                                source_observation_ids.clone(),
+                            )
+                            .await?;
+                        for memory in affected {
+                            absorb_sources(
+                                &mut source_episode_ids,
+                                &mut source_observation_ids,
+                                &memory,
+                            );
+                            push_memory_unique(&mut superseded, memory);
+                        }
+                    }
+                }
+            }
+        }
+
+        for id in &draft.superseded_derived_memory_ids {
+            let memory = self.fetch_derived_memory(*id).await?;
+            absorb_sources(
+                &mut source_episode_ids,
+                &mut source_observation_ids,
+                &memory,
+            );
+            push_memory_unique(&mut superseded, memory);
+        }
+        sort_derived_memories(&mut superseded);
+
+        let replacement_drafts = replacement_drafts_or_default(
+            &draft,
+            &superseded,
+            &source_episode_ids,
+            &source_observation_ids,
+        )?;
+        let replacement_memories = replacement_drafts
+            .into_iter()
+            .map(|replacement| replacement_memory(replacement, &superseded, &draft))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut graph_objects = Vec::new();
+        for memory in superseded.iter().cloned() {
+            graph_objects.push(MemoryObject::DerivedMemory(non_current_superseded_memory(
+                memory,
+                draft.lifecycle_policy.suppress_superseded_derived_memories,
+            )));
+        }
+        graph_objects.extend(
+            replacement_memories
+                .iter()
+                .cloned()
+                .map(MemoryObject::DerivedMemory),
+        );
+
+        let superseded_ids = superseded
+            .iter()
+            .map(|memory| memory.id)
+            .collect::<Vec<_>>();
+        let mut graph_links = Vec::new();
+        if draft.lifecycle_policy.supersede_replaced_derived_memories {
+            for replacement in &replacement_memories {
+                for superseded_id in &superseded_ids {
+                    graph_links.push(supersedes_link(
+                        replacement.id,
+                        *superseded_id,
+                        &draft.rationale,
+                    ));
+                }
+            }
+        }
+        graph_links.sort_by_key(|link| (link.from_id, link.to_id, link.id));
+
+        let vector_upsert_objects = replacement_memories
+            .iter()
+            .cloned()
+            .map(MemoryObject::DerivedMemory)
+            .collect::<Vec<_>>();
+        let vector_delete_refs = superseded_ids
+            .iter()
+            .copied()
+            .map(|id| MemoryObjectRef::new(ObjectType::DerivedMemory, id))
+            .collect::<Vec<_>>();
+        let trace = draft.include_trace.then(|| LifecycleMutationTrace {
+            requested_targets,
+            superseded_by: if draft.lifecycle_policy.supersede_replaced_derived_memories {
+                superseded_ids
+                    .iter()
+                    .flat_map(|superseded_id| {
+                        replacement_memories
+                            .iter()
+                            .map(move |replacement| SupersededByEvidence {
+                                superseded_memory_id: *superseded_id,
+                                superseded_by_memory_id: replacement.id,
+                            })
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            },
+        });
+
+        Ok(MutationPlan::new(
+            graph_objects,
+            graph_links,
+            vector_delete_refs,
+            vector_upsert_objects,
+            trace,
+        ))
+    }
+
+    async fn forget_plan(&self, draft: ForgetMemoryDraft) -> Result<MutationPlan, CustomError> {
+        let mut graph_objects = Vec::new();
+        let mut vector_delete_refs = Vec::new();
+        let requested_targets = draft.targets.clone();
+
+        for target in &draft.targets {
+            match target {
+                LifecycleTargetRef::DerivedMemory(id) => {
+                    let memory = self.fetch_derived_memory(*id).await?;
+                    let suppressed = suppress_derived_memory(memory, draft.target_retention_state);
+                    push_object_unique(&mut graph_objects, MemoryObject::DerivedMemory(suppressed));
+                    push_ref_unique(&mut vector_delete_refs, target.as_memory_object_ref());
+                }
+                LifecycleTargetRef::Episode(id) => {
+                    let episode = self.fetch_episode(*id).await?;
+                    let mut suppressed = episode;
+                    if draft.lifecycle_policy.suppression.suppress_target {
+                        suppressed.retention_state = draft.target_retention_state;
+                    }
+                    push_object_unique(&mut graph_objects, MemoryObject::Episode(suppressed));
+                    push_ref_unique(&mut vector_delete_refs, target.as_memory_object_ref());
+                    if draft.cascade_policy.apply_to_derived_from_target
+                        && draft
+                            .lifecycle_policy
+                            .suppression
+                            .suppress_derived_from_target
+                    {
+                        self.add_forget_cascade(
+                            &mut graph_objects,
+                            &mut vector_delete_refs,
+                            vec![*id],
+                            Vec::new(),
+                            draft.target_retention_state,
+                        )
+                        .await?;
+                    }
+                }
+                LifecycleTargetRef::Observation(id) => {
+                    let observation = self.fetch_observation(*id).await?;
+                    let mut suppressed = observation;
+                    if draft.lifecycle_policy.suppression.suppress_target {
+                        suppressed.retention_state = draft.target_retention_state;
+                    }
+                    push_object_unique(&mut graph_objects, MemoryObject::Observation(suppressed));
+                    push_ref_unique(&mut vector_delete_refs, target.as_memory_object_ref());
+                    if draft.cascade_policy.apply_to_derived_from_target
+                        && draft
+                            .lifecycle_policy
+                            .suppression
+                            .suppress_derived_from_target
+                    {
+                        self.add_forget_cascade(
+                            &mut graph_objects,
+                            &mut vector_delete_refs,
+                            Vec::new(),
+                            vec![*id],
+                            draft.target_retention_state,
+                        )
+                        .await?;
+                    }
+                }
+                LifecycleTargetRef::MemoryThread(id) => {
+                    let thread = self.fetch_thread(*id).await?;
+                    let mut archived = thread;
+                    if draft.lifecycle_policy.archive.archive_thread {
+                        archived.status =
+                            draft.target_thread_status.unwrap_or(ThreadStatus::Archived);
+                    }
+                    push_object_unique(&mut graph_objects, MemoryObject::MemoryThread(archived));
+                    push_ref_unique(&mut vector_delete_refs, target.as_memory_object_ref());
+                    if draft
+                        .lifecycle_policy
+                        .archive
+                        .archive_thread_derived_memories
+                        || draft.cascade_policy.apply_to_thread_members
+                    {
+                        self.add_thread_forget_cascade(
+                            &mut graph_objects,
+                            &mut vector_delete_refs,
+                            *id,
+                            draft.target_retention_state,
+                        )
+                        .await?;
+                    }
+                }
+            }
+        }
+
+        let trace = draft.include_trace.then(|| LifecycleMutationTrace {
+            requested_targets,
+            superseded_by: Vec::new(),
+        });
+        Ok(MutationPlan::new(
+            graph_objects,
+            Vec::new(),
+            vector_delete_refs,
+            Vec::new(),
+            trace,
+        ))
+    }
+
+    async fn add_forget_cascade(
+        &self,
+        graph_objects: &mut Vec<MemoryObject>,
+        vector_delete_refs: &mut Vec<MemoryObjectRef>,
+        episode_ids: Vec<MemoryId>,
+        observation_ids: Vec<MemoryId>,
+        target_retention_state: RetentionState,
+    ) -> Result<(), CustomError> {
+        let affected = self
+            .query_current_derived_by_provenance(episode_ids, observation_ids)
+            .await?;
+        for memory in affected {
+            let id = memory.id;
+            push_object_unique(
+                graph_objects,
+                MemoryObject::DerivedMemory(suppress_derived_memory(
+                    memory,
+                    target_retention_state,
+                )),
+            );
+            push_ref_unique(
+                vector_delete_refs,
+                MemoryObjectRef::new(ObjectType::DerivedMemory, id),
+            );
+        }
+        Ok(())
+    }
+
+    async fn add_thread_forget_cascade(
+        &self,
+        graph_objects: &mut Vec<MemoryObject>,
+        vector_delete_refs: &mut Vec<MemoryObjectRef>,
+        thread_id: MemoryId,
+        target_retention_state: RetentionState,
+    ) -> Result<(), CustomError> {
+        let objects = self
+            .graph_store
+            .query_objects(&GraphObjectQuery::by_types(
+                vec![ObjectType::DerivedMemory],
+                None,
+            ))
+            .await?;
+        for object in objects {
+            if let MemoryObject::DerivedMemory(memory) = object {
+                if memory.thread_ids.contains(&thread_id) {
+                    let id = memory.id;
+                    push_object_unique(
+                        graph_objects,
+                        MemoryObject::DerivedMemory(suppress_derived_memory(
+                            memory,
+                            target_retention_state,
+                        )),
+                    );
+                    push_ref_unique(
+                        vector_delete_refs,
+                        MemoryObjectRef::new(ObjectType::DerivedMemory, id),
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn fetch_derived_memory(&self, id: MemoryId) -> Result<DerivedMemory, CustomError> {
+        let object = self
+            .fetch_one(GraphObjectRef::new(id, ObjectType::DerivedMemory))
+            .await?;
+        match object {
+            MemoryObject::DerivedMemory(memory) => Ok(memory),
+            _ => Err(missing_object_error(ObjectType::DerivedMemory, id)),
+        }
+    }
+
+    async fn fetch_episode(&self, id: MemoryId) -> Result<crate::api::types::Episode, CustomError> {
+        let object = self
+            .fetch_one(GraphObjectRef::new(id, ObjectType::Episode))
+            .await?;
+        match object {
+            MemoryObject::Episode(episode) => Ok(episode),
+            _ => Err(missing_object_error(ObjectType::Episode, id)),
+        }
+    }
+
+    async fn fetch_observation(
+        &self,
+        id: MemoryId,
+    ) -> Result<crate::api::types::Observation, CustomError> {
+        let object = self
+            .fetch_one(GraphObjectRef::new(id, ObjectType::Observation))
+            .await?;
+        match object {
+            MemoryObject::Observation(observation) => Ok(observation),
+            _ => Err(missing_object_error(ObjectType::Observation, id)),
+        }
+    }
+
+    async fn fetch_thread(
+        &self,
+        id: MemoryId,
+    ) -> Result<crate::api::types::MemoryThread, CustomError> {
+        let object = self
+            .fetch_one(GraphObjectRef::new(id, ObjectType::MemoryThread))
+            .await?;
+        match object {
+            MemoryObject::MemoryThread(thread) => Ok(thread),
+            _ => Err(missing_object_error(ObjectType::MemoryThread, id)),
+        }
+    }
+
+    async fn fetch_one(&self, object_ref: GraphObjectRef) -> Result<MemoryObject, CustomError> {
+        let mut objects = self
+            .graph_store
+            .query_objects(&GraphObjectQuery::by_refs(vec![object_ref]))
+            .await?;
+        objects
+            .pop()
+            .ok_or_else(|| missing_object_error(object_ref.object_type, object_ref.object_id))
+    }
+
+    async fn ensure_source_object_exists(
+        &self,
+        target: &SourceObjectCorrectionTarget,
+    ) -> Result<(), CustomError> {
+        let object_ref = GraphObjectRef::new(target.id(), target.object_type());
+        self.fetch_one(object_ref).await.map(|_| ())
+    }
+
+    async fn query_current_derived_by_provenance(
+        &self,
+        episode_ids: Vec<MemoryId>,
+        observation_ids: Vec<MemoryId>,
+    ) -> Result<Vec<DerivedMemory>, CustomError> {
+        let mut matches = self
+            .graph_store
+            .query_derived_memories_by_provenance(
+                &GraphDerivedMemoryProvenanceQuery::by_sources(episode_ids, observation_ids)
+                    .with_lifecycle_policy(GraphExpansionLifecyclePolicy::default()),
+            )
+            .await?;
+        sort_derived_memories(&mut matches);
+        Ok(matches)
+    }
+
+    async fn maintain_vectors(
+        &self,
+        delete_refs: &[MemoryObjectRef],
+        upsert_objects: &[MemoryObject],
+    ) -> VectorMaintenanceResult {
+        let mut maintained = Vec::new();
+        let mut unmaintained = Vec::new();
+        let mut errors = Vec::new();
+
+        if !delete_refs.is_empty() {
+            let delete_ids = delete_refs
+                .iter()
+                .map(|object_ref| object_ref.id)
+                .collect::<Vec<_>>();
+            match self.vector_store.delete_candidates(&delete_ids).await {
+                Ok(()) => maintained.extend_from_slice(delete_refs),
+                Err(error) => {
+                    unmaintained.extend_from_slice(delete_refs);
+                    errors.push(error.to_string());
+                }
+            }
+        }
+
+        let vector_records = upsert_objects
+            .iter()
+            .filter_map(memory_object_vector_record)
+            .collect::<Vec<_>>();
+        if !vector_records.is_empty() {
+            match self.index_vector_records(&vector_records).await {
+                Ok(indexed_refs) => maintained.extend(indexed_refs),
+                Err(error) => {
+                    unmaintained.extend(
+                        vector_records.iter().map(|record| {
+                            MemoryObjectRef::new(record.object_type, record.object_id)
+                        }),
+                    );
+                    errors.push(error);
+                }
+            }
+        }
+
+        sort_refs(&mut maintained);
+        maintained.dedup();
+        sort_refs(&mut unmaintained);
+        unmaintained.dedup();
+
+        VectorMaintenanceResult {
+            maintained,
+            failure: (!errors.is_empty()).then(|| VectorMaintenanceFailure {
+                unmaintained_object_ids: unmaintained,
+                error_message: errors.join("; "),
+            }),
+        }
+    }
+
+    async fn index_vector_records(
+        &self,
+        vector_records: &[VectorRecord],
+    ) -> Result<Vec<MemoryObjectRef>, String> {
+        let embedding_inputs = vector_records
+            .iter()
+            .map(VectorRecord::embedding_input)
+            .collect::<Vec<_>>();
+        let embeddings = self
+            .embedder
+            .embed_batch(&embedding_inputs)
+            .await
+            .map_err(|error| error.to_string())?;
+
+        if embeddings.len() != vector_records.len() {
+            return Err(format!(
+                "embedder returned {} embeddings for {} vector records",
+                embeddings.len(),
+                vector_records.len()
+            ));
+        }
+
+        let record_embeddings = vector_records
+            .iter()
+            .zip(embeddings.iter())
+            .map(|(record, embedding)| VectorRecordEmbedding::new(record, embedding.as_slice()))
+            .collect::<Vec<_>>();
+        self.vector_store
+            .upsert_vector_records(&record_embeddings)
+            .await
+            .map_err(|error| error.to_string())?;
+
+        Ok(vector_records
+            .iter()
+            .map(|record| MemoryObjectRef::new(record.object_type, record.object_id))
+            .collect())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MutationPlan {
+    graph_objects: Vec<MemoryObject>,
+    graph_links: Vec<MemoryLink>,
+    vector_delete_refs: Vec<MemoryObjectRef>,
+    vector_upsert_objects: Vec<MemoryObject>,
+    trace: Option<LifecycleMutationTrace>,
+}
+
+impl MutationPlan {
+    fn new(
+        mut graph_objects: Vec<MemoryObject>,
+        mut graph_links: Vec<MemoryLink>,
+        mut vector_delete_refs: Vec<MemoryObjectRef>,
+        vector_upsert_objects: Vec<MemoryObject>,
+        trace: Option<LifecycleMutationTrace>,
+    ) -> Self {
+        sort_objects(&mut graph_objects);
+        graph_links.sort_by_key(|link| link.id);
+        sort_refs(&mut vector_delete_refs);
+        vector_delete_refs.dedup();
+        Self {
+            graph_objects,
+            graph_links,
+            vector_delete_refs,
+            vector_upsert_objects,
+            trace,
+        }
+    }
+
+    fn outcome_after_graph_success(&self) -> LifecycleMutationOutcome {
+        let mut graph_mutated_object_ids = self
+            .graph_objects
+            .iter()
+            .map(memory_object_ref)
+            .collect::<Vec<_>>();
+        sort_refs(&mut graph_mutated_object_ids);
+        LifecycleMutationOutcome {
+            graph_mutated_object_ids,
+            graph_mutated_link_ids: self.graph_links.iter().map(|link| link.id).collect(),
+            vector_maintained_object_ids: Vec::new(),
+            vector_maintenance_failure: None,
+            trace: self.trace.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct VectorMaintenanceResult {
+    maintained: Vec<MemoryObjectRef>,
+    failure: Option<VectorMaintenanceFailure>,
+}
+
+fn validate_correction_request(draft: &CorrectMemoryDraft) -> Result<(), CustomError> {
+    if draft.targets.is_empty() {
+        return Err(validation_error("correction requires at least one target"));
+    }
+    if draft.rationale.trim().is_empty() {
+        return Err(validation_error("correction rationale must not be empty"));
+    }
+    if !draft.correction_origin.has_reference() {
+        return Err(validation_error("correction origin provenance is required"));
+    }
+    for replacement in &draft.replacement_derived_memories {
+        if replacement.text.trim().is_empty() {
+            return Err(validation_error(
+                "replacement derived memory text must not be empty",
+            ));
+        }
+        if !replacement.correction_origin_provenance.has_reference()
+            && !draft.correction_origin.has_reference()
+        {
+            return Err(validation_error(
+                "replacement correction origin provenance is required",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_forget_request(draft: &ForgetMemoryDraft) -> Result<(), CustomError> {
+    draft
+        .validate()
+        .map_err(|error| validation_error(error_string(error)))
+}
+
+fn replacement_drafts_or_default(
+    draft: &CorrectMemoryDraft,
+    superseded: &[DerivedMemory],
+    source_episode_ids: &[MemoryId],
+    source_observation_ids: &[MemoryId],
+) -> Result<Vec<ReplacementDerivedMemoryDraft>, CustomError> {
+    let mut replacements = if draft.replacement_derived_memories.is_empty() {
+        vec![ReplacementDerivedMemoryDraft {
+            id: None,
+            derived_type: DerivedType::Correction,
+            text: draft.rationale.clone(),
+            derived_from_episode_ids: source_episode_ids.to_vec(),
+            derived_from_observation_ids: source_observation_ids.to_vec(),
+            thread_ids: stable_union(
+                superseded
+                    .iter()
+                    .flat_map(|memory| memory.thread_ids.clone()),
+            ),
+            entity_ids: stable_union(
+                superseded
+                    .iter()
+                    .flat_map(|memory| memory.entity_ids.clone()),
+            ),
+            confidence: 1.0,
+            salience_score: superseded
+                .iter()
+                .map(|memory| memory.salience_score)
+                .max_by(f32::total_cmp)
+                .unwrap_or(0.5),
+            stability: Stability::Medium,
+            supersedes: superseded.iter().map(|memory| memory.id).collect(),
+            original_source_provenance: SourceProvenanceReference {
+                episode_ids: source_episode_ids.to_vec(),
+                observation_ids: source_observation_ids.to_vec(),
+                external_refs: Vec::new(),
+            },
+            correction_origin_provenance: draft.correction_origin.clone(),
+        }]
+    } else {
+        draft.replacement_derived_memories.clone()
+    };
+
+    for replacement in &mut replacements {
+        merge_sources(
+            &mut replacement.derived_from_episode_ids,
+            &mut replacement.derived_from_observation_ids,
+            &replacement.original_source_provenance,
+        );
+        merge_sources(
+            &mut replacement.derived_from_episode_ids,
+            &mut replacement.derived_from_observation_ids,
+            &replacement.correction_origin_provenance,
+        );
+        merge_sources(
+            &mut replacement.derived_from_episode_ids,
+            &mut replacement.derived_from_observation_ids,
+            &draft.correction_origin,
+        );
+        if replacement.derived_from_episode_ids.is_empty()
+            && replacement.derived_from_observation_ids.is_empty()
+        {
+            replacement
+                .derived_from_episode_ids
+                .extend_from_slice(source_episode_ids);
+            replacement
+                .derived_from_observation_ids
+                .extend_from_slice(source_observation_ids);
+        }
+        for memory in superseded {
+            if replacement.thread_ids.is_empty() {
+                replacement.thread_ids.extend_from_slice(&memory.thread_ids);
+            }
+            if replacement.entity_ids.is_empty() {
+                replacement.entity_ids.extend_from_slice(&memory.entity_ids);
+            }
+            push_unique(&mut replacement.supersedes, memory.id);
+        }
+        sort_dedup(&mut replacement.derived_from_episode_ids);
+        sort_dedup(&mut replacement.derived_from_observation_ids);
+        sort_dedup(&mut replacement.thread_ids);
+        sort_dedup(&mut replacement.entity_ids);
+        sort_dedup(&mut replacement.supersedes);
+        replacement
+            .validate()
+            .map_err(|error| validation_error(error_string(error)))?;
+    }
+
+    Ok(replacements)
+}
+
+fn replacement_memory(
+    draft: ReplacementDerivedMemoryDraft,
+    superseded: &[DerivedMemory],
+    request: &CorrectMemoryDraft,
+) -> Result<DerivedMemory, CustomError> {
+    let now = Utc::now();
+    let memory = DerivedMemory {
+        id: draft.id.unwrap_or_else(Uuid::new_v4),
+        object_type: ObjectType::DerivedMemory,
+        derived_type: draft.derived_type,
+        text: draft.text,
+        derived_from_episode_ids: draft.derived_from_episode_ids,
+        derived_from_observation_ids: draft.derived_from_observation_ids,
+        thread_ids: draft.thread_ids,
+        entity_ids: draft.entity_ids,
+        confidence: draft.confidence,
+        salience_score: draft.salience_score,
+        stability: draft.stability,
+        is_current: true,
+        supersedes: if request.lifecycle_policy.supersede_replaced_derived_memories {
+            draft.supersedes
+        } else {
+            Vec::new()
+        },
+        retention_state: RetentionState::Active,
+        created_at: now,
+        updated_at: now,
+        schema_version: superseded
+            .first()
+            .map(|memory| memory.schema_version.clone())
+            .unwrap_or_else(|| DEFAULT_SCHEMA_VERSION.to_owned()),
+    };
+    memory.validate().map_err(validation_error)?;
+    Ok(memory)
+}
+
+fn non_current_superseded_memory(mut memory: DerivedMemory, suppress: bool) -> DerivedMemory {
+    memory.is_current = false;
+    if suppress {
+        memory.retention_state = RetentionState::Suppressed;
+    }
+    memory.updated_at = Utc::now();
+    memory
+}
+
+fn suppress_derived_memory(
+    mut memory: DerivedMemory,
+    retention_state: RetentionState,
+) -> DerivedMemory {
+    memory.is_current = false;
+    memory.retention_state = retention_state;
+    memory.updated_at = Utc::now();
+    memory
+}
+
+fn supersedes_link(from_id: MemoryId, to_id: MemoryId, rationale: &str) -> MemoryLink {
+    MemoryLink {
+        id: Uuid::new_v4(),
+        object_type: ObjectType::MemoryLink,
+        from_id,
+        from_type: ObjectType::DerivedMemory,
+        to_id,
+        to_type: ObjectType::DerivedMemory,
+        relation: RelationType::Supersedes,
+        confidence: 1.0,
+        rationale: Some(rationale.to_owned()),
+        created_at: Utc::now(),
+        schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+    }
+}
+
+fn source_correction_lifecycle_ref(target: &SourceObjectCorrectionTarget) -> LifecycleTargetRef {
+    match target {
+        SourceObjectCorrectionTarget::Episode { id, .. } => LifecycleTargetRef::Episode(*id),
+        SourceObjectCorrectionTarget::Observation { id, .. } => {
+            LifecycleTargetRef::Observation(*id)
+        }
+    }
+}
+
+fn absorb_sources(
+    episode_ids: &mut Vec<MemoryId>,
+    observation_ids: &mut Vec<MemoryId>,
+    memory: &DerivedMemory,
+) {
+    for id in &memory.derived_from_episode_ids {
+        push_unique(episode_ids, *id);
+    }
+    for id in &memory.derived_from_observation_ids {
+        push_unique(observation_ids, *id);
+    }
+}
+
+fn merge_sources(
+    episode_ids: &mut Vec<MemoryId>,
+    observation_ids: &mut Vec<MemoryId>,
+    provenance: &SourceProvenanceReference,
+) {
+    for id in &provenance.episode_ids {
+        push_unique(episode_ids, *id);
+    }
+    for id in &provenance.observation_ids {
+        push_unique(observation_ids, *id);
+    }
+}
+
+fn apply_vector_result(outcome: &mut LifecycleMutationOutcome, result: VectorMaintenanceResult) {
+    outcome.vector_maintained_object_ids = result.maintained;
+    outcome.vector_maintenance_failure = result.failure;
+}
+
+fn memory_object_ref(object: &MemoryObject) -> MemoryObjectRef {
+    match object {
+        MemoryObject::Episode(object) => MemoryObjectRef::new(ObjectType::Episode, object.id),
+        MemoryObject::Observation(object) => {
+            MemoryObjectRef::new(ObjectType::Observation, object.id)
+        }
+        MemoryObject::Entity(object) => MemoryObjectRef::new(ObjectType::Entity, object.id),
+        MemoryObject::MemoryThread(object) => {
+            MemoryObjectRef::new(ObjectType::MemoryThread, object.id)
+        }
+        MemoryObject::DerivedMemory(object) => {
+            MemoryObjectRef::new(ObjectType::DerivedMemory, object.id)
+        }
+        MemoryObject::MemoryLink(object) => MemoryObjectRef::new(ObjectType::MemoryLink, object.id),
+    }
+}
+
+fn object_key(object: &MemoryObject) -> (MemoryId, u8) {
+    let object_ref = memory_object_ref(object);
+    (object_ref.id, object_type_rank(object_ref.object_type))
+}
+
+fn sort_objects(objects: &mut [MemoryObject]) {
+    objects.sort_by_key(object_key);
+}
+
+fn sort_refs(refs: &mut [MemoryObjectRef]) {
+    refs.sort_by_key(|object_ref| (object_ref.id, object_type_rank(object_ref.object_type)));
+}
+
+fn sort_derived_memories(memories: &mut [DerivedMemory]) {
+    memories.sort_by_key(|memory| memory.id);
+}
+
+fn push_memory_unique(memories: &mut Vec<DerivedMemory>, memory: DerivedMemory) {
+    if !memories.iter().any(|existing| existing.id == memory.id) {
+        memories.push(memory);
+    }
+}
+
+fn push_object_unique(objects: &mut Vec<MemoryObject>, object: MemoryObject) {
+    let object_ref = memory_object_ref(&object);
+    objects.retain(|existing| memory_object_ref(existing) != object_ref);
+    objects.push(object);
+}
+
+fn push_ref_unique(refs: &mut Vec<MemoryObjectRef>, object_ref: MemoryObjectRef) {
+    if !refs.contains(&object_ref) {
+        refs.push(object_ref);
+    }
+}
+
+fn push_unique(ids: &mut Vec<MemoryId>, id: MemoryId) {
+    if !ids.contains(&id) {
+        ids.push(id);
+    }
+}
+
+fn sort_dedup(ids: &mut Vec<MemoryId>) {
+    ids.sort();
+    ids.dedup();
+}
+
+fn stable_union(ids: impl IntoIterator<Item = MemoryId>) -> Vec<MemoryId> {
+    let mut values = ids.into_iter().collect::<Vec<_>>();
+    sort_dedup(&mut values);
+    values
+}
+
+fn validation_error(error: impl ToString) -> CustomError {
+    CustomError::MemoryValidation(error.to_string())
+}
+
+fn missing_object_error(object_type: ObjectType, id: MemoryId) -> CustomError {
+    CustomError::GraphExpansionRootNotFound {
+        object_type,
+        object_id: id,
+    }
+}
+
+fn error_string(error: impl std::fmt::Debug) -> String {
+    format!("{error:?}")
+}
+
+fn object_type_rank(object_type: ObjectType) -> u8 {
+    match object_type {
+        ObjectType::Episode => 0,
+        ObjectType::Observation => 1,
+        ObjectType::Entity => 2,
+        ObjectType::MemoryThread => 3,
+        ObjectType::DerivedMemory => 4,
+        ObjectType::MemoryLink => 5,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::{Arc, Mutex, MutexGuard};
+
+    use crate::api::types::{
+        ExternalSourceReference, RetrievalContext, StaleCandidateReason, VectorCandidateTrace,
+    };
+    use crate::internal::models::vector::{
+        EmbeddingInput, VectorCandidateMatch, VectorCandidateSearch,
+    };
+    use crate::internal::repositories::test_support::{
+        representative_fixtures, DeterministicMemoryEmbedder, FakeGraphAuthorityStore,
+        FakeVectorCandidateStore,
+    };
+    use crate::internal::repositories::{GraphExpansion, GraphExpansionQuery, RetrievePipeline};
+
+    #[tokio::test]
+    async fn correction_writes_graph_before_vector_maintenance_in_stable_order() {
+        let ids = fixed_ids();
+        let graph = RecordingGraphStore::new(vec![MemoryObject::DerivedMemory(old_memory(&ids))]);
+        let vector = RecordingVectorStore::default();
+        let embedder = RecordingEmbedder::default();
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+
+        let outcome = pipeline
+            .correct(correction_draft(&ids))
+            .await
+            .expect("correction should succeed");
+
+        assert_eq!(
+            graph.calls(),
+            vec![
+                StoreCall::GraphQuery(vec![ids.old]),
+                StoreCall::GraphObjects(vec![ids.old, ids.replacement]),
+                StoreCall::GraphLinks(vec![(ids.replacement, ids.old)]),
+            ]
+        );
+        assert_eq!(
+            vector.calls(),
+            vec![
+                StoreCall::VectorDelete(vec![ids.old]),
+                StoreCall::VectorUpsert(vec![ids.replacement]),
+            ]
+        );
+        assert_eq!(
+            embedder.calls(),
+            vec![StoreCall::EmbedBatch(vec![ids.replacement])]
+        );
+        assert_eq!(
+            outcome.graph_mutated_object_ids,
+            vec![
+                MemoryObjectRef::new(ObjectType::DerivedMemory, ids.old),
+                MemoryObjectRef::new(ObjectType::DerivedMemory, ids.replacement),
+            ]
+        );
+        assert_eq!(
+            outcome.vector_maintained_object_ids,
+            vec![
+                MemoryObjectRef::new(ObjectType::DerivedMemory, ids.old),
+                MemoryObjectRef::new(ObjectType::DerivedMemory, ids.replacement),
+            ]
+        );
+        assert!(outcome.vector_maintenance_failure.is_none());
+    }
+
+    #[tokio::test]
+    async fn validation_failure_prevents_graph_and_vector_writes() {
+        let ids = fixed_ids();
+        let graph = RecordingGraphStore::new(vec![MemoryObject::DerivedMemory(old_memory(&ids))]);
+        let vector = RecordingVectorStore::default();
+        let embedder = RecordingEmbedder::default();
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+        let mut draft = correction_draft(&ids);
+        draft.rationale = " ".to_owned();
+
+        let error = pipeline.correct(draft).await.unwrap_err();
+
+        assert!(error.to_string().contains("rationale"));
+        assert!(graph.calls().is_empty());
+        assert!(vector.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn graph_failure_prevents_vector_maintenance() {
+        let ids = fixed_ids();
+        let graph = RecordingGraphStore::new(vec![MemoryObject::DerivedMemory(old_memory(&ids))])
+            .fail_objects();
+        let vector = RecordingVectorStore::default();
+        let embedder = RecordingEmbedder::default();
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+
+        let error = pipeline.correct(correction_draft(&ids)).await.unwrap_err();
+
+        assert!(error.to_string().contains("object write failed"));
+        assert!(vector.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn vector_failure_after_graph_success_returns_partial_outcome() {
+        let ids = fixed_ids();
+        let graph = RecordingGraphStore::new(vec![MemoryObject::DerivedMemory(old_memory(&ids))]);
+        let vector = RecordingVectorStore::default().fail_delete();
+        let embedder = RecordingEmbedder::default();
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+
+        let outcome = pipeline
+            .correct(correction_draft(&ids))
+            .await
+            .expect("graph success should return partial vector failure");
+
+        assert_eq!(
+            outcome.graph_mutated_object_ids,
+            vec![
+                MemoryObjectRef::new(ObjectType::DerivedMemory, ids.old),
+                MemoryObjectRef::new(ObjectType::DerivedMemory, ids.replacement),
+            ]
+        );
+        assert_eq!(
+            outcome.vector_maintained_object_ids,
+            vec![MemoryObjectRef::new(
+                ObjectType::DerivedMemory,
+                ids.replacement
+            )]
+        );
+        let failure = outcome
+            .vector_maintenance_failure
+            .expect("delete failure should be explicit");
+        assert_eq!(
+            failure.unmaintained_object_ids,
+            vec![MemoryObjectRef::new(ObjectType::DerivedMemory, ids.old)]
+        );
+        assert!(failure.error_message.contains("vector delete failed"));
+    }
+
+    #[tokio::test]
+    async fn correction_policy_can_mark_non_current_without_supersession_evidence() {
+        let ids = fixed_ids();
+        let graph = RecordingGraphStore::new(vec![MemoryObject::DerivedMemory(old_memory(&ids))]);
+        let vector = RecordingVectorStore::default();
+        let embedder = RecordingEmbedder::default();
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+        let mut draft = correction_draft(&ids).with_trace();
+        draft.lifecycle_policy.supersede_replaced_derived_memories = false;
+
+        let outcome = pipeline.correct(draft).await.unwrap();
+
+        assert_eq!(graph.calls()[2], StoreCall::GraphLinks(Vec::new()));
+        let objects = graph
+            .query_objects(&GraphObjectQuery::by_refs(vec![GraphObjectRef::new(
+                ids.replacement,
+                ObjectType::DerivedMemory,
+            )]))
+            .await
+            .unwrap();
+        let MemoryObject::DerivedMemory(replacement) = &objects[0] else {
+            panic!("expected replacement derived memory");
+        };
+        assert!(replacement.supersedes.is_empty());
+        assert!(outcome.trace.unwrap().superseded_by.is_empty());
+    }
+
+    #[tokio::test]
+    async fn source_object_correction_supersedes_provenanced_memories_without_rewriting_source() {
+        let fixtures = representative_fixtures();
+        let graph = FakeGraphAuthorityStore::new();
+        graph.upsert_objects(&fixtures.objects()).await.unwrap();
+        graph.upsert_links(&fixtures.links()).await.unwrap();
+        let vector = FakeVectorCandidateStore::new();
+        let embedder = DeterministicMemoryEmbedder::new(4);
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+        let replacement_id = Uuid::from_u128(0x550e_8400_e29b_41d4_a716_4466_5544_9100);
+        let mut replacement = ReplacementDerivedMemoryDraft::new(
+            DerivedType::Correction,
+            "The corrected source changes the behavioral note.",
+        )
+        .with_source_observation(fixtures.salient_observation.id);
+        replacement.id = Some(replacement_id);
+        replacement.original_source_provenance =
+            SourceProvenanceReference::episode(fixtures.episode.id);
+        replacement.correction_origin_provenance =
+            SourceProvenanceReference::observation(fixtures.salient_observation.id)
+                .with_external_ref(ExternalSourceReference::raw("raw://correction/1"));
+        let mut draft = CorrectMemoryDraft::new(
+            CorrectionTarget::source_object(SourceObjectCorrectionTarget::Episode {
+                id: fixtures.episode.id,
+                original_raw_ref: fixtures.episode.raw_ref.clone(),
+                original_source_ref: fixtures.episode.source_conversation_id.clone(),
+            }),
+            "Correct episode-derived behavior.",
+        )
+        .with_replacement(replacement)
+        .with_trace();
+        draft.correction_origin =
+            SourceProvenanceReference::observation(fixtures.salient_observation.id);
+
+        let outcome = pipeline.correct(draft).await.unwrap();
+
+        assert!(outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::DerivedMemory,
+                replacement_id
+            )));
+        assert!(!outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::Episode,
+                fixtures.episode.id
+            )));
+        let objects = graph
+            .query_objects(&GraphObjectQuery::by_refs(vec![
+                GraphObjectRef::new(fixtures.episode.id, ObjectType::Episode),
+                GraphObjectRef::new(fixtures.user_preference.id, ObjectType::DerivedMemory),
+                GraphObjectRef::new(replacement_id, ObjectType::DerivedMemory),
+            ]))
+            .await
+            .unwrap();
+        assert!(objects.contains(&MemoryObject::Episode(fixtures.episode.clone())));
+        let old = objects
+            .iter()
+            .find_map(|object| match object {
+                MemoryObject::DerivedMemory(memory) if memory.id == fixtures.user_preference.id => {
+                    Some(memory)
+                }
+                _ => None,
+            })
+            .unwrap();
+        assert!(!old.is_current);
+        assert_eq!(old.retention_state, RetentionState::Suppressed);
+        let replacement = objects
+            .iter()
+            .find_map(|object| match object {
+                MemoryObject::DerivedMemory(memory) if memory.id == replacement_id => Some(memory),
+                _ => None,
+            })
+            .unwrap();
+        assert!(replacement
+            .derived_from_episode_ids
+            .contains(&fixtures.episode.id));
+        assert!(replacement
+            .derived_from_observation_ids
+            .contains(&fixtures.salient_observation.id));
+        assert!(outcome.trace.unwrap().superseded_by.iter().any(|evidence| {
+            evidence.superseded_memory_id == fixtures.user_preference.id
+                && evidence.superseded_by_memory_id == replacement_id
+        }));
+    }
+
+    #[tokio::test]
+    async fn forget_suppresses_source_and_dependent_derived_memories_and_deletes_vectors() {
+        let fixtures = representative_fixtures();
+        let graph = FakeGraphAuthorityStore::new();
+        graph.upsert_objects(&fixtures.objects()).await.unwrap();
+        graph.upsert_links(&fixtures.links()).await.unwrap();
+        let vector = FakeVectorCandidateStore::new();
+        let embedder = DeterministicMemoryEmbedder::new(4);
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+
+        let outcome = pipeline
+            .forget(ForgetMemoryDraft::suppress(
+                LifecycleTargetRef::Observation(fixtures.salient_observation.id),
+                "Forget source observation.",
+            ))
+            .await
+            .unwrap();
+
+        assert!(outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::Observation,
+                fixtures.salient_observation.id,
+            )));
+        assert!(outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::DerivedMemory,
+                fixtures.user_preference.id,
+            )));
+        assert_eq!(
+            outcome.vector_maintained_object_ids,
+            outcome.graph_mutated_object_ids
+        );
+        let objects = graph
+            .query_objects(&GraphObjectQuery::by_refs(vec![
+                GraphObjectRef::new(fixtures.salient_observation.id, ObjectType::Observation),
+                GraphObjectRef::new(fixtures.user_preference.id, ObjectType::DerivedMemory),
+            ]))
+            .await
+            .unwrap();
+        assert!(objects.iter().all(|object| match object {
+            MemoryObject::Observation(observation) => {
+                observation.retention_state == RetentionState::Suppressed
+            }
+            MemoryObject::DerivedMemory(memory) => {
+                memory.retention_state == RetentionState::Suppressed && !memory.is_current
+            }
+            _ => false,
+        }));
+    }
+
+    #[tokio::test]
+    async fn forget_policy_can_suppress_source_without_derived_cascade() {
+        let fixtures = representative_fixtures();
+        let graph = FakeGraphAuthorityStore::new();
+        graph.upsert_objects(&fixtures.objects()).await.unwrap();
+        graph.upsert_links(&fixtures.links()).await.unwrap();
+        let vector = FakeVectorCandidateStore::new();
+        let embedder = DeterministicMemoryEmbedder::new(4);
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+        let mut draft = ForgetMemoryDraft::suppress(
+            LifecycleTargetRef::Episode(fixtures.episode.id),
+            "Hide source only.",
+        );
+        draft
+            .lifecycle_policy
+            .suppression
+            .suppress_derived_from_target = false;
+
+        let outcome = pipeline.forget(draft).await.unwrap();
+
+        assert_eq!(
+            outcome.graph_mutated_object_ids,
+            vec![MemoryObjectRef::new(
+                ObjectType::Episode,
+                fixtures.episode.id
+            )]
+        );
+        let objects = graph
+            .query_objects(&GraphObjectQuery::by_refs(vec![
+                GraphObjectRef::new(fixtures.episode.id, ObjectType::Episode),
+                GraphObjectRef::new(fixtures.user_preference.id, ObjectType::DerivedMemory),
+            ]))
+            .await
+            .unwrap();
+        assert!(objects.iter().any(|object| matches!(
+            object,
+            MemoryObject::Episode(episode)
+                if episode.id == fixtures.episode.id
+                    && episode.retention_state == RetentionState::Suppressed
+        )));
+        assert!(objects.iter().any(|object| matches!(
+            object,
+            MemoryObject::DerivedMemory(memory)
+                if memory.id == fixtures.user_preference.id
+                    && memory.retention_state == RetentionState::Active
+                    && memory.is_current
+        )));
+    }
+
+    #[tokio::test]
+    async fn forget_archives_memory_thread() {
+        let fixtures = representative_fixtures();
+        let graph = FakeGraphAuthorityStore::new();
+        graph.upsert_objects(&fixtures.objects()).await.unwrap();
+        let vector = FakeVectorCandidateStore::new();
+        let embedder = DeterministicMemoryEmbedder::new(4);
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+
+        let outcome = pipeline
+            .forget(ForgetMemoryDraft::archive_thread(
+                fixtures.soft_thread.id,
+                "Archive thread.",
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome.graph_mutated_object_ids,
+            vec![MemoryObjectRef::new(
+                ObjectType::MemoryThread,
+                fixtures.soft_thread.id,
+            )]
+        );
+        let objects = graph
+            .query_objects(&GraphObjectQuery::by_refs(vec![GraphObjectRef::new(
+                fixtures.soft_thread.id,
+                ObjectType::MemoryThread,
+            )]))
+            .await
+            .unwrap();
+        let MemoryObject::MemoryThread(thread) = &objects[0] else {
+            panic!("expected memory thread");
+        };
+        assert_eq!(thread.status, ThreadStatus::Archived);
+    }
+
+    #[tokio::test]
+    async fn retrieval_excludes_stale_superseded_candidate_when_vector_cleanup_fails() {
+        let ids = fixed_ids();
+        let graph = FakeGraphAuthorityStore::new();
+        graph
+            .upsert_objects(&[MemoryObject::DerivedMemory(old_memory(&ids))])
+            .await
+            .unwrap();
+        let vector = DeleteFailingVectorStore::new();
+        vector
+            .inner
+            .upsert_vector_records(&[VectorRecordEmbedding::new(
+                &memory_object_vector_record(&MemoryObject::DerivedMemory(old_memory(&ids)))
+                    .unwrap(),
+                &[1.0, 0.0, 0.0, 0.0],
+            )])
+            .await
+            .unwrap();
+        let embedder = DeterministicMemoryEmbedder::new(4);
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+        let outcome = pipeline.correct(correction_draft(&ids)).await.unwrap();
+        assert!(outcome.vector_maintenance_failure.is_some());
+
+        let retrieval = RetrievePipeline::new(&graph, &vector, &embedder)
+            .retrieve(RetrievalContext::new("stable correction behavior").with_trace())
+            .await
+            .unwrap();
+
+        assert!(
+            !trace_contains_candidate(
+                retrieval
+                    .trace
+                    .as_ref()
+                    .unwrap()
+                    .vector_candidates
+                    .as_slice(),
+                ids.old,
+            ) || retrieval
+                .trace
+                .as_ref()
+                .unwrap()
+                .stale_candidate_omissions
+                .iter()
+                .any(|omission| {
+                    omission.candidate.id == ids.old
+                        && matches!(omission.reason, StaleCandidateReason::LifecycleMismatch)
+                })
+        );
+        assert!(!pack_contains_derived_memory(&retrieval.pack, ids.old));
+    }
+
+    #[tokio::test]
+    async fn retrieval_excludes_stale_source_and_dependent_candidates_when_forget_cleanup_fails() {
+        let fixtures = representative_fixtures();
+        let graph = FakeGraphAuthorityStore::new();
+        graph.upsert_objects(&fixtures.objects()).await.unwrap();
+        graph.upsert_links(&fixtures.links()).await.unwrap();
+        let vector = DeleteFailingVectorStore::new();
+        let embedder = DeterministicMemoryEmbedder::new(4);
+        for object in [
+            MemoryObject::Episode(fixtures.episode.clone()),
+            MemoryObject::DerivedMemory(fixtures.user_preference.clone()),
+        ] {
+            let record = memory_object_vector_record(&object).unwrap();
+            vector
+                .inner
+                .upsert_vector_records(&[VectorRecordEmbedding::new(
+                    &record,
+                    &[1.0, 0.0, 0.0, 0.0],
+                )])
+                .await
+                .unwrap();
+        }
+        let pipeline = CorrectionForgetPipeline::new(&graph, &vector, &embedder);
+        let outcome = pipeline
+            .forget(ForgetMemoryDraft::suppress(
+                LifecycleTargetRef::Episode(fixtures.episode.id),
+                "Forget source episode.",
+            ))
+            .await
+            .unwrap();
+        assert!(outcome.vector_maintenance_failure.is_some());
+
+        let retrieval = RetrievePipeline::new(&graph, &vector, &embedder)
+            .retrieve(RetrievalContext::new("deterministic store contracts").with_trace())
+            .await
+            .unwrap();
+
+        let trace = retrieval.trace.as_ref().unwrap();
+        assert!(trace.stale_candidate_omissions.iter().any(|omission| {
+            omission.candidate.id == fixtures.episode.id
+                && matches!(omission.reason, StaleCandidateReason::LifecycleMismatch)
+        }));
+        assert!(trace.stale_candidate_omissions.iter().any(|omission| {
+            omission.candidate.id == fixtures.user_preference.id
+                && matches!(omission.reason, StaleCandidateReason::LifecycleMismatch)
+        }));
+        assert!(!retrieval
+            .pack
+            .relevant_episodes
+            .iter()
+            .any(|episode| episode.id == fixtures.episode.id));
+        assert!(!pack_contains_derived_memory(
+            &retrieval.pack,
+            fixtures.user_preference.id,
+        ));
+    }
+
+    fn correction_draft(ids: &FixedIds) -> CorrectMemoryDraft {
+        let mut replacement = ReplacementDerivedMemoryDraft::new(
+            DerivedType::Correction,
+            "Use graph-authoritative lifecycle correction.",
+        )
+        .with_source_episode(ids.episode)
+        .with_source_observation(ids.observation)
+        .with_superseded_memory(ids.old);
+        replacement.id = Some(ids.replacement);
+        replacement.original_source_provenance = SourceProvenanceReference::episode(ids.episode);
+        replacement.correction_origin_provenance =
+            SourceProvenanceReference::observation(ids.observation);
+        let mut draft = CorrectMemoryDraft::new(
+            CorrectionTarget::derived_memory(ids.old),
+            "Replace stale derived memory.",
+        )
+        .with_replacement(replacement);
+        draft.correction_origin = SourceProvenanceReference::observation(ids.observation);
+        draft
+    }
+
+    fn old_memory(ids: &FixedIds) -> DerivedMemory {
+        DerivedMemory {
+            id: ids.old,
+            object_type: ObjectType::DerivedMemory,
+            derived_type: DerivedType::UserPreference,
+            text: "Prefer stale lifecycle behavior.".to_owned(),
+            derived_from_episode_ids: vec![ids.episode],
+            derived_from_observation_ids: vec![ids.observation],
+            thread_ids: vec![ids.thread],
+            entity_ids: Vec::new(),
+            confidence: 0.8,
+            salience_score: 0.7,
+            stability: Stability::Medium,
+            is_current: true,
+            supersedes: Vec::new(),
+            retention_state: RetentionState::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct FixedIds {
+        old: MemoryId,
+        replacement: MemoryId,
+        episode: MemoryId,
+        observation: MemoryId,
+        thread: MemoryId,
+    }
+
+    fn fixed_ids() -> FixedIds {
+        FixedIds {
+            old: id("550e8400-e29b-41d4-a716-446655448001"),
+            replacement: id("550e8400-e29b-41d4-a716-446655448002"),
+            episode: id("550e8400-e29b-41d4-a716-446655448003"),
+            observation: id("550e8400-e29b-41d4-a716-446655448004"),
+            thread: id("550e8400-e29b-41d4-a716-446655448005"),
+        }
+    }
+
+    fn id(value: &str) -> MemoryId {
+        Uuid::parse_str(value).unwrap()
+    }
+
+    fn trace_contains_candidate(trace: &[VectorCandidateTrace], object_id: MemoryId) -> bool {
+        trace
+            .iter()
+            .any(|candidate| candidate.object.id == object_id)
+    }
+
+    fn pack_contains_derived_memory(
+        pack: &crate::api::types::ContinuityContextPack,
+        object_id: MemoryId,
+    ) -> bool {
+        pack.derived_memories
+            .iter()
+            .chain(pack.preferences.iter())
+            .chain(pack.relationship_notes.iter())
+            .chain(pack.open_loops.iter())
+            .chain(pack.commitments.iter())
+            .chain(pack.character_signals.iter())
+            .any(|memory| memory.memory.id == object_id)
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum StoreCall {
+        GraphQuery(Vec<MemoryId>),
+        GraphObjects(Vec<MemoryId>),
+        GraphLinks(Vec<(MemoryId, MemoryId)>),
+        EmbedBatch(Vec<MemoryId>),
+        VectorUpsert(Vec<MemoryId>),
+        VectorDelete(Vec<MemoryId>),
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingGraphStore {
+        objects: Mutex<Vec<MemoryObject>>,
+        links: Mutex<Vec<MemoryLink>>,
+        calls: Arc<Mutex<Vec<StoreCall>>>,
+        fail_objects: bool,
+    }
+
+    impl RecordingGraphStore {
+        fn new(objects: Vec<MemoryObject>) -> Self {
+            Self {
+                objects: Mutex::new(objects),
+                ..Self::default()
+            }
+        }
+
+        fn fail_objects(mut self) -> Self {
+            self.fail_objects = true;
+            self
+        }
+
+        fn calls(&self) -> Vec<StoreCall> {
+            lock(&self.calls).clone()
+        }
+    }
+
+    #[async_trait]
+    impl GraphAuthorityStore for RecordingGraphStore {
+        async fn upsert_objects(&self, objects: &[MemoryObject]) -> Result<(), CustomError> {
+            lock(&self.calls).push(StoreCall::GraphObjects(
+                objects
+                    .iter()
+                    .map(|object| memory_object_ref(object).id)
+                    .collect(),
+            ));
+            if self.fail_objects {
+                return Err(CustomError::DatabaseError("object write failed".to_owned()));
+            }
+            let mut stored = lock(&self.objects);
+            for object in objects {
+                let object_ref = memory_object_ref(object);
+                stored.retain(|existing| memory_object_ref(existing) != object_ref);
+                stored.push(object.clone());
+            }
+            Ok(())
+        }
+
+        async fn upsert_links(&self, links: &[MemoryLink]) -> Result<(), CustomError> {
+            lock(&self.calls).push(StoreCall::GraphLinks(
+                links
+                    .iter()
+                    .map(|link| (link.from_id, link.to_id))
+                    .collect(),
+            ));
+            lock(&self.links).extend_from_slice(links);
+            Ok(())
+        }
+
+        async fn query_objects(
+            &self,
+            query: &GraphObjectQuery,
+        ) -> Result<Vec<MemoryObject>, CustomError> {
+            lock(&self.calls).push(StoreCall::GraphQuery(
+                query
+                    .object_refs
+                    .iter()
+                    .map(|object_ref| object_ref.object_id)
+                    .collect(),
+            ));
+            Ok(lock(&self.objects)
+                .iter()
+                .filter(|object| {
+                    let object_ref = memory_object_ref(object);
+                    (query.object_refs.is_empty()
+                        || query.object_refs.iter().any(|query_ref| {
+                            query_ref.object_id == object_ref.id
+                                && query_ref.object_type == object_ref.object_type
+                        }))
+                        && (query.object_ids.is_empty()
+                            || query.object_ids.contains(&object_ref.id))
+                        && (query.object_types.is_empty()
+                            || query.object_types.contains(&object_ref.object_type))
+                })
+                .cloned()
+                .collect())
+        }
+
+        async fn query_derived_memories_by_provenance(
+            &self,
+            _query: &GraphDerivedMemoryProvenanceQuery,
+        ) -> Result<Vec<DerivedMemory>, CustomError> {
+            Ok(Vec::new())
+        }
+
+        async fn expand_bounded(
+            &self,
+            _query: &GraphExpansionQuery,
+        ) -> Result<GraphExpansion, CustomError> {
+            Ok(GraphExpansion::new(Vec::new(), Vec::new()))
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingVectorStore {
+        calls: Arc<Mutex<Vec<StoreCall>>>,
+        fail_delete: bool,
+    }
+
+    impl RecordingVectorStore {
+        fn fail_delete(mut self) -> Self {
+            self.fail_delete = true;
+            self
+        }
+
+        fn calls(&self) -> Vec<StoreCall> {
+            lock(&self.calls).clone()
+        }
+    }
+
+    #[async_trait]
+    impl VectorCandidateStore for RecordingVectorStore {
+        async fn upsert_vector_records(
+            &self,
+            records: &[VectorRecordEmbedding<'_>],
+        ) -> Result<(), CustomError> {
+            lock(&self.calls).push(StoreCall::VectorUpsert(
+                records
+                    .iter()
+                    .map(|record| record.record.object_id)
+                    .collect(),
+            ));
+            Ok(())
+        }
+
+        async fn search_candidates(
+            &self,
+            _query: &VectorCandidateSearch,
+        ) -> Result<Vec<VectorCandidateMatch>, CustomError> {
+            Ok(Vec::new())
+        }
+
+        async fn delete_candidates(&self, object_ids: &[MemoryId]) -> Result<(), CustomError> {
+            lock(&self.calls).push(StoreCall::VectorDelete(object_ids.to_vec()));
+            if self.fail_delete {
+                return Err(CustomError::DatabaseError(
+                    "vector delete failed".to_owned(),
+                ));
+            }
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingEmbedder {
+        calls: Arc<Mutex<Vec<StoreCall>>>,
+    }
+
+    impl RecordingEmbedder {
+        fn calls(&self) -> Vec<StoreCall> {
+            lock(&self.calls).clone()
+        }
+    }
+
+    #[async_trait]
+    impl MemoryEmbedder for RecordingEmbedder {
+        async fn embed(&self, _input: &EmbeddingInput) -> Result<Vec<f32>, CustomError> {
+            Ok(vec![1.0, 0.0, 0.0, 0.0])
+        }
+
+        async fn embed_batch(
+            &self,
+            inputs: &[EmbeddingInput],
+        ) -> Result<Vec<Vec<f32>>, CustomError> {
+            lock(&self.calls).push(StoreCall::EmbedBatch(
+                inputs.iter().filter_map(|input| input.object_id).collect(),
+            ));
+            Ok(inputs.iter().map(|_| vec![1.0, 0.0, 0.0, 0.0]).collect())
+        }
+    }
+
+    #[derive(Debug)]
+    struct DeleteFailingVectorStore {
+        inner: FakeVectorCandidateStore,
+    }
+
+    impl DeleteFailingVectorStore {
+        fn new() -> Self {
+            Self {
+                inner: FakeVectorCandidateStore::new(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl VectorCandidateStore for DeleteFailingVectorStore {
+        async fn upsert_vector_records(
+            &self,
+            records: &[VectorRecordEmbedding<'_>],
+        ) -> Result<(), CustomError> {
+            self.inner.upsert_vector_records(records).await
+        }
+
+        async fn search_candidates(
+            &self,
+            query: &VectorCandidateSearch,
+        ) -> Result<Vec<VectorCandidateMatch>, CustomError> {
+            self.inner.search_candidates(query).await
+        }
+
+        async fn delete_candidates(&self, _object_ids: &[MemoryId]) -> Result<(), CustomError> {
+            Err(CustomError::DatabaseError(
+                "vector delete failed".to_owned(),
+            ))
+        }
+    }
+
+    fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+        mutex.lock().expect("test mutex should not be poisoned")
+    }
+}

--- a/src/internal/repositories/graph_authority_store.rs
+++ b/src/internal/repositories/graph_authority_store.rs
@@ -972,6 +972,12 @@ pub(crate) trait GraphAuthorityStore: Send + Sync {
 
     async fn upsert_links(&self, links: &[MemoryLink]) -> Result<(), CustomError>;
 
+    async fn upsert_objects_and_links(
+        &self,
+        objects: &[MemoryObject],
+        links: &[MemoryLink],
+    ) -> Result<(), CustomError>;
+
     async fn query_objects(
         &self,
         query: &GraphObjectQuery,
@@ -1001,6 +1007,14 @@ impl<T: GraphAuthorityStore + ?Sized> GraphAuthorityStore for Box<T> {
 
     async fn upsert_links(&self, links: &[MemoryLink]) -> Result<(), CustomError> {
         (**self).upsert_links(links).await
+    }
+
+    async fn upsert_objects_and_links(
+        &self,
+        objects: &[MemoryObject],
+        links: &[MemoryLink],
+    ) -> Result<(), CustomError> {
+        (**self).upsert_objects_and_links(objects, links).await
     }
 
     async fn query_objects(

--- a/src/internal/repositories/graph_authority_store.rs
+++ b/src/internal/repositories/graph_authority_store.rs
@@ -7,7 +7,8 @@ use async_trait::async_trait;
 use std::collections::{HashSet, VecDeque};
 
 use crate::api::types::{
-    MemoryId, MemoryLink, MemoryObject, ObjectType, RelationType, RetentionState, ThreadStatus,
+    DerivedMemory, MemoryId, MemoryLink, MemoryObject, ObjectType, RelationType, RetentionState,
+    ThreadStatus,
 };
 use crate::errors::CustomError;
 
@@ -32,6 +33,38 @@ pub(crate) struct GraphObjectQuery {
     pub(crate) object_ids: Vec<MemoryId>,
     pub(crate) object_types: Vec<ObjectType>,
     pub(crate) limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GraphDerivedMemoryProvenanceQuery {
+    pub(crate) episode_ids: Vec<MemoryId>,
+    pub(crate) observation_ids: Vec<MemoryId>,
+    pub(crate) lifecycle_policy: GraphExpansionLifecyclePolicy,
+    pub(crate) limit: Option<usize>,
+}
+
+impl GraphDerivedMemoryProvenanceQuery {
+    pub(crate) fn by_sources(episode_ids: Vec<MemoryId>, observation_ids: Vec<MemoryId>) -> Self {
+        Self {
+            episode_ids,
+            observation_ids,
+            lifecycle_policy: GraphExpansionLifecyclePolicy::default(),
+            limit: None,
+        }
+    }
+
+    pub(crate) fn with_lifecycle_policy(
+        mut self,
+        lifecycle_policy: GraphExpansionLifecyclePolicy,
+    ) -> Self {
+        self.lifecycle_policy = lifecycle_policy;
+        self
+    }
+
+    pub(crate) fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
 }
 
 impl GraphObjectQuery {
@@ -282,6 +315,99 @@ pub(crate) fn bounded_expansion(
         plan.filtered_nodes,
         plan.bounded_failure,
     ))
+}
+
+pub(crate) fn derived_memories_by_provenance(
+    query: &GraphDerivedMemoryProvenanceQuery,
+    objects: impl IntoIterator<Item = MemoryObject>,
+    links: impl IntoIterator<Item = MemoryLink>,
+) -> Vec<DerivedMemory> {
+    let links = links.into_iter().collect::<Vec<_>>();
+    let link_refs = links.iter().collect::<Vec<_>>();
+    let superseded = superseded_derived_memory_ids(&link_refs);
+    let provenance_linked = provenance_linked_derived_memory_ids(query, &links);
+    let mut memories = objects
+        .into_iter()
+        .filter_map(|object| match object {
+            MemoryObject::DerivedMemory(memory) => Some(memory),
+            _ => None,
+        })
+        .filter(|memory| derived_memory_matches_provenance(query, memory, &provenance_linked))
+        .filter(|memory| {
+            lifecycle_filter_reason(
+                &MemoryObject::DerivedMemory(memory.clone()),
+                &superseded,
+                query.lifecycle_policy,
+            )
+            .is_none()
+        })
+        .collect::<Vec<_>>();
+
+    memories.sort_by_key(|memory| memory.id);
+    if let Some(limit) = query.limit {
+        memories.truncate(limit);
+    }
+    memories
+}
+
+fn derived_memory_matches_provenance(
+    query: &GraphDerivedMemoryProvenanceQuery,
+    memory: &DerivedMemory,
+    provenance_linked: &HashSet<MemoryId>,
+) -> bool {
+    (!query.episode_ids.is_empty()
+        && memory
+            .derived_from_episode_ids
+            .iter()
+            .any(|episode_id| query.episode_ids.contains(episode_id)))
+        || (!query.observation_ids.is_empty()
+            && memory
+                .derived_from_observation_ids
+                .iter()
+                .any(|observation_id| query.observation_ids.contains(observation_id)))
+        || provenance_linked.contains(&memory.id)
+}
+
+fn provenance_linked_derived_memory_ids(
+    query: &GraphDerivedMemoryProvenanceQuery,
+    links: &[MemoryLink],
+) -> HashSet<MemoryId> {
+    links
+        .iter()
+        .filter(|link| link.relation == RelationType::DerivedFrom)
+        .filter_map(|link| provenance_linked_derived_memory_id(query, link))
+        .collect()
+}
+
+fn provenance_linked_derived_memory_id(
+    query: &GraphDerivedMemoryProvenanceQuery,
+    link: &MemoryLink,
+) -> Option<MemoryId> {
+    let from = GraphObjectRef::new(link.from_id, link.from_type);
+    let to = GraphObjectRef::new(link.to_id, link.to_type);
+    match (from.object_type, to.object_type) {
+        (ObjectType::DerivedMemory, ObjectType::Episode)
+            if query.episode_ids.contains(&to.object_id) =>
+        {
+            Some(from.object_id)
+        }
+        (ObjectType::Episode, ObjectType::DerivedMemory)
+            if query.episode_ids.contains(&from.object_id) =>
+        {
+            Some(to.object_id)
+        }
+        (ObjectType::DerivedMemory, ObjectType::Observation)
+            if query.observation_ids.contains(&to.object_id) =>
+        {
+            Some(from.object_id)
+        }
+        (ObjectType::Observation, ObjectType::DerivedMemory)
+            if query.observation_ids.contains(&from.object_id) =>
+        {
+            Some(to.object_id)
+        }
+        _ => None,
+    }
 }
 
 pub(crate) fn bounded_expansion_node_set(
@@ -767,6 +893,11 @@ pub(crate) trait GraphAuthorityStore: Send + Sync {
         query: &GraphObjectQuery,
     ) -> Result<Vec<MemoryObject>, CustomError>;
 
+    async fn query_derived_memories_by_provenance(
+        &self,
+        query: &GraphDerivedMemoryProvenanceQuery,
+    ) -> Result<Vec<DerivedMemory>, CustomError>;
+
     async fn expand_bounded(
         &self,
         query: &GraphExpansionQuery,
@@ -788,6 +919,13 @@ impl<T: GraphAuthorityStore + ?Sized> GraphAuthorityStore for Box<T> {
         query: &GraphObjectQuery,
     ) -> Result<Vec<MemoryObject>, CustomError> {
         (**self).query_objects(query).await
+    }
+
+    async fn query_derived_memories_by_provenance(
+        &self,
+        query: &GraphDerivedMemoryProvenanceQuery,
+    ) -> Result<Vec<DerivedMemory>, CustomError> {
+        (**self).query_derived_memories_by_provenance(query).await
     }
 
     async fn expand_bounded(

--- a/src/internal/repositories/graph_authority_store.rs
+++ b/src/internal/repositories/graph_authority_store.rs
@@ -378,12 +378,8 @@ pub(crate) fn derived_memories_by_provenance(
             )
         })
         .filter(|memory| {
-            lifecycle_filter_reason(
-                &MemoryObject::DerivedMemory(memory.clone()),
-                &superseded,
-                query.lifecycle_policy,
-            )
-            .is_none()
+            derived_memory_lifecycle_filter_reason(memory, &superseded, query.lifecycle_policy)
+                .is_none()
         })
         .collect::<Vec<_>>();
 
@@ -417,12 +413,8 @@ pub(crate) fn derived_memories_by_thread(
                     .any(|thread_id| thread_ids.contains(thread_id))
         })
         .filter(|memory| {
-            lifecycle_filter_reason(
-                &MemoryObject::DerivedMemory(memory.clone()),
-                &superseded,
-                query.lifecycle_policy,
-            )
-            .is_none()
+            derived_memory_lifecycle_filter_reason(memory, &superseded, query.lifecycle_policy)
+                .is_none()
         })
         .collect::<Vec<_>>();
 
@@ -831,22 +823,30 @@ fn lifecycle_filter_reason(
             }
         }
         MemoryObject::DerivedMemory(object) => {
-            retention_filter_reason(object.retention_state, policy)
-                .or(if !object.is_current && !policy.include_non_current {
-                    Some(GraphExpansionFilteredReason::NonCurrent)
-                } else {
-                    None
-                })
-                .or(
-                    if superseded.contains(&object.id) && !policy.include_superseded {
-                        Some(GraphExpansionFilteredReason::Superseded)
-                    } else {
-                        None
-                    },
-                )
+            derived_memory_lifecycle_filter_reason(object, superseded, policy)
         }
         MemoryObject::Entity(_) | MemoryObject::MemoryLink(_) => None,
     }
+}
+
+fn derived_memory_lifecycle_filter_reason(
+    object: &DerivedMemory,
+    superseded: &HashSet<MemoryId>,
+    policy: GraphExpansionLifecyclePolicy,
+) -> Option<GraphExpansionFilteredReason> {
+    retention_filter_reason(object.retention_state, policy)
+        .or(if !object.is_current && !policy.include_non_current {
+            Some(GraphExpansionFilteredReason::NonCurrent)
+        } else {
+            None
+        })
+        .or(
+            if superseded.contains(&object.id) && !policy.include_superseded {
+                Some(GraphExpansionFilteredReason::Superseded)
+            } else {
+                None
+            },
+        )
 }
 
 fn retention_filter_reason(

--- a/src/internal/repositories/graph_authority_store.rs
+++ b/src/internal/repositories/graph_authority_store.rs
@@ -43,11 +43,41 @@ pub(crate) struct GraphDerivedMemoryProvenanceQuery {
     pub(crate) limit: Option<usize>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GraphDerivedMemoryThreadQuery {
+    pub(crate) thread_ids: Vec<MemoryId>,
+    pub(crate) lifecycle_policy: GraphExpansionLifecyclePolicy,
+    pub(crate) limit: Option<usize>,
+}
+
 impl GraphDerivedMemoryProvenanceQuery {
     pub(crate) fn by_sources(episode_ids: Vec<MemoryId>, observation_ids: Vec<MemoryId>) -> Self {
         Self {
             episode_ids,
             observation_ids,
+            lifecycle_policy: GraphExpansionLifecyclePolicy::default(),
+            limit: None,
+        }
+    }
+
+    pub(crate) fn with_lifecycle_policy(
+        mut self,
+        lifecycle_policy: GraphExpansionLifecyclePolicy,
+    ) -> Self {
+        self.lifecycle_policy = lifecycle_policy;
+        self
+    }
+
+    pub(crate) fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+}
+
+impl GraphDerivedMemoryThreadQuery {
+    pub(crate) fn by_threads(thread_ids: Vec<MemoryId>) -> Self {
+        Self {
+            thread_ids,
             lifecycle_policy: GraphExpansionLifecyclePolicy::default(),
             limit: None,
         }
@@ -346,6 +376,45 @@ pub(crate) fn derived_memories_by_provenance(
                 memory,
                 &provenance_linked,
             )
+        })
+        .filter(|memory| {
+            lifecycle_filter_reason(
+                &MemoryObject::DerivedMemory(memory.clone()),
+                &superseded,
+                query.lifecycle_policy,
+            )
+            .is_none()
+        })
+        .collect::<Vec<_>>();
+
+    memories.sort_by_key(|memory| memory.id);
+    if let Some(limit) = query.limit {
+        memories.truncate(limit);
+    }
+    memories
+}
+
+pub(crate) fn derived_memories_by_thread(
+    query: &GraphDerivedMemoryThreadQuery,
+    objects: impl IntoIterator<Item = MemoryObject>,
+    links: impl IntoIterator<Item = MemoryLink>,
+) -> Vec<DerivedMemory> {
+    let thread_ids = query.thread_ids.iter().copied().collect::<HashSet<_>>();
+    let links = links.into_iter().collect::<Vec<_>>();
+    let link_refs = links.iter().collect::<Vec<_>>();
+    let superseded = superseded_derived_memory_ids(&link_refs);
+    let mut memories = objects
+        .into_iter()
+        .filter_map(|object| match object {
+            MemoryObject::DerivedMemory(memory) => Some(memory),
+            _ => None,
+        })
+        .filter(|memory| {
+            !thread_ids.is_empty()
+                && memory
+                    .thread_ids
+                    .iter()
+                    .any(|thread_id| thread_ids.contains(thread_id))
         })
         .filter(|memory| {
             lifecycle_filter_reason(
@@ -913,6 +982,11 @@ pub(crate) trait GraphAuthorityStore: Send + Sync {
         query: &GraphDerivedMemoryProvenanceQuery,
     ) -> Result<Vec<DerivedMemory>, CustomError>;
 
+    async fn query_derived_memories_by_thread(
+        &self,
+        query: &GraphDerivedMemoryThreadQuery,
+    ) -> Result<Vec<DerivedMemory>, CustomError>;
+
     async fn expand_bounded(
         &self,
         query: &GraphExpansionQuery,
@@ -941,6 +1015,13 @@ impl<T: GraphAuthorityStore + ?Sized> GraphAuthorityStore for Box<T> {
         query: &GraphDerivedMemoryProvenanceQuery,
     ) -> Result<Vec<DerivedMemory>, CustomError> {
         (**self).query_derived_memories_by_provenance(query).await
+    }
+
+    async fn query_derived_memories_by_thread(
+        &self,
+        query: &GraphDerivedMemoryThreadQuery,
+    ) -> Result<Vec<DerivedMemory>, CustomError> {
+        (**self).query_derived_memories_by_thread(query).await
     }
 
     async fn expand_bounded(

--- a/src/internal/repositories/graph_authority_store.rs
+++ b/src/internal/repositories/graph_authority_store.rs
@@ -322,17 +322,31 @@ pub(crate) fn derived_memories_by_provenance(
     objects: impl IntoIterator<Item = MemoryObject>,
     links: impl IntoIterator<Item = MemoryLink>,
 ) -> Vec<DerivedMemory> {
+    let episode_ids = query.episode_ids.iter().copied().collect::<HashSet<_>>();
+    let observation_ids = query
+        .observation_ids
+        .iter()
+        .copied()
+        .collect::<HashSet<_>>();
     let links = links.into_iter().collect::<Vec<_>>();
     let link_refs = links.iter().collect::<Vec<_>>();
     let superseded = superseded_derived_memory_ids(&link_refs);
-    let provenance_linked = provenance_linked_derived_memory_ids(query, &links);
+    let provenance_linked =
+        provenance_linked_derived_memory_ids(&episode_ids, &observation_ids, &links);
     let mut memories = objects
         .into_iter()
         .filter_map(|object| match object {
             MemoryObject::DerivedMemory(memory) => Some(memory),
             _ => None,
         })
-        .filter(|memory| derived_memory_matches_provenance(query, memory, &provenance_linked))
+        .filter(|memory| {
+            derived_memory_matches_provenance(
+                &episode_ids,
+                &observation_ids,
+                memory,
+                &provenance_linked,
+            )
+        })
         .filter(|memory| {
             lifecycle_filter_reason(
                 &MemoryObject::DerivedMemory(memory.clone()),
@@ -351,58 +365,59 @@ pub(crate) fn derived_memories_by_provenance(
 }
 
 fn derived_memory_matches_provenance(
-    query: &GraphDerivedMemoryProvenanceQuery,
+    episode_ids: &HashSet<MemoryId>,
+    observation_ids: &HashSet<MemoryId>,
     memory: &DerivedMemory,
     provenance_linked: &HashSet<MemoryId>,
 ) -> bool {
-    (!query.episode_ids.is_empty()
+    (!episode_ids.is_empty()
         && memory
             .derived_from_episode_ids
             .iter()
-            .any(|episode_id| query.episode_ids.contains(episode_id)))
-        || (!query.observation_ids.is_empty()
+            .any(|episode_id| episode_ids.contains(episode_id)))
+        || (!observation_ids.is_empty()
             && memory
                 .derived_from_observation_ids
                 .iter()
-                .any(|observation_id| query.observation_ids.contains(observation_id)))
+                .any(|observation_id| observation_ids.contains(observation_id)))
         || provenance_linked.contains(&memory.id)
 }
 
 fn provenance_linked_derived_memory_ids(
-    query: &GraphDerivedMemoryProvenanceQuery,
+    episode_ids: &HashSet<MemoryId>,
+    observation_ids: &HashSet<MemoryId>,
     links: &[MemoryLink],
 ) -> HashSet<MemoryId> {
     links
         .iter()
         .filter(|link| link.relation == RelationType::DerivedFrom)
-        .filter_map(|link| provenance_linked_derived_memory_id(query, link))
+        .filter_map(|link| provenance_linked_derived_memory_id(episode_ids, observation_ids, link))
         .collect()
 }
 
 fn provenance_linked_derived_memory_id(
-    query: &GraphDerivedMemoryProvenanceQuery,
+    episode_ids: &HashSet<MemoryId>,
+    observation_ids: &HashSet<MemoryId>,
     link: &MemoryLink,
 ) -> Option<MemoryId> {
     let from = GraphObjectRef::new(link.from_id, link.from_type);
     let to = GraphObjectRef::new(link.to_id, link.to_type);
     match (from.object_type, to.object_type) {
-        (ObjectType::DerivedMemory, ObjectType::Episode)
-            if query.episode_ids.contains(&to.object_id) =>
-        {
+        (ObjectType::DerivedMemory, ObjectType::Episode) if episode_ids.contains(&to.object_id) => {
             Some(from.object_id)
         }
         (ObjectType::Episode, ObjectType::DerivedMemory)
-            if query.episode_ids.contains(&from.object_id) =>
+            if episode_ids.contains(&from.object_id) =>
         {
             Some(to.object_id)
         }
         (ObjectType::DerivedMemory, ObjectType::Observation)
-            if query.observation_ids.contains(&to.object_id) =>
+            if observation_ids.contains(&to.object_id) =>
         {
             Some(from.object_id)
         }
         (ObjectType::Observation, ObjectType::DerivedMemory)
-            if query.observation_ids.contains(&from.object_id) =>
+            if observation_ids.contains(&from.object_id) =>
         {
             Some(to.object_id)
         }

--- a/src/internal/repositories/remember_pipeline.rs
+++ b/src/internal/repositories/remember_pipeline.rs
@@ -647,6 +647,13 @@ mod tests {
             Ok(Vec::new())
         }
 
+        async fn query_derived_memories_by_provenance(
+            &self,
+            _query: &crate::internal::repositories::GraphDerivedMemoryProvenanceQuery,
+        ) -> Result<Vec<crate::api::types::DerivedMemory>, CustomError> {
+            Ok(Vec::new())
+        }
+
         async fn expand_bounded(
             &self,
             _query: &GraphExpansionQuery,

--- a/src/internal/repositories/remember_pipeline.rs
+++ b/src/internal/repositories/remember_pipeline.rs
@@ -654,6 +654,13 @@ mod tests {
             Ok(Vec::new())
         }
 
+        async fn query_derived_memories_by_thread(
+            &self,
+            _query: &crate::internal::repositories::GraphDerivedMemoryThreadQuery,
+        ) -> Result<Vec<crate::api::types::DerivedMemory>, CustomError> {
+            Ok(Vec::new())
+        }
+
         async fn expand_bounded(
             &self,
             _query: &GraphExpansionQuery,

--- a/src/internal/repositories/remember_pipeline.rs
+++ b/src/internal/repositories/remember_pipeline.rs
@@ -640,6 +640,15 @@ mod tests {
             Ok(())
         }
 
+        async fn upsert_objects_and_links(
+            &self,
+            objects: &[MemoryObject],
+            links: &[MemoryLink],
+        ) -> Result<(), CustomError> {
+            self.upsert_objects(objects).await?;
+            self.upsert_links(links).await
+        }
+
         async fn query_objects(
             &self,
             _query: &GraphObjectQuery,

--- a/src/internal/repositories/retrieve_pipeline.rs
+++ b/src/internal/repositories/retrieve_pipeline.rs
@@ -1796,6 +1796,14 @@ mod tests {
             Ok(())
         }
 
+        async fn upsert_objects_and_links(
+            &self,
+            _objects: &[MemoryObject],
+            _links: &[crate::api::types::MemoryLink],
+        ) -> Result<(), CustomError> {
+            Ok(())
+        }
+
         async fn query_objects(
             &self,
             _query: &crate::internal::repositories::GraphObjectQuery,

--- a/src/internal/repositories/retrieve_pipeline.rs
+++ b/src/internal/repositories/retrieve_pipeline.rs
@@ -1803,6 +1803,13 @@ mod tests {
             Ok(Vec::new())
         }
 
+        async fn query_derived_memories_by_provenance(
+            &self,
+            _query: &crate::internal::repositories::GraphDerivedMemoryProvenanceQuery,
+        ) -> Result<Vec<crate::api::types::DerivedMemory>, CustomError> {
+            Ok(Vec::new())
+        }
+
         async fn expand_bounded(
             &self,
             _query: &GraphExpansionQuery,

--- a/src/internal/repositories/retrieve_pipeline.rs
+++ b/src/internal/repositories/retrieve_pipeline.rs
@@ -1810,6 +1810,13 @@ mod tests {
             Ok(Vec::new())
         }
 
+        async fn query_derived_memories_by_thread(
+            &self,
+            _query: &crate::internal::repositories::GraphDerivedMemoryThreadQuery,
+        ) -> Result<Vec<crate::api::types::DerivedMemory>, CustomError> {
+            Ok(Vec::new())
+        }
+
         async fn expand_bounded(
             &self,
             _query: &GraphExpansionQuery,

--- a/src/internal/repositories/test_support.rs
+++ b/src/internal/repositories/test_support.rs
@@ -24,9 +24,10 @@ use crate::internal::models::vector::{
     VectorTimeRangeFilter,
 };
 use crate::internal::repositories::{
-    bounded_expansion, derived_memories_by_provenance, GraphAuthorityStore,
-    GraphDerivedMemoryProvenanceQuery, GraphExpansion, GraphExpansionQuery, GraphObjectQuery,
-    MemoryEmbedder, RawReference, RawReferenceResolver, VectorCandidateStore,
+    bounded_expansion, derived_memories_by_provenance, derived_memories_by_thread,
+    GraphAuthorityStore, GraphDerivedMemoryProvenanceQuery, GraphDerivedMemoryThreadQuery,
+    GraphExpansion, GraphExpansionQuery, GraphObjectQuery, MemoryEmbedder, RawReference,
+    RawReferenceResolver, VectorCandidateStore,
 };
 
 #[derive(Debug, Default)]
@@ -259,6 +260,15 @@ impl GraphAuthorityStore for FakeGraphAuthorityStore {
         let objects = lock(&self.objects)?.clone();
         let links = lock(&self.links)?.clone();
         Ok(derived_memories_by_provenance(query, objects, links))
+    }
+
+    async fn query_derived_memories_by_thread(
+        &self,
+        query: &GraphDerivedMemoryThreadQuery,
+    ) -> Result<Vec<DerivedMemory>, CustomError> {
+        let objects = lock(&self.objects)?.clone();
+        let links = lock(&self.links)?.clone();
+        Ok(derived_memories_by_thread(query, objects, links))
     }
 
     async fn expand_bounded(

--- a/src/internal/repositories/test_support.rs
+++ b/src/internal/repositories/test_support.rs
@@ -227,6 +227,27 @@ impl GraphAuthorityStore for FakeGraphAuthorityStore {
         Ok(())
     }
 
+    async fn upsert_objects_and_links(
+        &self,
+        objects: &[MemoryObject],
+        links: &[MemoryLink],
+    ) -> Result<(), CustomError> {
+        let mut stored_objects = lock(&self.objects)?;
+        let mut stored_links = lock(&self.links)?;
+
+        for object in objects {
+            let (object_id, object_type) = object_identity(object);
+            stored_objects.retain(|existing| object_identity(existing) != (object_id, object_type));
+            stored_objects.push(object.clone());
+        }
+        for link in links {
+            stored_links.retain(|existing| existing.id != link.id);
+            stored_links.push(link.clone());
+        }
+
+        Ok(())
+    }
+
     async fn query_objects(
         &self,
         query: &GraphObjectQuery,

--- a/src/internal/repositories/test_support.rs
+++ b/src/internal/repositories/test_support.rs
@@ -24,7 +24,8 @@ use crate::internal::models::vector::{
     VectorTimeRangeFilter,
 };
 use crate::internal::repositories::{
-    bounded_expansion, GraphAuthorityStore, GraphExpansion, GraphExpansionQuery, GraphObjectQuery,
+    bounded_expansion, derived_memories_by_provenance, GraphAuthorityStore,
+    GraphDerivedMemoryProvenanceQuery, GraphExpansion, GraphExpansionQuery, GraphObjectQuery,
     MemoryEmbedder, RawReference, RawReferenceResolver, VectorCandidateStore,
 };
 
@@ -249,6 +250,15 @@ impl GraphAuthorityStore for FakeGraphAuthorityStore {
         }
 
         Ok(objects)
+    }
+
+    async fn query_derived_memories_by_provenance(
+        &self,
+        query: &GraphDerivedMemoryProvenanceQuery,
+    ) -> Result<Vec<DerivedMemory>, CustomError> {
+        let objects = lock(&self.objects)?.clone();
+        let links = lock(&self.links)?.clone();
+        Ok(derived_memories_by_provenance(query, objects, links))
     }
 
     async fn expand_bounded(
@@ -819,6 +829,214 @@ fn surface_rank(surface: VectorSurface) -> u8 {
         VectorSurface::Name => 2,
         VectorSurface::DerivedText => 3,
         VectorSurface::Query => 4,
+    }
+}
+
+#[cfg(test)]
+mod lifecycle_tests {
+    use super::*;
+    use crate::internal::repositories::{
+        GraphExpansionFilteredReason, GraphExpansionLifecyclePolicy, GraphObjectRef,
+    };
+
+    #[tokio::test]
+    async fn fake_graph_lifecycle_upserts_keep_historical_objects_inspectable() {
+        let graph = FakeGraphAuthorityStore::new();
+        let fixtures = representative_fixtures();
+        let mut episode = fixtures.episode.clone();
+        let mut observation = fixtures.salient_observation.clone();
+        let mut old_memory = fixtures.user_preference.clone();
+        let mut replacement = fixtures.correction.clone();
+        let mut thread = fixtures.soft_thread.clone();
+
+        episode.retention_state = RetentionState::Suppressed;
+        observation.retention_state = RetentionState::Suppressed;
+        old_memory.retention_state = RetentionState::Suppressed;
+        old_memory.is_current = false;
+        replacement.supersedes = vec![old_memory.id];
+        thread.status = ThreadStatus::Archived;
+        let supersedes_link = link(
+            fixture_id(250),
+            replacement.id,
+            ObjectType::DerivedMemory,
+            old_memory.id,
+            ObjectType::DerivedMemory,
+            RelationType::Supersedes,
+        );
+        let thread_link = link(
+            fixture_id(251),
+            observation.id,
+            ObjectType::Observation,
+            thread.id,
+            ObjectType::MemoryThread,
+            RelationType::PartOfThread,
+        );
+
+        graph
+            .upsert_objects(&[
+                MemoryObject::Episode(episode.clone()),
+                MemoryObject::Observation(observation.clone()),
+                MemoryObject::DerivedMemory(old_memory.clone()),
+                MemoryObject::DerivedMemory(replacement.clone()),
+                MemoryObject::MemoryThread(thread.clone()),
+            ])
+            .await
+            .unwrap();
+        graph
+            .upsert_links(&[supersedes_link.clone(), thread_link.clone()])
+            .await
+            .unwrap();
+
+        let explicit_history = graph
+            .query_objects(&GraphObjectQuery::by_refs(vec![
+                GraphObjectRef::new(old_memory.id, ObjectType::DerivedMemory),
+                GraphObjectRef::new(replacement.id, ObjectType::DerivedMemory),
+                GraphObjectRef::new(episode.id, ObjectType::Episode),
+                GraphObjectRef::new(observation.id, ObjectType::Observation),
+                GraphObjectRef::new(thread.id, ObjectType::MemoryThread),
+            ]))
+            .await
+            .unwrap();
+        assert_eq!(explicit_history.len(), 5);
+        assert!(explicit_history.contains(&MemoryObject::DerivedMemory(old_memory.clone())));
+        assert!(explicit_history.contains(&MemoryObject::DerivedMemory(replacement.clone())));
+
+        let default_expansion = graph
+            .expand_bounded(
+                &GraphExpansionQuery::new(replacement.id, ObjectType::DerivedMemory, 1, 5)
+                    .with_allowed_relation_types(vec![RelationType::Supersedes]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            default_expansion.objects,
+            vec![MemoryObject::DerivedMemory(replacement.clone())]
+        );
+        assert!(default_expansion.links.is_empty());
+        assert!(default_expansion.filtered_nodes.iter().any(|filtered| {
+            filtered.object_ref == GraphObjectRef::new(old_memory.id, ObjectType::DerivedMemory)
+                && filtered.reason == GraphExpansionFilteredReason::Suppressed
+        }));
+
+        let historical_expansion = graph
+            .expand_bounded(
+                &GraphExpansionQuery::new(replacement.id, ObjectType::DerivedMemory, 1, 5)
+                    .with_allowed_relation_types(vec![RelationType::Supersedes])
+                    .with_lifecycle_policy(GraphExpansionLifecyclePolicy {
+                        include_suppressed: true,
+                        include_non_current: true,
+                        include_superseded: true,
+                        ..GraphExpansionLifecyclePolicy::default()
+                    }),
+            )
+            .await
+            .unwrap();
+        assert!(historical_expansion
+            .objects
+            .contains(&MemoryObject::DerivedMemory(old_memory.clone())));
+        assert_eq!(historical_expansion.links, vec![supersedes_link]);
+        assert_eq!(replacement.supersedes, vec![old_memory.id]);
+
+        let archived_thread_expansion = graph
+            .expand_bounded(
+                &GraphExpansionQuery::new(observation.id, ObjectType::Observation, 1, 5)
+                    .with_allowed_relation_types(vec![RelationType::PartOfThread])
+                    .with_lifecycle_policy(GraphExpansionLifecyclePolicy {
+                        include_suppressed: true,
+                        ..GraphExpansionLifecyclePolicy::default()
+                    }),
+            )
+            .await
+            .unwrap();
+        assert!(archived_thread_expansion
+            .filtered_nodes
+            .iter()
+            .any(|filtered| {
+                filtered.object_ref == GraphObjectRef::new(thread.id, ObjectType::MemoryThread)
+                    && filtered.reason == GraphExpansionFilteredReason::Archived
+            }));
+    }
+
+    #[tokio::test]
+    async fn fake_graph_discovers_source_provenanced_derived_memories_with_history_policy() {
+        let graph = FakeGraphAuthorityStore::new();
+        let fixtures = representative_fixtures();
+        let mut non_current = fixtures.user_preference.clone();
+        non_current.is_current = false;
+        let mut link_only = derived_memory(
+            fixture_id(260),
+            DerivedType::ProjectNote,
+            "Typed provenance link discovers this derived memory.",
+            fixture_id(998),
+            fixture_id(999),
+            Vec::new(),
+            Vec::new(),
+            true,
+            Vec::new(),
+            RetentionState::Active,
+        );
+        link_only.derived_from_episode_ids.clear();
+        link_only.derived_from_observation_ids.clear();
+        let provenance_link = link(
+            fixture_id(261),
+            link_only.id,
+            ObjectType::DerivedMemory,
+            fixtures.episode.id,
+            ObjectType::Episode,
+            RelationType::DerivedFrom,
+        );
+
+        graph
+            .upsert_objects(&[
+                MemoryObject::Episode(fixtures.episode.clone()),
+                MemoryObject::Observation(fixtures.salient_observation.clone()),
+                MemoryObject::DerivedMemory(fixtures.derived_reflection.clone()),
+                MemoryObject::DerivedMemory(non_current.clone()),
+                MemoryObject::DerivedMemory(link_only.clone()),
+            ])
+            .await
+            .unwrap();
+        graph
+            .upsert_links(std::slice::from_ref(&provenance_link))
+            .await
+            .unwrap();
+
+        let default_matches = graph
+            .query_derived_memories_by_provenance(
+                &GraphDerivedMemoryProvenanceQuery::by_sources(
+                    vec![fixtures.episode.id],
+                    vec![fixtures.salient_observation.id],
+                )
+                .with_limit(10),
+            )
+            .await
+            .unwrap();
+        assert!(default_matches
+            .iter()
+            .any(|memory| memory.id == fixtures.derived_reflection.id));
+        assert!(default_matches
+            .iter()
+            .any(|memory| memory.id == link_only.id));
+        assert!(!default_matches
+            .iter()
+            .any(|memory| memory.id == non_current.id));
+
+        let historical_matches = graph
+            .query_derived_memories_by_provenance(
+                &GraphDerivedMemoryProvenanceQuery::by_sources(
+                    vec![fixtures.episode.id],
+                    vec![fixtures.salient_observation.id],
+                )
+                .with_lifecycle_policy(GraphExpansionLifecyclePolicy {
+                    include_non_current: true,
+                    ..GraphExpansionLifecyclePolicy::default()
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(historical_matches
+            .iter()
+            .any(|memory| memory.id == non_current.id));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,26 +13,32 @@ use crate::internal::infrastructures::external_services::{
 };
 use crate::internal::models::vector::VectorMetadata;
 use crate::internal::repositories::{
-    GraphAuthorityStore, LinkPipeline, MemoryEmbedder, MemoryRepository, RememberPipeline,
-    RememberPipelineDraft, RetrievePipeline, VectorCandidateStore,
+    CorrectionForgetPipeline, GraphAuthorityStore, LinkPipeline, MemoryEmbedder, MemoryRepository,
+    RememberPipeline, RememberPipelineDraft, RetrievePipeline, VectorCandidateStore,
 };
 
 // Re-export types for public use
 pub use crate::api::embedding::EmbeddingProvider;
 pub use crate::api::types::{
-    default_retrieval_object_types, graph_uri, ContextPackSection, ContinuityContextPack,
-    ContinuitySectionLimits, DerivedMemory, DerivedMemoryDraft, DerivedType, DomainValidationError,
-    DraftDefaults, Entity, EntityDraft, EntityType, Episode, EpisodeDraft, GraphRelationTrace,
-    IncludedDerivedMemory, LifecycleFilterAction, LifecycleFilterDecision, LifecycleFilterReason,
-    LifecycleOmissionSummary, Memory, MemoryFilters, MemoryId, MemoryInput, MemoryLink,
-    MemoryLinkDraft, MemoryObject, MemoryObjectDraft, MemoryObjectRef, MemoryThread,
-    MemoryThreadDraft, MemoryType, Modality, ObjectType, Observation, ObservationDraft,
-    RelationType, RememberDraft, RememberOutcome, RetentionState, RetrievalCandidateLimits,
-    RetrievalContext, RetrievalGraphLimits, RetrievalLifecyclePolicy, RetrievalRationale,
-    RetrievalTrace, RetrieveOutcome, ScoredMemory, SectionAssignment, Stability,
-    StaleCandidateOmission, StaleCandidateOmissionSummary, StaleCandidateReason, ThreadStatus,
-    VectorCandidateTrace, VectorIndexingFailure, CURRENT_SCHEMA_VERSION, DEFAULT_SCHEMA_VERSION,
-    EPISODIC_MEMORY_SCHEMA_VERSION,
+    default_retrieval_object_types, graph_uri, ArchivePolicy, ContextPackSection,
+    ContinuityContextPack, ContinuitySectionLimits, CorrectMemoryDraft, CorrectionCascadePolicy,
+    CorrectionLifecyclePolicy, CorrectionTarget, DeferredDestructiveLifecyclePolicy,
+    DeferredLifecycleAction, DerivedMemory, DerivedMemoryDraft, DerivedType, DomainValidationError,
+    DraftDefaults, Entity, EntityDraft, EntityType, Episode, EpisodeDraft, ExternalSourceReference,
+    ForgetCascadePolicy, ForgetLifecyclePolicy, ForgetMemoryDraft, GraphRelationTrace,
+    IncludedDerivedMemory, LifecycleDtoValidationError, LifecycleFilterAction,
+    LifecycleFilterDecision, LifecycleFilterReason, LifecycleMutationOutcome,
+    LifecycleMutationTrace, LifecycleOmissionSummary, LifecycleTargetRef, Memory, MemoryFilters,
+    MemoryId, MemoryInput, MemoryLink, MemoryLinkDraft, MemoryObject, MemoryObjectDraft,
+    MemoryObjectRef, MemoryThread, MemoryThreadDraft, MemoryType, Modality, ObjectType,
+    Observation, ObservationDraft, RelationType, RememberDraft, RememberOutcome,
+    ReplacementDerivedMemoryDraft, RetentionState, RetrievalCandidateLimits, RetrievalContext,
+    RetrievalGraphLimits, RetrievalLifecyclePolicy, RetrievalRationale, RetrievalTrace,
+    RetrieveOutcome, ScoredMemory, SectionAssignment, SourceObjectCorrectionTarget,
+    SourceProvenanceReference, Stability, StaleCandidateOmission, StaleCandidateOmissionSummary,
+    StaleCandidateReason, SupersededByEvidence, SuppressionPolicy, ThreadStatus,
+    VectorCandidateTrace, VectorIndexingFailure, VectorMaintenanceFailure, CURRENT_SCHEMA_VERSION,
+    DEFAULT_SCHEMA_VERSION, EPISODIC_MEMORY_SCHEMA_VERSION,
 };
 pub use crate::config::settings::Settings;
 pub use crate::errors::CustomError;
@@ -255,6 +261,42 @@ impl CharacterMemory {
         .await
     }
 
+    /// Applies a non-destructive lifecycle correction through injected graph/vector parts.
+    // Remove this allow once public graph/vector construction or internal lifecycle wiring
+    // consumes the injected correction path outside source-module tests.
+    #[allow(dead_code)]
+    pub(crate) async fn correct(
+        &self,
+        draft: CorrectMemoryDraft,
+    ) -> Result<LifecycleMutationOutcome, CustomError> {
+        let parts = self.memory_composition()?;
+        CorrectionForgetPipeline::new(
+            parts.graph_store.as_ref(),
+            parts.vector_store.as_ref(),
+            parts.embedder.as_ref(),
+        )
+        .correct(draft)
+        .await
+    }
+
+    /// Applies suppression/archive lifecycle mutation through injected graph/vector parts.
+    // Remove this allow once public graph/vector construction or internal lifecycle wiring
+    // consumes the injected forget path outside source-module tests.
+    #[allow(dead_code)]
+    pub(crate) async fn forget(
+        &self,
+        draft: ForgetMemoryDraft,
+    ) -> Result<LifecycleMutationOutcome, CustomError> {
+        let parts = self.memory_composition()?;
+        CorrectionForgetPipeline::new(
+            parts.graph_store.as_ref(),
+            parts.vector_store.as_ref(),
+            parts.embedder.as_ref(),
+        )
+        .forget(draft)
+        .await
+    }
+
     /// Legacy flat vector-only create path retained for existing integration coverage until the
     /// default production constructor is rewired to graph/vector composition.
     #[deprecated(
@@ -455,8 +497,8 @@ mod tests {
 
     use crate::api::types::{EntityDraft, EntityType, ObjectType, RelationType};
     use crate::internal::models::vector::{
-        EmbeddingInput, VectorCandidateMatch, VectorCandidateSearch, VectorRecordEmbedding,
-        VectorSurface,
+        memory_object_vector_record, EmbeddingInput, VectorCandidateMatch, VectorCandidateSearch,
+        VectorRecordEmbedding, VectorSurface,
     };
     use crate::internal::repositories::test_support::{
         representative_fixtures, DeterministicMemoryEmbedder, FakeGraphAuthorityStore,
@@ -568,6 +610,320 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn injected_facade_corrects_derived_memory_and_retrieval_excludes_superseded_memory() {
+        let (memory, fixtures, replacement_id) = lifecycle_memory().await;
+
+        let outcome = memory
+            .correct(derived_correction_draft(
+                &fixtures,
+                replacement_id,
+                fixtures.user_preference.id,
+            ))
+            .await
+            .expect("correct facade should use injected lifecycle pipeline");
+
+        assert!(outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::DerivedMemory,
+                fixtures.user_preference.id,
+            )));
+        assert!(outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::DerivedMemory,
+                replacement_id,
+            )));
+        assert!(outcome
+            .trace
+            .as_ref()
+            .unwrap()
+            .superseded_by
+            .iter()
+            .any(|evidence| {
+                evidence.superseded_memory_id == fixtures.user_preference.id
+                    && evidence.superseded_by_memory_id == replacement_id
+            }));
+
+        let normal = memory
+            .retrieve(RetrievalContext::new("corrected deterministic preference").with_trace())
+            .await
+            .expect("normal retrieval should use graph lifecycle filters");
+        assert!(pack_contains_derived_memory(&normal.pack, replacement_id));
+        assert!(!pack_contains_derived_memory(
+            &normal.pack,
+            fixtures.user_preference.id,
+        ));
+        assert!(normal
+            .trace
+            .as_ref()
+            .unwrap()
+            .lifecycle_filter_decisions
+            .iter()
+            .any(|decision| {
+                decision.object.id == fixtures.user_preference.id
+                    && decision.action == LifecycleFilterAction::Omitted
+            }));
+
+        let mut historical =
+            RetrievalContext::new("corrected deterministic preference").with_trace();
+        historical.lifecycle_policy.include_suppressed = true;
+        historical.lifecycle_policy.include_non_current = true;
+        historical.lifecycle_policy.include_superseded = true;
+        let historical = memory
+            .retrieve(historical)
+            .await
+            .expect("historical opt-in should keep lifecycle state inspectable");
+        assert!(pack_contains_derived_memory(
+            &historical.pack,
+            fixtures.user_preference.id,
+        ));
+        assert!(historical
+            .trace
+            .as_ref()
+            .unwrap()
+            .lifecycle_filter_decisions
+            .iter()
+            .any(|decision| {
+                decision.object.id == fixtures.user_preference.id
+                    && decision.superseded_by.contains(&replacement_id)
+                    && decision.action == LifecycleFilterAction::Included
+            }));
+    }
+
+    #[tokio::test]
+    async fn injected_facade_corrects_episode_and_observation_provenanced_derived_memories() {
+        let (memory, fixtures, episode_replacement_id) =
+            lifecycle_memory_with_replacement(id("550e8400-e29b-41d4-a716-446655449200")).await;
+
+        let episode_outcome = memory
+            .correct(source_object_correction_draft(
+                &fixtures,
+                SourceObjectCorrectionTarget::Episode {
+                    id: fixtures.episode.id,
+                    original_raw_ref: fixtures.episode.raw_ref.clone(),
+                    original_source_ref: fixtures.episode.source_conversation_id.clone(),
+                },
+                episode_replacement_id,
+            ))
+            .await
+            .expect("episode correction should supersede affected derived memories");
+
+        assert!(episode_outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::DerivedMemory,
+                fixtures.user_preference.id,
+            )));
+        assert!(!episode_outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::Episode,
+                fixtures.episode.id
+            )));
+        let episode_retrieval = memory
+            .retrieve(RetrievalContext::new("episode corrected preference"))
+            .await
+            .unwrap();
+        assert!(pack_contains_derived_memory(
+            &episode_retrieval.pack,
+            episode_replacement_id,
+        ));
+        assert!(!pack_contains_derived_memory(
+            &episode_retrieval.pack,
+            fixtures.user_preference.id,
+        ));
+
+        let (memory, fixtures, observation_replacement_id) =
+            lifecycle_memory_with_replacement(id("550e8400-e29b-41d4-a716-446655449201")).await;
+        let observation_outcome = memory
+            .correct(source_object_correction_draft(
+                &fixtures,
+                SourceObjectCorrectionTarget::Observation {
+                    id: fixtures.salient_observation.id,
+                    original_raw_ref: fixtures.salient_observation.raw_ref.clone(),
+                    original_source_ref: fixtures.episode.source_conversation_id.clone(),
+                },
+                observation_replacement_id,
+            ))
+            .await
+            .expect("observation correction should supersede affected derived memories");
+
+        assert!(observation_outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::DerivedMemory,
+                fixtures.user_preference.id,
+            )));
+        assert!(!observation_outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::Observation,
+                fixtures.salient_observation.id,
+            )));
+        let observation_retrieval = memory
+            .retrieve(RetrievalContext::new("observation corrected preference"))
+            .await
+            .unwrap();
+        assert!(pack_contains_derived_memory(
+            &observation_retrieval.pack,
+            observation_replacement_id,
+        ));
+        assert!(!pack_contains_derived_memory(
+            &observation_retrieval.pack,
+            fixtures.user_preference.id,
+        ));
+    }
+
+    #[tokio::test]
+    async fn injected_facade_forgets_derived_memory_and_source_objects_without_deletion() {
+        let (memory, fixtures, _) = lifecycle_memory().await;
+
+        let derived_outcome = memory
+            .forget(
+                ForgetMemoryDraft::suppress(
+                    LifecycleTargetRef::derived_memory(fixtures.user_preference.id),
+                    "Suppress stale derived preference.",
+                )
+                .with_trace(),
+            )
+            .await
+            .expect("derived forget should use injected lifecycle pipeline");
+        assert_eq!(
+            derived_outcome.graph_mutated_object_ids,
+            vec![MemoryObjectRef::new(
+                ObjectType::DerivedMemory,
+                fixtures.user_preference.id,
+            )]
+        );
+        let normal = memory
+            .retrieve(RetrievalContext::new("deterministic local fakes"))
+            .await
+            .unwrap();
+        assert!(!pack_contains_derived_memory(
+            &normal.pack,
+            fixtures.user_preference.id,
+        ));
+
+        let (memory, fixtures, _) = lifecycle_memory().await;
+        let source_outcome = memory
+            .forget(
+                ForgetMemoryDraft::suppress(
+                    LifecycleTargetRef::episode(fixtures.episode.id),
+                    "Suppress source episode and dependent derived memories.",
+                )
+                .with_trace(),
+            )
+            .await
+            .expect("source forget should cascade to provenanced derived memories");
+        assert!(source_outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::Episode,
+                fixtures.episode.id,
+            )));
+        assert!(source_outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::DerivedMemory,
+                fixtures.user_preference.id,
+            )));
+
+        let source_retrieval = memory
+            .retrieve(RetrievalContext::new("deterministic local fakes").with_trace())
+            .await
+            .unwrap();
+        assert!(!source_retrieval
+            .pack
+            .relevant_episodes
+            .iter()
+            .any(|episode| episode.id == fixtures.episode.id));
+        assert!(!pack_contains_derived_memory(
+            &source_retrieval.pack,
+            fixtures.user_preference.id,
+        ));
+    }
+
+    #[tokio::test]
+    async fn injected_facade_archives_memory_thread() {
+        let (memory, fixtures, _) = lifecycle_memory().await;
+
+        let outcome = memory
+            .forget(
+                ForgetMemoryDraft::archive_thread(fixtures.soft_thread.id, "Archive soft thread.")
+                    .with_trace(),
+            )
+            .await
+            .expect("thread forget should archive through injected lifecycle pipeline");
+
+        assert_eq!(
+            outcome.graph_mutated_object_ids,
+            vec![MemoryObjectRef::new(
+                ObjectType::MemoryThread,
+                fixtures.soft_thread.id,
+            )]
+        );
+        let normal = memory
+            .retrieve(RetrievalContext::new("contract test support"))
+            .await
+            .unwrap();
+        assert!(!normal
+            .pack
+            .active_threads
+            .iter()
+            .any(|thread| thread.id == fixtures.soft_thread.id));
+    }
+
+    #[tokio::test]
+    #[allow(deprecated)]
+    async fn injected_lifecycle_facades_are_isolated_from_legacy_update_and_delete() {
+        let (memory, fixtures, replacement_id) = lifecycle_memory().await;
+        let input = MemoryInput {
+            id: Some(fixtures.user_preference.id),
+            content: "legacy flat update should remain unavailable".to_owned(),
+            memory_type: MemoryType::Semantic,
+            timestamp: None,
+            location_text: None,
+            participants: None,
+        };
+
+        let update_error = memory.update_memory(input).await.unwrap_err();
+        assert!(
+            matches!(update_error, CustomError::UnsupportedOperation(message) if message.contains("legacy flat memory API is not available"))
+        );
+        let delete_error = memory
+            .delete_memory(fixtures.user_preference.id)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(delete_error, CustomError::UnsupportedOperation(message) if message.contains("legacy flat memory API is not available"))
+        );
+
+        memory
+            .correct(derived_correction_draft(
+                &fixtures,
+                replacement_id,
+                fixtures.user_preference.id,
+            ))
+            .await
+            .expect("legacy update/delete isolation should not block lifecycle correction");
+        let outcome = memory
+            .forget(ForgetMemoryDraft::suppress(
+                LifecycleTargetRef::derived_memory(replacement_id),
+                "Suppress replacement via lifecycle forget.",
+            ))
+            .await
+            .expect("legacy update/delete isolation should not block lifecycle forget");
+
+        assert!(outcome
+            .graph_mutated_object_ids
+            .contains(&MemoryObjectRef::new(
+                ObjectType::DerivedMemory,
+                replacement_id,
+            )));
+    }
+
     fn injected_memory() -> CharacterMemory {
         CharacterMemory::from_parts(
             Box::new(FakeGraphAuthorityStore::new()),
@@ -597,6 +953,137 @@ mod tests {
         );
 
         (memory, fixtures)
+    }
+
+    async fn lifecycle_memory() -> (
+        CharacterMemory,
+        crate::internal::repositories::test_support::RepresentativeFixtures,
+        MemoryId,
+    ) {
+        lifecycle_memory_with_replacement(id("550e8400-e29b-41d4-a716-446655449100")).await
+    }
+
+    async fn lifecycle_memory_with_replacement(
+        replacement_id: MemoryId,
+    ) -> (
+        CharacterMemory,
+        crate::internal::repositories::test_support::RepresentativeFixtures,
+        MemoryId,
+    ) {
+        let fixtures = representative_fixtures();
+        let graph = FakeGraphAuthorityStore::new();
+        graph.upsert_objects(&fixtures.objects()).await.unwrap();
+        graph.upsert_links(&fixtures.links()).await.unwrap();
+        let vector = FakeVectorCandidateStore::new();
+        let objects = [
+            MemoryObject::Episode(fixtures.episode.clone()),
+            MemoryObject::Observation(fixtures.salient_observation.clone()),
+            MemoryObject::MemoryThread(fixtures.soft_thread.clone()),
+            MemoryObject::DerivedMemory(fixtures.user_preference.clone()),
+        ];
+        for object in objects {
+            let record = memory_object_vector_record(&object).unwrap();
+            vector
+                .upsert_vector_records(&[VectorRecordEmbedding::new(
+                    &record,
+                    &[1.0, 0.0, 0.0, 0.0],
+                )])
+                .await
+                .unwrap();
+        }
+
+        let memory = CharacterMemory::from_parts(
+            Box::new(graph),
+            Box::new(vector),
+            Box::new(DeterministicMemoryEmbedder::new(4)),
+        );
+
+        (memory, fixtures, replacement_id)
+    }
+
+    fn derived_correction_draft(
+        fixtures: &crate::internal::repositories::test_support::RepresentativeFixtures,
+        replacement_id: MemoryId,
+        superseded_id: MemoryId,
+    ) -> CorrectMemoryDraft {
+        let mut replacement = ReplacementDerivedMemoryDraft::new(
+            DerivedType::Correction,
+            "Prefer corrected deterministic lifecycle facade coverage.",
+        )
+        .with_source_episode(fixtures.episode.id)
+        .with_source_observation(fixtures.salient_observation.id)
+        .with_superseded_memory(superseded_id);
+        replacement.id = Some(replacement_id);
+        replacement.original_source_provenance =
+            SourceProvenanceReference::episode(fixtures.episode.id)
+                .with_external_ref(ExternalSourceReference::raw("raw://original/preference"));
+        replacement.correction_origin_provenance =
+            SourceProvenanceReference::observation(fixtures.salient_observation.id)
+                .with_external_ref(ExternalSourceReference::raw("raw://correction/facade"));
+
+        let mut draft = CorrectMemoryDraft::new(
+            CorrectionTarget::derived_memory(superseded_id),
+            "Correct stale derived memory through injected facade.",
+        )
+        .with_replacement(replacement)
+        .with_superseded_derived_memory(superseded_id)
+        .with_trace();
+        draft.correction_origin =
+            SourceProvenanceReference::observation(fixtures.salient_observation.id)
+                .with_external_ref(ExternalSourceReference::raw("raw://correction/facade"));
+        draft
+    }
+
+    fn source_object_correction_draft(
+        fixtures: &crate::internal::repositories::test_support::RepresentativeFixtures,
+        target: SourceObjectCorrectionTarget,
+        replacement_id: MemoryId,
+    ) -> CorrectMemoryDraft {
+        let mut draft = CorrectMemoryDraft::new(
+            CorrectionTarget::source_object(target),
+            "Correct source-provenanced derived behavior through injected facade.",
+        )
+        .with_replacement(derived_correction_replacement(fixtures, replacement_id))
+        .with_trace();
+        draft.correction_origin =
+            SourceProvenanceReference::observation(fixtures.salient_observation.id)
+                .with_external_ref(ExternalSourceReference::raw(
+                    "raw://correction/source-object",
+                ));
+        draft
+    }
+
+    fn derived_correction_replacement(
+        fixtures: &crate::internal::repositories::test_support::RepresentativeFixtures,
+        replacement_id: MemoryId,
+    ) -> ReplacementDerivedMemoryDraft {
+        let mut replacement = ReplacementDerivedMemoryDraft::new(
+            DerivedType::Correction,
+            "Correct source-provenanced deterministic facade behavior.",
+        )
+        .with_source_episode(fixtures.episode.id)
+        .with_source_observation(fixtures.salient_observation.id);
+        replacement.id = Some(replacement_id);
+        replacement.original_source_provenance =
+            SourceProvenanceReference::episode(fixtures.episode.id)
+                .with_external_ref(ExternalSourceReference::raw("raw://original/source-object"));
+        replacement.correction_origin_provenance =
+            SourceProvenanceReference::observation(fixtures.salient_observation.id)
+                .with_external_ref(ExternalSourceReference::raw(
+                    "raw://correction/source-object",
+                ));
+        replacement
+    }
+
+    fn pack_contains_derived_memory(pack: &ContinuityContextPack, memory_id: MemoryId) -> bool {
+        pack.derived_memories
+            .iter()
+            .chain(pack.preferences.iter())
+            .chain(pack.relationship_notes.iter())
+            .chain(pack.open_loops.iter())
+            .chain(pack.commitments.iter())
+            .chain(pack.character_signals.iter())
+            .any(|included| included.memory.id == memory_id)
     }
 
     #[derive(Debug)]


### PR DESCRIPTION
### Motivation and Context

This implements the v0.1 Correction And Forget Lifecycle roadmap step on top of the graph-authoritative remember/link/retrieve path.

It enables non-destructive correction through derived-memory supersession, soft forget behavior through suppression/archive lifecycle state, and graph-authoritative retrieval exclusion so stale vector candidates cannot make suppressed or superseded memories influence normal context.

### Description

- Adds backend-free correction/forget lifecycle DTOs and re-exports them through the public type surface.
- Extends graph authority support for source-provenance discovery, lifecycle/currentness updates, supersession links, and embedded Oxigraph parity.
- Adds an internal correction/forget pipeline that mutates graph truth first, then performs vector candidate hygiene with explicit partial-failure reporting.
- Wires crate-visible injected `CharacterMemory::correct` and `CharacterMemory::forget` facades without extending the deprecated legacy flat update/delete paths.
- Covers derived-memory correction, episode/observation correction of affected derived memories, correction-origin provenance, source-object forget cascades, memory-thread archival, stale-vector retrieval exclusion, and policy-toggle behavior.
- Follow-up review remediation aligns vector candidate deletion with actual graph lifecycle mutation, rejects unsupported correction/forget policy states before writes, normalizes provenance lookups through `HashSet` membership, uses a provider-neutral thread-membership graph query for thread forget cascades, trims external provenance refs, validates source-object original refs before cascade, removes clone-only derived-memory lifecycle filtering, persists correction graph objects plus supersession links through a combined graph-authority call, exposes caller-facing lifecycle DTO validation messages, batches Oxigraph object/link RDF replacement in a transaction before cache updates, and cascades episode correction/forget through observations so observation-only derived memories are covered.
- Completes the lifecycle execution plan and drafts the next Documentation, Migration Cleanup, And Release Validation plan.

### Checklist

- [x] Service-free compile check passes
      `cargo check`
- [x] Service-free test target compilation passes
      `cargo test --no-run`
- [x] **Clippy** passes with warnings denied
      `cargo clippy --all-targets -- -D warnings`
- [x] Rust formatting check passes
      `cargo fmt --check`
- [ ] Full Qdrant-backed integration tests pass in trusted same-repository CI or with local service configuration
      `cargo test --verbose`
- [x] Documentation updated where needed
- [x] BREAKING CHANGE? **No** / _describe impact_
- [x] I didn’t break anyone 😊

### Additional Notes (optional)

Validation run locally:

- `cargo fmt --check`
- `cargo check`
- `cargo test --no-run`
- `cargo test --lib` — 194 passed, 0 failed, 1 ignored
- `cargo clippy --all-targets -- -D warnings`
- `cargo test episode_correction_supersedes_observation_only_derived_memories --lib` — 1 passed
- `cargo test episode_forget_suppresses_observation_only_derived_memories --lib` — 1 passed
- `cargo test correction_forget_pipeline --lib` — 22 passed
- `cargo test oxigraph --lib` — 15 passed
- `docker compose -f docker-compose.qdrant.yml up -d && QDRANT_CONNECTION_STRING=http://localhost:6334 cargo test --lib qdrant_candidate_store_live_smoke_upserts_filters_searches_and_deletes -- --ignored && docker compose -f docker-compose.qdrant.yml down` — 1 passed

The full `cargo test --verbose` Qdrant-backed integration suite was not run locally; the targeted live Qdrant candidate-maintenance smoke passed.
