### PR TITLE
⚡ Implement schema migration hooks

### DIFF
--- a/docs/coding-agent/plans/active/v0-1-schema-migration-hooks-tests-plan.md
+++ b/docs/coding-agent/plans/active/v0-1-schema-migration-hooks-tests-plan.md
@@ -1,0 +1,193 @@
+# Plan: v0.1 Schema Migration Hooks And Tests
+
+- status: draft
+- generated: 2026-05-01
+- last_updated: 2026-05-01
+- work_type: code
+
+## Goal
+- Add explicit schema-version compatibility and migration seams for current persisted surfaces without introducing a second schema or overbuilding real migrations before they exist.
+
+## Definition of Done
+- Current schema version is accepted consistently at storage/payload/graph mapping boundaries.
+- Unsupported schema versions fail with clear, typed errors before silent persistence or payload mapping.
+- A minimal migration hook exists for future schema versions and has tested no-op behavior for the current schema.
+- Domain, Qdrant payload, and RDF graph mapping tests document the expected schema-version behavior.
+
+## Scope / Non-goals
+- Scope:
+  - Internal schema compatibility helpers.
+  - Validation at graph and vector persistence/mapping boundaries.
+  - Tests for current-version no-op behavior and unsupported-version failure behavior.
+- Non-goals:
+  - A real migration from an older schema.
+  - Backward compatibility with unmodeled historical schemas.
+  - Changing `DEFAULT_SCHEMA_VERSION`.
+  - Persistent Oxigraph or Qdrant/Oxigraph reconciliation.
+
+## Context (workspace)
+- Related files/areas:
+  - `src/api/types/domain.rs`
+  - `src/api/types/draft.rs`
+  - `src/internal/infrastructures/graph/rdf_mapping.rs`
+  - `src/internal/infrastructures/graph/oxigraph_authority_store.rs`
+  - `src/internal/infrastructures/external_services/qdrant_payload.rs`
+  - `src/internal/models/vector/record.rs`
+  - `src/errors/custom.rs`
+- Existing patterns or references:
+  - Domain objects already carry `schema_version`.
+  - Qdrant payloads and RDF triples already include schema-version fields.
+  - Draft defaults use `DEFAULT_SCHEMA_VERSION`.
+- Repo reference docs consulted:
+  - `docs/coding-agent/rules/index.md`
+  - `docs/coding-agent/rules/common.md`
+  - `docs/coding-agent/rules/orchestrator.md`
+  - `docs/coding-agent/lessons.md`
+  - `docs/decisions/implementation/ADR-I-0007-schema-versioning.md`
+  - `docs/design/roadmap-phases/v0_1_storage_and_backend_contracts.md`
+
+## Open Questions (max 3)
+- Q1: Should unsupported schema rejection live in domain `validate()` or only at persistence/import boundaries?
+
+## Assumptions
+- A1: The first implementation should validate current compatibility and fail unsupported versions rather than transforming records.
+- A2: Domain objects may still represent records with non-current versions if future import/migration code needs that, so persistence-boundary rejection is the safer default.
+- A3: Error messages should use stable schema language, not roadmap version labels.
+
+## Tasks
+
+### Task_1: Define Internal Schema Compatibility Boundary
+- type: impl
+- owns:
+  - `src/internal/**`
+  - `src/errors/custom.rs`
+- depends_on: []
+- description: |
+  Add an internal compatibility/migration seam that can validate schema versions, expose current no-op migration behavior, and return clear errors for unsupported versions.
+- acceptance:
+  - Current schema is accepted by a single reusable helper.
+  - Unsupported schema produces a clear `CustomError` variant or message appropriate for storage/mapping failures.
+  - The helper does not expose backend-specific types or public migration APIs.
+  - Tests cover accepted current schema and rejected unsupported schema.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo fmt --check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test api::types::domain --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal --lib"
+
+### Task_2: Apply Schema Checks To Graph And Vector Mapping Boundaries
+- type: impl
+- owns:
+  - `src/internal/infrastructures/graph/rdf_mapping.rs`
+  - `src/internal/infrastructures/graph/oxigraph_authority_store.rs`
+  - `src/internal/infrastructures/external_services/qdrant_payload.rs`
+  - `src/internal/models/vector/record.rs`
+- depends_on: [Task_1]
+- description: |
+  Wire schema compatibility checks into persistence and mapping paths that serialize records to RDF or Qdrant payloads. Ensure failures happen before unsupported records are silently written or indexed.
+- acceptance:
+  - RDF mapping rejects unsupported schema versions for all durable memory object variants.
+  - Oxigraph upsert paths reject unsupported schema versions before committing graph mutations.
+  - Qdrant payload mapping rejects unsupported schema versions before point construction.
+  - Existing current-schema fixtures continue to pass.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::infrastructures::graph --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::infrastructures::external_services::qdrant_payload --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo check"
+
+### Task_3: Add Migration Hook Regression Tests
+- type: test
+- owns:
+  - `src/api/types/domain/tests.rs`
+  - `src/internal/infrastructures/graph/rdf_mapping.rs`
+  - `src/internal/infrastructures/external_services/qdrant_payload.rs`
+  - `src/internal/repositories/test_support.rs`
+- depends_on: [Task_2]
+- description: |
+  Add regression tests that document current-version no-op migration behavior, unsupported-version failure behavior, and payload/triple schema-version preservation.
+- acceptance:
+  - Tests verify current schema version remains pinned to `EPISODIC_MEMORY_SCHEMA_VERSION`.
+  - Tests verify unsupported versions fail clearly at graph/vector mapping boundaries.
+  - Tests verify schema-version fields are preserved in RDF and Qdrant payload surfaces.
+  - Tests document that real forward migrations are intentionally absent until a second schema exists.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --no-run"
+
+### Task_4: Reviewer Gate
+- type: review
+- owns: []
+- depends_on: [Task_1, Task_2, Task_3]
+- description: |
+  Review the schema boundary for appropriate scope, failure behavior, and future migration extensibility.
+- acceptance:
+  - Reviewer status is APPROVED.
+  - Review confirms current-schema behavior is unchanged.
+  - Review confirms the plan did not add fake historical migrations or persistent-backend behavior.
+- validation:
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Diff review against ADR-I-0007 and storage/backend migration-test expectations"
+
+## Task Waves (explicit parallel dispatch sets)
+
+- Wave 1 (parallel): [Task_1]
+- Wave 2 (parallel): [Task_2]
+- Wave 3 (parallel): [Task_3]
+- Wave 4 (parallel): [Task_4]
+
+## E2E / Visual Validation Spec
+
+- Not applicable. Rust library/storage behavior only.
+
+## Rollback / Safety
+- Keep the helper internal and narrowly wired so rejection behavior can be adjusted without public API churn.
+- Avoid changing schema constants in this plan.
+
+## Progress Log (append-only)
+
+- 2026-05-01 00:00 Draft created.
+  - Summary: Split schema migration hooks/tests into their own v0.1 backend-contract plan.
+  - Validation evidence: Not run; plan only.
+  - Notes: Awaiting user approval before implementation.
+
+## Decision Log (append-only; re-plans and major discoveries)
+
+- 2026-05-01 00:00 Decision:
+  - Trigger / new insight: Prior repository assessment found schema fields/constants exist, but migration hooks and unsupported-version tests are not implemented.
+  - Plan delta (what changed): Created a standalone plan for schema compatibility and migration-test seams.
+  - Tradeoffs considered: Persistence-boundary rejection avoids constraining future import/migration representation in domain objects.
+  - User approval: no
+
+## Notes
+- Risks:
+  - Rejecting unsupported versions too deep may allow partial work before failure; the implementation should fail before graph/vector writes.
+  - Rejecting unsupported versions in domain validation may prevent future migration tooling from representing old objects.
+- Edge cases:
+  - Mixed object batches where one object has unsupported schema.
+  - Links with unsupported schema.
+  - Vector records produced from otherwise valid domain objects but carrying unsupported schema metadata.

--- a/docs/coding-agent/plans/completed/v0-1-schema-migration-hooks-tests-plan.md
+++ b/docs/coding-agent/plans/completed/v0-1-schema-migration-hooks-tests-plan.md
@@ -1,6 +1,6 @@
 # Plan: v0.1 Schema Migration Hooks And Tests
 
-- status: draft
+- status: done
 - generated: 2026-05-01
 - last_updated: 2026-05-01
 - work_type: code
@@ -47,7 +47,7 @@
   - `docs/design/roadmap-phases/v0_1_storage_and_backend_contracts.md`
 
 ## Open Questions (max 3)
-- Q1: Should unsupported schema rejection live in domain `validate()` or only at persistence/import boundaries?
+- Resolved: Unsupported schema rejection should live at persistence/import/mapping boundaries, not domain `validate()`.
 
 ## Assumptions
 - A1: The first implementation should validate current compatibility and fail unsupported versions rather than transforming records.
@@ -115,6 +115,7 @@
 ### Task_3: Add Migration Hook Regression Tests
 - type: test
 - owns:
+  - `src/internal/schema.rs`
   - `src/api/types/domain/tests.rs`
   - `src/internal/infrastructures/graph/rdf_mapping.rs`
   - `src/internal/infrastructures/external_services/qdrant_payload.rs`
@@ -175,6 +176,26 @@
   - Validation evidence: Not run; plan only.
   - Notes: Awaiting user approval before implementation.
 
+- 2026-05-01 01:35 Wave 1 completed: [Task_1]
+  - Summary: Added internal schema compatibility helpers and typed unsupported-schema error.
+  - Validation evidence: Worker reported `cargo fmt --check`, `cargo test api::types::domain --lib`, and `cargo test internal --lib` passed after formatting.
+  - Notes: Initial `cargo fmt --check` failed before formatting, then passed after `cargo fmt`.
+
+- 2026-05-01 01:45 Wave 2 completed: [Task_2]
+  - Summary: Wired current-schema checks into RDF mapping, Oxigraph upserts, and Qdrant payload mapping.
+  - Validation evidence: Worker reported `cargo test internal::infrastructures::graph --lib`, `cargo test internal::infrastructures::external_services::qdrant_payload --lib`, and `cargo check` passed.
+  - Notes: `cargo check` passed with a dead-code warning for the intentionally introduced migration hook; Task_3 owns was expanded to cover `src/internal/schema.rs` for regression documentation or an explicit temporary suppression.
+
+- 2026-05-01 01:55 Wave 3 completed: [Task_3]
+  - Summary: Added regression coverage for current-schema no-op migration, absent forward migrations, RDF schema-version preservation, and Qdrant schema-version preservation.
+  - Validation evidence: Worker reported `cargo test --lib` and `cargo test --no-run` passed; optional `cargo fmt --check` and `cargo check` also passed.
+  - Notes: The intentionally future-facing migration hook now has a narrow documented dead-code allowance.
+
+- 2026-05-01 02:05 Wave 4 completed: [Task_4]
+  - Summary: Reviewer approved the schema boundary implementation with no findings.
+  - Validation evidence: Reviewer reran `cargo fmt --check`, `cargo check`, `cargo test internal::schema --lib`, `cargo test internal::infrastructures::graph --lib`, and `cargo test internal::infrastructures::external_services::qdrant_payload --lib`.
+  - Notes: Reviewer inspected worker evidence for full `cargo test --lib` and `cargo test --no-run`; live Qdrant remains out of scope for this plan.
+
 ## Decision Log (append-only; re-plans and major discoveries)
 
 - 2026-05-01 00:00 Decision:
@@ -182,6 +203,18 @@
   - Plan delta (what changed): Created a standalone plan for schema compatibility and migration-test seams.
   - Tradeoffs considered: Persistence-boundary rejection avoids constraining future import/migration representation in domain objects.
   - User approval: no
+
+- 2026-05-01 01:30 Decision:
+  - Trigger / new insight: User approved implementation and asked to resolve open questions before work.
+  - Plan delta (what changed): Marked the plan in progress and resolved schema-version rejection to persistence/import/mapping boundaries.
+  - Tradeoffs considered: Keeping domain validation schema-version-neutral preserves future ability to represent old records before migration.
+  - User approval: yes
+
+- 2026-05-01 01:45 Decision:
+  - Trigger / new insight: Task_2 validation passed with an unused-hook warning for `migrate_current_schema`.
+  - Plan delta (what changed): Expanded Task_3 owns to include `src/internal/schema.rs` so the regression task can document or suppress the intentionally unused future migration hook within scope.
+  - Tradeoffs considered: Keeping the hook preserves the migration seam required by the plan; adding a narrow owned path avoids out-of-scope follow-up edits.
+  - User approval: yes
 
 ## Notes
 - Risks:

--- a/src/errors/custom.rs
+++ b/src/errors/custom.rs
@@ -29,6 +29,13 @@ pub enum CustomError {
     #[error("Database operation failed: {0}")]
     DatabaseError(String),
 
+    #[error("Unsupported schema version for {context}: expected {expected}, got {actual}")]
+    UnsupportedSchemaVersion {
+        context: &'static str,
+        expected: &'static str,
+        actual: String,
+    },
+
     #[error("Graph expansion root not found: {object_type:?} {object_id}")]
     GraphExpansionRootNotFound {
         object_type: ObjectType,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -2,3 +2,4 @@ pub(crate) mod config;
 pub(crate) mod infrastructures;
 pub(crate) mod models;
 pub(crate) mod repositories;
+pub(crate) mod schema;

--- a/src/internal/infrastructures/external_services/qdrant_payload.rs
+++ b/src/internal/infrastructures/external_services/qdrant_payload.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 
 use crate::errors::CustomError;
 use crate::internal::models::vector::{VectorRecord, VectorSurface};
+use crate::internal::schema::require_current_schema_version;
 
 pub(crate) const GRAPH_AUTHORITY_NOTE: &str =
     "Qdrant relationship ID fields are denormalized filter hints only; GraphAuthorityStore remains authoritative for relationships, provenance, lifecycle, currentness, and graph expansion.";
@@ -57,6 +58,8 @@ pub(crate) struct QdrantPayloadIndexField {
 pub(crate) fn qdrant_payload_map(
     record: &VectorRecord,
 ) -> Result<serde_json::Map<String, serde_json::Value>, CustomError> {
+    require_current_schema_version(&record.schema_version, "Qdrant payload mapping")?;
+
     let payload = QdrantVectorPayload::from(record);
     serde_json::to_value(payload)?
         .as_object()
@@ -348,6 +351,13 @@ mod tests {
     }
 
     #[test]
+    fn payload_preserves_schema_version_field() {
+        let payload = qdrant_payload_map(&derived_memory_record(id(40))).expect("payload maps");
+
+        assert_eq!(payload[SCHEMA_VERSION_FIELD], json!(DEFAULT_SCHEMA_VERSION));
+    }
+
+    #[test]
     fn payload_preserves_raw_ref_without_full_raw_transcript_field() {
         let record = VectorRecord::new(
             id(10),
@@ -374,6 +384,22 @@ mod tests {
     }
 
     #[test]
+    fn payload_mapping_rejects_unsupported_schema_versions() {
+        let mut record = derived_memory_record(id(40));
+        record.schema_version = "future_schema".to_owned();
+
+        let error = qdrant_payload_map(&record).expect_err("unsupported schema fails");
+
+        assert!(matches!(
+            error,
+            CustomError::UnsupportedSchemaVersion {
+                context: "Qdrant payload mapping",
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn index_helper_covers_high_value_filter_fields() {
         let fields = qdrant_payload_index_fields();
         let names: Vec<_> = fields.iter().map(|field| field.name).collect();
@@ -382,6 +408,7 @@ mod tests {
             OBJECT_TYPE_FIELD,
             RECORD_TYPE_FIELD,
             DERIVED_TYPE_FIELD,
+            SCHEMA_VERSION_FIELD,
             ENTITY_IDS_FIELD,
             THREAD_IDS_FIELD,
             EPISODE_IDS_FIELD,

--- a/src/internal/infrastructures/graph/oxigraph_authority_store.rs
+++ b/src/internal/infrastructures/graph/oxigraph_authority_store.rs
@@ -145,32 +145,44 @@ fn quads_for_triples(
 #[async_trait]
 impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
     async fn upsert_objects(&self, objects: &[MemoryObject]) -> Result<(), CustomError> {
+        let mut replacements = Vec::new();
         for object in objects {
             object
                 .validate()
                 .map_err(|error| CustomError::MemoryValidation(error.to_string()))?;
             let (object_id, object_type) = object_identity(object);
-            self.replace_triples(
-                graph_uri(object_type, object_id),
-                &rdf_triples_for_object(object),
-            )?;
+            let owner_graph_uri = graph_uri(object_type, object_id);
+            replacements.push((
+                owner_graph_uri.clone(),
+                quads_for_triples(&owner_graph_uri, &rdf_triples_for_object(object)?)?,
+            ));
+        }
 
-            let mut stored = lock(&self.objects)?;
+        self.replace_triples_batch(replacements)?;
+
+        let mut stored = lock(&self.objects)?;
+        for object in objects {
             stored.insert(object_identity(object), object.clone());
         }
         Ok(())
     }
 
     async fn upsert_links(&self, links: &[MemoryLink]) -> Result<(), CustomError> {
+        let mut replacements = Vec::new();
         for link in links {
             link.validate()
                 .map_err(|error| CustomError::MemoryValidation(error.to_string()))?;
-            self.replace_triples(
-                graph_uri(ObjectType::MemoryLink, link.id),
-                &rdf_triples_for_link(link),
-            )?;
+            let owner_graph_uri = graph_uri(ObjectType::MemoryLink, link.id);
+            replacements.push((
+                owner_graph_uri.clone(),
+                quads_for_triples(&owner_graph_uri, &rdf_triples_for_link(link)?)?,
+            ));
+        }
 
-            let mut stored = lock(&self.links)?;
+        self.replace_triples_batch(replacements)?;
+
+        let mut stored = lock(&self.links)?;
+        for link in links {
             stored.insert(link.id, link.clone());
         }
         Ok(())
@@ -190,7 +202,7 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
             let owner_graph_uri = graph_uri(object_type, object_id);
             replacements.push((
                 owner_graph_uri.clone(),
-                quads_for_triples(&owner_graph_uri, &rdf_triples_for_object(object))?,
+                quads_for_triples(&owner_graph_uri, &rdf_triples_for_object(object)?)?,
             ));
         }
 
@@ -200,7 +212,7 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
             let owner_graph_uri = graph_uri(ObjectType::MemoryLink, link.id);
             replacements.push((
                 owner_graph_uri.clone(),
-                quads_for_triples(&owner_graph_uri, &rdf_triples_for_link(link))?,
+                quads_for_triples(&owner_graph_uri, &rdf_triples_for_link(link)?)?,
             ));
         }
 
@@ -388,6 +400,93 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn oxigraph_upsert_objects_rejects_unsupported_schema_before_mutation() {
+        let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
+        let fixtures = representative_fixtures();
+        let mut unsupported = fixtures.salient_observation.clone();
+        unsupported.schema_version = "future_schema".to_owned();
+
+        let error = store
+            .upsert_objects(&[
+                MemoryObject::Episode(fixtures.episode.clone()),
+                MemoryObject::Observation(unsupported),
+            ])
+            .await
+            .expect_err("unsupported schema fails");
+
+        assert!(matches!(
+            error,
+            CustomError::UnsupportedSchemaVersion { .. }
+        ));
+        assert_eq!(store.triple_count().unwrap(), 0);
+        assert!(store
+            .query_objects(&GraphObjectQuery::by_ids(vec![fixtures.episode.id]))
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn oxigraph_upsert_links_rejects_unsupported_schema_before_mutation() {
+        let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
+        let fixtures = representative_fixtures();
+        store.upsert_objects(&fixtures.objects()).await.unwrap();
+        let baseline_triples = store.triple_count().unwrap();
+        let mut unsupported = fixtures.soft_thread_link.clone();
+        unsupported.id = MemoryId::new_v4();
+        unsupported.schema_version = "future_schema".to_owned();
+
+        let error = store
+            .upsert_links(&[fixtures.soft_thread_link.clone(), unsupported])
+            .await
+            .expect_err("unsupported schema fails");
+
+        assert!(matches!(
+            error,
+            CustomError::UnsupportedSchemaVersion { .. }
+        ));
+        assert_eq!(store.triple_count().unwrap(), baseline_triples);
+        assert!(store
+            .expand_bounded(&GraphExpansionQuery::new(
+                fixtures.salient_observation.id,
+                ObjectType::Observation,
+                1,
+                4,
+            ))
+            .await
+            .unwrap()
+            .links
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn oxigraph_combined_upsert_rejects_unsupported_schema_before_mutation() {
+        let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
+        let fixtures = representative_fixtures();
+        let mut unsupported = fixtures.soft_thread_link.clone();
+        unsupported.schema_version = "future_schema".to_owned();
+
+        let error = store
+            .upsert_objects_and_links(
+                &[MemoryObject::Episode(fixtures.episode.clone())],
+                &[unsupported],
+            )
+            .await
+            .expect_err("unsupported schema fails");
+
+        assert!(matches!(
+            error,
+            CustomError::UnsupportedSchemaVersion { .. }
+        ));
+        assert_eq!(store.triple_count().unwrap(), 0);
+        assert!(store
+            .query_objects(&GraphObjectQuery::by_ids(vec![fixtures.episode.id]))
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
     async fn oxigraph_store_replaces_stale_object_quads_on_repeated_upsert() {
         let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
         let fixtures = representative_fixtures();
@@ -421,7 +520,9 @@ mod tests {
         assert!(store.contains_triple(&replacement_summary).unwrap());
         assert_eq!(
             store.triple_count().unwrap(),
-            rdf_triples_for_object(&MemoryObject::Episode(updated_episode.clone())).len()
+            rdf_triples_for_object(&MemoryObject::Episode(updated_episode.clone()))
+                .unwrap()
+                .len()
         );
         assert_eq!(
             store

--- a/src/internal/infrastructures/graph/rdf_mapping.rs
+++ b/src/internal/infrastructures/graph/rdf_mapping.rs
@@ -9,6 +9,8 @@ use crate::api::types::{
     graph_uri, DerivedMemory, Entity, Episode, MemoryId, MemoryLink, MemoryObject, MemoryThread,
     ObjectType, Observation,
 };
+use crate::errors::CustomError;
+use crate::internal::schema::require_current_schema_version;
 
 use super::vocabulary as vocab;
 
@@ -51,18 +53,35 @@ impl RdfTriple {
     }
 }
 
-pub(crate) fn rdf_triples_for_object(object: &MemoryObject) -> Vec<RdfTriple> {
+pub(crate) fn rdf_triples_for_object(object: &MemoryObject) -> Result<Vec<RdfTriple>, CustomError> {
     match object {
-        MemoryObject::Episode(object) => episode_triples(object),
-        MemoryObject::Observation(object) => observation_triples(object),
-        MemoryObject::Entity(object) => entity_triples(object),
-        MemoryObject::MemoryThread(object) => memory_thread_triples(object),
-        MemoryObject::DerivedMemory(object) => derived_memory_triples(object),
+        MemoryObject::Episode(object) => {
+            require_current_schema_version(&object.schema_version, "RDF episode mapping")?;
+            Ok(episode_triples(object))
+        }
+        MemoryObject::Observation(object) => {
+            require_current_schema_version(&object.schema_version, "RDF observation mapping")?;
+            Ok(observation_triples(object))
+        }
+        MemoryObject::Entity(object) => {
+            require_current_schema_version(&object.schema_version, "RDF entity mapping")?;
+            Ok(entity_triples(object))
+        }
+        MemoryObject::MemoryThread(object) => {
+            require_current_schema_version(&object.schema_version, "RDF memory thread mapping")?;
+            Ok(memory_thread_triples(object))
+        }
+        MemoryObject::DerivedMemory(object) => {
+            require_current_schema_version(&object.schema_version, "RDF derived memory mapping")?;
+            Ok(derived_memory_triples(object))
+        }
         MemoryObject::MemoryLink(object) => rdf_triples_for_link(object),
     }
 }
 
-pub(crate) fn rdf_triples_for_link(link: &MemoryLink) -> Vec<RdfTriple> {
+pub(crate) fn rdf_triples_for_link(link: &MemoryLink) -> Result<Vec<RdfTriple>, CustomError> {
+    require_current_schema_version(&link.schema_version, "RDF memory link mapping")?;
+
     let subject = graph_uri(ObjectType::MemoryLink, link.id);
     let from = graph_uri(link.from_type, link.from_id);
     let to = graph_uri(link.to_type, link.to_id);
@@ -92,7 +111,7 @@ pub(crate) fn rdf_triples_for_link(link: &MemoryLink) -> Vec<RdfTriple> {
         vocab::RATIONALE,
         link.rationale.as_deref(),
     );
-    triples
+    Ok(triples)
 }
 
 fn episode_triples(episode: &Episode) -> Vec<RdfTriple> {
@@ -399,7 +418,7 @@ mod tests {
         let fixtures = representative_fixtures();
 
         for object in fixtures.objects() {
-            let triples = rdf_triples_for_object(&object);
+            let triples = rdf_triples_for_object(&object).expect("current schema maps");
             let (id, object_type) = object_identity(&object);
 
             assert!(triples
@@ -416,7 +435,8 @@ mod tests {
     fn rdf_mapping_covers_lifecycle_currentness_provenance_and_supersession() {
         let fixtures = representative_fixtures();
         let triples =
-            rdf_triples_for_object(&MemoryObject::DerivedMemory(fixtures.correction.clone()));
+            rdf_triples_for_object(&MemoryObject::DerivedMemory(fixtures.correction.clone()))
+                .expect("current schema maps");
 
         assert_contains_literal(&triples, vocab::SCHEMA_VERSION, DEFAULT_SCHEMA_VERSION);
         assert_contains_literal(&triples, vocab::IS_CURRENT, "true");
@@ -449,10 +469,27 @@ mod tests {
     }
 
     #[test]
+    fn rdf_mapping_preserves_schema_version_literals_for_objects_and_links() {
+        let fixtures = representative_fixtures();
+
+        for object in fixtures.objects() {
+            let triples = rdf_triples_for_object(&object).expect("current schema maps");
+
+            assert_contains_literal(&triples, vocab::SCHEMA_VERSION, DEFAULT_SCHEMA_VERSION);
+        }
+
+        for link in fixtures.links() {
+            let triples = rdf_triples_for_link(&link).expect("current schema maps");
+
+            assert_contains_literal(&triples, vocab::SCHEMA_VERSION, DEFAULT_SCHEMA_VERSION);
+        }
+    }
+
+    #[test]
     fn rdf_mapping_reifies_memory_links_and_adds_typed_relation_triples() {
         let fixtures = representative_fixtures();
         let link = fixtures.soft_thread_link;
-        let triples = rdf_triples_for_link(&link);
+        let triples = rdf_triples_for_link(&link).expect("current schema maps");
         let from = graph_uri(link.from_type, link.from_id);
         let to = graph_uri(link.to_type, link.to_id);
 
@@ -464,6 +501,48 @@ mod tests {
                 && triple.predicate == "urn:cmem:relation:part_of_thread"
                 && triple.object == RdfObject::Resource(to.clone())
         }));
+    }
+
+    #[test]
+    fn rdf_mapping_rejects_unsupported_schema_versions_for_all_object_variants() {
+        let fixtures = representative_fixtures();
+        let mut objects = fixtures.objects();
+        objects.push(MemoryObject::MemoryLink(fixtures.soft_thread_link));
+
+        for mut object in objects {
+            set_schema_version(&mut object, "future_schema");
+
+            let error = rdf_triples_for_object(&object).expect_err("unsupported schema fails");
+
+            assert!(
+                matches!(
+                    error,
+                    CustomError::UnsupportedSchemaVersion {
+                        expected: DEFAULT_SCHEMA_VERSION,
+                        ref actual,
+                        ..
+                    } if actual == "future_schema"
+                ),
+                "expected unsupported schema error for {object:?}, got {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rdf_link_mapping_rejects_unsupported_schema_versions() {
+        let fixtures = representative_fixtures();
+        let mut link = fixtures.soft_thread_link;
+        link.schema_version = "future_schema".to_owned();
+
+        let error = rdf_triples_for_link(&link).expect_err("unsupported schema fails");
+
+        assert!(matches!(
+            error,
+            CustomError::UnsupportedSchemaVersion {
+                context: "RDF memory link mapping",
+                ..
+            }
+        ));
     }
 
     fn assert_contains_literal(triples: &[RdfTriple], predicate: &'static str, value: &str) {
@@ -486,6 +565,19 @@ mod tests {
             MemoryObject::MemoryThread(object) => (object.id, object.object_type),
             MemoryObject::DerivedMemory(object) => (object.id, object.object_type),
             MemoryObject::MemoryLink(object) => (object.id, object.object_type),
+        }
+    }
+
+    fn set_schema_version(object: &mut MemoryObject, schema_version: &str) {
+        match object {
+            MemoryObject::Episode(object) => object.schema_version = schema_version.to_owned(),
+            MemoryObject::Observation(object) => object.schema_version = schema_version.to_owned(),
+            MemoryObject::Entity(object) => object.schema_version = schema_version.to_owned(),
+            MemoryObject::MemoryThread(object) => object.schema_version = schema_version.to_owned(),
+            MemoryObject::DerivedMemory(object) => {
+                object.schema_version = schema_version.to_owned()
+            }
+            MemoryObject::MemoryLink(object) => object.schema_version = schema_version.to_owned(),
         }
     }
 }

--- a/src/internal/schema.rs
+++ b/src/internal/schema.rs
@@ -1,0 +1,88 @@
+use crate::api::types::CURRENT_SCHEMA_VERSION;
+use crate::errors::CustomError;
+
+pub(crate) fn require_current_schema_version(
+    schema_version: &str,
+    context: &'static str,
+) -> Result<(), CustomError> {
+    if schema_version == CURRENT_SCHEMA_VERSION {
+        return Ok(());
+    }
+
+    Err(CustomError::UnsupportedSchemaVersion {
+        context,
+        expected: CURRENT_SCHEMA_VERSION,
+        actual: schema_version.to_owned(),
+    })
+}
+
+// This seam is intentionally unused by production paths while only the current
+// schema exists; boundary code should reject unsupported versions until a
+// second schema introduces a real migration.
+#[allow(dead_code)]
+pub(crate) fn migrate_current_schema<T>(
+    value: T,
+    schema_version: &str,
+    context: &'static str,
+) -> Result<T, CustomError> {
+    require_current_schema_version(schema_version, context)?;
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_schema_version_is_accepted() {
+        assert!(
+            require_current_schema_version(CURRENT_SCHEMA_VERSION, "test storage boundary").is_ok()
+        );
+    }
+
+    #[test]
+    fn current_schema_migration_is_a_noop() {
+        let value = String::from("unchanged");
+
+        let migrated = migrate_current_schema(
+            value.clone(),
+            CURRENT_SCHEMA_VERSION,
+            "test mapping boundary",
+        )
+        .expect("current schema should migrate without changes");
+
+        assert_eq!(migrated, value);
+    }
+
+    #[test]
+    fn forward_migrations_are_absent_until_a_second_schema_exists() {
+        let value = String::from("unchanged");
+
+        let error = migrate_current_schema(value, "future_schema", "test migration boundary")
+            .expect_err("unsupported schema should not be migrated without a real migration");
+
+        assert!(matches!(
+            error,
+            CustomError::UnsupportedSchemaVersion {
+                context: "test migration boundary",
+                expected: CURRENT_SCHEMA_VERSION,
+                actual
+            } if actual == "future_schema"
+        ));
+    }
+
+    #[test]
+    fn unsupported_schema_version_is_rejected_with_context() {
+        let error = require_current_schema_version("future_schema", "test storage boundary")
+            .expect_err("unsupported schema should fail");
+
+        assert!(matches!(
+            error,
+            CustomError::UnsupportedSchemaVersion {
+                context: "test storage boundary",
+                expected: CURRENT_SCHEMA_VERSION,
+                actual
+            } if actual == "future_schema"
+        ));
+    }
+}


### PR DESCRIPTION
### Motivation and Context

Implements the v0.1 storage/backend schema-version boundary plan. The repo already carried schema-version fields in domain records, RDF triples, and Qdrant payloads, but unsupported schema versions were not rejected at persistence/mapping boundaries and no migration seam existed for future schema evolution.

### Description

- Adds an internal schema compatibility module with current-schema validation and a documented no-op migration seam.
- Adds `CustomError::UnsupportedSchemaVersion` for clear persistence/mapping boundary failures.
- Rejects unsupported schema versions in RDF mapping, Oxigraph graph upserts, and Qdrant payload mapping before silent writes/indexing.
- Adds regression coverage for schema-version preservation, unsupported-version rejection, current-schema no-op behavior, and absent forward migrations.
- Completes the execution plan by moving it from active to completed.

### Checklist

- [x] Service-free compile check passes
      `cargo check`
- [x] Service-free test target compilation passes
      `cargo test --no-run`
- [x] **Clippy** passes with warnings denied
      `cargo clippy --all-targets -- -D warnings`
- [x] Rust formatting check passes
      `cargo fmt --check`
- [x] Full Qdrant-backed integration tests pass in trusted same-repository CI or with local service configuration
      `cargo test --verbose`
- [x] Documentation updated where needed
- [x] BREAKING CHANGE? **No**
- [x] I didn’t break anyone

### Additional Notes

Validation also included reviewer reruns of focused schema, graph, and Qdrant payload tests. `cargo test --verbose` passed; Cargo emitted a non-fatal cache last-use warning about a readonly global cache database after tests completed.