### PR TITLE
⚡ Implement SPARQL-backed graph selectors

### DIFF
--- a/docs/coding-agent/lessons.md
+++ b/docs/coding-agent/lessons.md
@@ -21,6 +21,63 @@ Purpose:
 
 ## Entries
 
+## 2026-05-01 - Verify Copilot Re-Review Requests Against Repo Rule Before Trusting Them  [tags: tooling, review, git, workflow]
+
+Context:
+- Plan: PR #38 and PR #39 Copilot review-fix loop
+- Task/Wave: post-fix re-review request
+- Roles involved: Orchestrator
+
+Symptom:
+- Initially re-requested Copilot review with `gh pr edit --add-reviewer '@copilot'` and treated the successful exit as meaningful.
+- Then retried GraphQL `requestReviewsByLogin` but omitted the repo-recorded `union: true` input before checking the existing lesson.
+
+Root cause:
+- Did not consult the repo lessons/orchestrator guidance before performing a known-special Copilot re-review workflow.
+- Verified too late that `reviewRequests` and `latestReviews` had not changed for the current PR heads.
+
+Fix applied:
+- Switched to GitHub GraphQL `requestReviewsByLogin` with `userLogins: ["copilot-pull-request-reviewer"]` and retried with the repo-recorded `union: true` input.
+- Verified `reviewRequests`, `latestReviews`, and review-thread state through GraphQL instead of relying on `gh pr edit` exit code.
+
+Prevention:
+- Before any Copilot re-review request, search `docs/coding-agent/lessons.md` and repo orchestrator rules for the current required command shape.
+- Treat a Copilot review request as unverified until GraphQL shows either a queued `reviewRequests` entry or a new `latestReviews` entry on the current head SHA.
+- If GraphQL returns success but neither signal appears after polling, report that no fresh Copilot review was observed instead of claiming one happened.
+
+Evidence:
+- PR #38 current head `87ced4dcf60f3fa572435b306660f5f7081ec4a9` had all Copilot threads resolved; GraphQL retries produced a Copilot internal-error review at `2026-05-01T07:37:52Z` rather than a usable review.
+- PR #39 current head `704d39f04120d434e28a79713ea1c5090d73a38b` had all Copilot threads resolved; GraphQL retries produced a Copilot internal-error review at `2026-05-01T07:37:53Z` rather than a usable review.
+
+## 2026-05-01 - Follow Repository Branch Naming Over Generic Agent Prefix  [tags: git, tooling, assumptions]
+
+Context:
+- Plan: none
+- Task/Wave: branch creation for separate plan commits
+- Roles involved: Orchestrator
+
+Symptom:
+- Started creating a branch with a generic Codex-style name for plan commits.
+- User corrected the workflow to follow the repository's branch naming conventions instead.
+
+Root cause:
+- Applied the desktop default branch prefix before checking the repo's visible branch naming pattern.
+- The current branch already showed the local convention: `feature/YYYY-MM-DD/<slug>`.
+
+Fix applied:
+- Switched to repository-convention branch names for the remaining branch/commit work.
+- Treat the temporary generic branch name as a misstep to rename or replace before committing.
+
+Prevention:
+- Repo rule candidate:
+  - audience: orchestrator
+  - proposed rule: Before creating branches, inspect existing local branch naming patterns and follow the repository convention over generic tool defaults unless the user requests otherwise.
+- Dispatch/plan guardrail:
+  - For branch creation tasks, record the selected branch naming pattern before the first branch mutation.
+
+Evidence:
+- User correction on 2026-05-01: "Actually, follow the branch name conventions rather than using the codex name."
+
 ## 2026-04-30 - Re-request Copilot PR Review Through GraphQL When Add-Reviewer Is A No-Op  [tags: tooling, review, git]
 
 Context:

--- a/docs/coding-agent/plans/active/v0-1-sparql-backed-oxigraph-query-helpers-plan.md
+++ b/docs/coding-agent/plans/active/v0-1-sparql-backed-oxigraph-query-helpers-plan.md
@@ -1,0 +1,183 @@
+# Plan: v0.1 SPARQL-Backed Oxigraph Query Helpers
+
+- status: draft
+- generated: 2026-05-01
+- last_updated: 2026-05-01
+- work_type: code
+
+## Goal
+- Make the embedded Oxigraph graph authority prove its v0.1 graph-query behavior through RDF/SPARQL-backed selectors and regression tests, while keeping public/domain contracts backend-free.
+
+## Definition of Done
+- Internal SPARQL helpers execute against Oxigraph named graphs and return stable object refs or IDs.
+- Oxigraph graph-authority query methods use SPARQL-backed selection for the v0.1 query intents instead of relying only on sidecar maps for candidate selection.
+- Regression tests cover object lookup, provenance/thread/entity context, current-only filtering, suppressed/archived/superseded omission, deterministic ordering, and named-graph predicate regressions.
+- Existing public facade behavior remains unchanged.
+
+## Scope / Non-goals
+- Scope:
+  - Add internal SPARQL query helpers under graph infrastructure.
+  - Route Oxigraph query/expansion selection through those helpers where practical for v0.1 contracts.
+  - Keep domain object hydration from the existing canonical in-memory object cache unless a narrow helper needs only IDs.
+- Non-goals:
+  - Persistent Oxigraph storage configuration.
+  - Qdrant/Oxigraph reconciliation diagnostics.
+  - Public SPARQL APIs or backend-specific public types.
+  - Full RDF-to-domain object hydration.
+
+## Context (workspace)
+- Related files/areas:
+  - `src/internal/infrastructures/graph/oxigraph_authority_store.rs`
+  - `src/internal/infrastructures/graph/rdf_mapping.rs`
+  - `src/internal/infrastructures/graph/vocabulary.rs`
+  - `src/internal/repositories/graph_authority_store.rs`
+  - `src/internal/repositories/test_support.rs`
+- Existing patterns or references:
+  - Current Oxigraph adapter materializes RDF quads but query methods hydrate from sidecar domain-object/link maps.
+  - RDF triples are inserted into named graphs owned by canonical graph URIs.
+  - Existing helper algorithms in `graph_authority_store.rs` provide deterministic ordering and lifecycle semantics.
+- Repo reference docs consulted:
+  - `docs/coding-agent/rules/index.md`
+  - `docs/coding-agent/rules/common.md`
+  - `docs/coding-agent/rules/orchestrator.md`
+  - `docs/coding-agent/lessons.md`
+  - `docs/design/roadmap-phases/v0_1_storage_and_backend_contracts.md`
+  - `docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md`
+
+## Open Questions (max 3)
+- Q1: Should SPARQL helpers only return IDs/object refs and let the cache hydrate canonical objects for v0.1?
+- Q2: Should any literal values be upgraded to typed RDF literals now, or should SPARQL account for current simple-string literals?
+
+## Assumptions
+- A1: SPARQL/Oxigraph types remain internal to `src/internal/infrastructures/graph/**`.
+- A2: Persistent graph authority and drift diagnostics stay deferred to v0.1.1.
+- A3: Existing deterministic ordering semantics should be preserved even if SPARQL result ordering differs.
+
+## Tasks
+
+### Task_1: Add SPARQL Selector Layer
+- type: impl
+- owns:
+  - `src/internal/infrastructures/graph/**`
+- depends_on: []
+- description: |
+  Add internal helpers that execute SPARQL against the embedded Oxigraph `Store` and return backend-neutral IDs/object refs for v0.1 graph query intents. Keep helper signatures private/internal and avoid leaking Oxigraph types outside graph infrastructure.
+- acceptance:
+  - Helpers can select objects by ID/type from RDF triples across named graphs.
+  - Helpers can select derived memories by provenance, thread, and entity predicates.
+  - Helpers can identify lifecycle/currentness predicates needed for default filtering.
+  - Helpers account for named graphs via `GRAPH ?g { ... }` or equivalent.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo fmt --check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::infrastructures::graph::oxigraph_authority_store --lib"
+
+### Task_2: Route Oxigraph Query Methods Through SPARQL Selectors
+- type: impl
+- owns:
+  - `src/internal/infrastructures/graph/oxigraph_authority_store.rs`
+- depends_on: [Task_1]
+- description: |
+  Update `GraphAuthorityStore` methods in the Oxigraph adapter to use SPARQL-backed selector results for candidate selection, then hydrate canonical objects/links from the existing in-memory cache. Preserve existing errors and deterministic sorting.
+- acceptance:
+  - `query_objects` uses SPARQL-selected refs before hydrating results.
+  - `query_derived_memories_by_provenance` and `query_derived_memories_by_thread` use SPARQL candidate selection and existing lifecycle semantics.
+  - `expand_bounded` uses SPARQL-visible graph refs/relations where practical while preserving bounded expansion behavior.
+  - Missing graph roots still produce the existing `GraphExpansionRootNotFound` behavior.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::infrastructures::graph::oxigraph_authority_store --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::repositories::retrieve_pipeline --lib"
+
+### Task_3: Add SPARQL Regression Coverage
+- type: test
+- owns:
+  - `src/internal/infrastructures/graph/oxigraph_authority_store.rs`
+  - `src/internal/infrastructures/graph/rdf_mapping.rs`
+  - `src/internal/infrastructures/graph/vocabulary.rs`
+- depends_on: [Task_2]
+- description: |
+  Add focused regression tests that fail when RDF predicate names, named graph handling, lifecycle predicates, or provenance/thread selectors drift from the v0.1 contract.
+- acceptance:
+  - Tests prove RDF/SPARQL selection works for representative fixtures.
+  - Tests cover suppression, archive, non-current, and supersession filtering through graph-authority behavior.
+  - Tests cover deterministic retrieval behavior after SPARQL-backed graph verification.
+  - Tests document that memory links remain graph-only and are not vector-indexed records.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::infrastructures::graph --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --no-run"
+
+### Task_4: Reviewer Gate
+- type: review
+- owns: []
+- depends_on: [Task_1, Task_2, Task_3]
+- description: |
+  Review the SPARQL-backed implementation against the storage contract and repository boundaries.
+- acceptance:
+  - Reviewer status is APPROVED.
+  - Review confirms backend-specific types did not leak into public/domain/repository contracts.
+  - Review confirms persistent Oxigraph and reconciliation were not accidentally included.
+- validation:
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Diff review against plan acceptance and v0.1 storage/backend contract"
+
+## Task Waves (explicit parallel dispatch sets)
+
+- Wave 1 (parallel): [Task_1]
+- Wave 2 (parallel): [Task_2]
+- Wave 3 (parallel): [Task_3]
+- Wave 4 (parallel): [Task_4]
+
+## E2E / Visual Validation Spec
+
+- Not applicable. Rust library/storage behavior only.
+
+## Rollback / Safety
+- Keep the sidecar object/link cache as the hydration source during this plan so SPARQL selector regressions can be reverted without redesigning domain serialization.
+- If SPARQL selector behavior proves too broad for one implementation pass, keep cache-backed behavior and land selector regression tests first, then replan routing.
+
+## Progress Log (append-only)
+
+- 2026-05-01 00:00 Draft created.
+  - Summary: Split SPARQL-backed Oxigraph query helpers into its own v0.1 backend-contract plan.
+  - Validation evidence: Not run; plan only.
+  - Notes: Awaiting user approval before implementation.
+
+## Decision Log (append-only; re-plans and major discoveries)
+
+- 2026-05-01 00:00 Decision:
+  - Trigger / new insight: Prior repository assessment found RDF materialization exists, but query behavior still relies on sidecar maps rather than SPARQL regression coverage.
+  - Plan delta (what changed): Created a standalone plan for SPARQL-backed query helpers and regression tests.
+  - Tradeoffs considered: Full RDF-to-domain hydration is deferred to avoid expanding the feature beyond v0.1 query contracts.
+  - User approval: no
+
+## Notes
+- Risks:
+  - Oxigraph named graph syntax and simple-string literals may make SPARQL filters more brittle than existing Rust helper filters.
+  - The plan should preserve deterministic ordering in Rust even if SPARQL result ordering is not stable.
+- Edge cases:
+  - Missing graph root.
+  - Duplicate relation quads owned by different links.
+  - Superseded derived memories where supersession evidence comes from relation links.

--- a/docs/coding-agent/plans/completed/v0-1-sparql-backed-oxigraph-query-helpers-plan.md
+++ b/docs/coding-agent/plans/completed/v0-1-sparql-backed-oxigraph-query-helpers-plan.md
@@ -1,6 +1,6 @@
 # Plan: v0.1 SPARQL-Backed Oxigraph Query Helpers
 
-- status: draft
+- status: done
 - generated: 2026-05-01
 - last_updated: 2026-05-01
 - work_type: code
@@ -45,8 +45,8 @@
   - `docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md`
 
 ## Open Questions (max 3)
-- Q1: Should SPARQL helpers only return IDs/object refs and let the cache hydrate canonical objects for v0.1?
-- Q2: Should any literal values be upgraded to typed RDF literals now, or should SPARQL account for current simple-string literals?
+- Resolved: SPARQL helpers should return IDs/object refs and let the existing cache hydrate canonical objects for v0.1.
+- Resolved: Do not upgrade literal values to typed RDF literals in this plan; SPARQL should account for the current simple-string mapping.
 
 ## Assumptions
 - A1: SPARQL/Oxigraph types remain internal to `src/internal/infrastructures/graph/**`.
@@ -165,6 +165,26 @@
   - Validation evidence: Not run; plan only.
   - Notes: Awaiting user approval before implementation.
 
+- 2026-05-01 02:20 Wave 1 completed: [Task_1]
+  - Summary: Added a private SPARQL selector layer under graph infrastructure for object refs, provenance/thread/entity derived memories, lifecycle predicates, and supersession evidence.
+  - Validation evidence: Worker reported `cargo fmt --check` and `cargo test internal::infrastructures::graph::oxigraph_authority_store --lib` passed after formatting; optional selector-specific tests also passed.
+  - Notes: Selector queries use separate named-graph patterns where relation evidence may be owned by link graph URIs.
+
+- 2026-05-01 02:35 Wave 2 completed: [Task_2]
+  - Summary: Routed Oxigraph object, derived-memory provenance/thread, and bounded-expansion candidate selection through SPARQL selectors while preserving cache hydration.
+  - Validation evidence: Worker reported `cargo check`, `cargo test internal::infrastructures::graph::oxigraph_authority_store --lib`, and `cargo test internal::repositories::retrieve_pipeline --lib` passed.
+  - Notes: Derived-memory selector limits are cleared before existing Rust lifecycle filtering and final limits are applied.
+
+- 2026-05-01 02:50 Wave 3 completed: [Task_3]
+  - Summary: Added regression coverage for RDF/SPARQL selection, named graph ownership, lifecycle filtering, deterministic retrieval, and graph-only memory links.
+  - Validation evidence: Worker reported `cargo test internal::infrastructures::graph --lib` and `cargo test --no-run` passed; optional `cargo fmt --check` passed after formatting.
+  - Notes: Vocabulary URI tests now pin graph-selection and lifecycle predicates used by SPARQL selectors.
+
+- 2026-05-01 03:00 Wave 4 completed: [Task_4]
+  - Summary: Reviewer approved the SPARQL selector implementation with no findings.
+  - Validation evidence: Reviewer reran `cargo fmt --check`, `cargo test internal::infrastructures::graph --lib`, and `cargo test --no-run`.
+  - Notes: Residual risk is intentionally v0.1-scoped selector coverage backed by cache/domain filtering.
+
 ## Decision Log (append-only; re-plans and major discoveries)
 
 - 2026-05-01 00:00 Decision:
@@ -172,6 +192,12 @@
   - Plan delta (what changed): Created a standalone plan for SPARQL-backed query helpers and regression tests.
   - Tradeoffs considered: Full RDF-to-domain hydration is deferred to avoid expanding the feature beyond v0.1 query contracts.
   - User approval: no
+
+- 2026-05-01 02:10 Decision:
+  - Trigger / new insight: User approved implementation and resolved open questions before work.
+  - Plan delta (what changed): Marked the plan in progress; resolved selector helpers to return IDs/object refs and to preserve current simple-string literal mapping.
+  - Tradeoffs considered: Avoiding RDF-to-domain hydration and typed-literal migration keeps this plan focused on SPARQL-backed selection and regression coverage.
+  - User approval: yes
 
 ## Notes
 - Risks:

--- a/src/internal/infrastructures/graph.rs
+++ b/src/internal/infrastructures/graph.rs
@@ -1,5 +1,6 @@
 mod oxigraph_authority_store;
 mod rdf_mapping;
+mod sparql_selectors;
 mod vocabulary;
 
 pub(crate) use oxigraph_authority_store::OxigraphGraphAuthorityStore;

--- a/src/internal/infrastructures/graph/oxigraph_authority_store.rs
+++ b/src/internal/infrastructures/graph/oxigraph_authority_store.rs
@@ -2,7 +2,7 @@
 // for contract reads while RDF triples are materialized into Oxigraph.
 #![allow(dead_code)]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, MutexGuard};
 
 use async_trait::async_trait;
@@ -14,10 +14,11 @@ use crate::errors::CustomError;
 use crate::internal::repositories::{
     bounded_expansion, derived_memories_by_provenance, derived_memories_by_thread,
     GraphAuthorityStore, GraphDerivedMemoryProvenanceQuery, GraphDerivedMemoryThreadQuery,
-    GraphExpansion, GraphExpansionQuery, GraphObjectQuery,
+    GraphExpansion, GraphExpansionQuery, GraphObjectQuery, GraphObjectRef,
 };
 
 use super::rdf_mapping::{rdf_triples_for_link, rdf_triples_for_object, RdfObject, RdfTriple};
+use super::sparql_selectors::SparqlGraphSelectors;
 
 pub(crate) struct OxigraphGraphAuthorityStore {
     store: Store,
@@ -104,6 +105,34 @@ impl OxigraphGraphAuthorityStore {
         for quad in self.store.iter() {
             let quad = quad.map_err(oxigraph_error)?;
             if quad.subject == subject && quad.predicate == predicate && quad.object == object {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+
+    #[cfg(test)]
+    fn contains_triple_in_graph(
+        &self,
+        triple: &RdfTriple,
+        owner_graph_uri: &str,
+    ) -> Result<bool, CustomError> {
+        let subject = NamedOrBlankNode::NamedNode(NamedNode::new(triple.subject.as_str())?);
+        let predicate = NamedNode::new(triple.predicate.as_str())?;
+        let graph_name = GraphName::NamedNode(NamedNode::new(owner_graph_uri)?);
+        let object = match &triple.object {
+            RdfObject::Resource(value) => Term::NamedNode(NamedNode::new(value.as_str())?),
+            RdfObject::Literal(value) => Term::Literal(Literal::new_simple_literal(value.as_str())),
+        };
+
+        for quad in self.store.iter() {
+            let quad = quad.map_err(oxigraph_error)?;
+            if quad.subject == subject
+                && quad.predicate == predicate
+                && quad.object == object
+                && quad.graph_name == graph_name
+            {
                 return Ok(true);
             }
         }
@@ -234,36 +263,29 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
         &self,
         query: &GraphObjectQuery,
     ) -> Result<Vec<MemoryObject>, CustomError> {
-        let mut objects: Vec<_> = lock(&self.objects)?
-            .values()
-            .filter(|object| {
-                let (object_id, object_type) = object_identity(object);
-                (query.object_refs.is_empty()
-                    || query.object_refs.iter().any(|object_ref| {
-                        object_ref.object_id == object_id && object_ref.object_type == object_type
-                    }))
-                    && (query.object_ids.is_empty() || query.object_ids.contains(&object_id))
-                    && (query.object_types.is_empty() || query.object_types.contains(&object_type))
-            })
-            .cloned()
-            .collect();
-
-        sort_objects(&mut objects);
-        if let Some(limit) = query.limit {
-            objects.truncate(limit);
-        }
-        Ok(objects)
+        let selected_refs = SparqlGraphSelectors::new(&self.store).select_objects(query)?;
+        let objects = lock(&self.objects)?;
+        Ok(hydrate_objects_by_refs(&selected_refs, &objects))
     }
 
     async fn query_derived_memories_by_provenance(
         &self,
         query: &GraphDerivedMemoryProvenanceQuery,
     ) -> Result<Vec<DerivedMemory>, CustomError> {
+        let mut selector_query = query.clone();
+        selector_query.limit = None;
+        let selected_ids = SparqlGraphSelectors::new(&self.store)
+            .select_derived_memories_by_provenance(&selector_query)?
+            .into_iter()
+            .collect::<HashSet<_>>();
+
         let objects = lock(&self.objects)?.clone();
         let links = lock(&self.links)?.clone();
         Ok(derived_memories_by_provenance(
             query,
-            objects.into_values(),
+            objects
+                .into_values()
+                .filter(|object| matches!(object, MemoryObject::DerivedMemory(memory) if selected_ids.contains(&memory.id))),
             links.into_values(),
         ))
     }
@@ -272,11 +294,20 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
         &self,
         query: &GraphDerivedMemoryThreadQuery,
     ) -> Result<Vec<DerivedMemory>, CustomError> {
+        let mut selector_query = query.clone();
+        selector_query.limit = None;
+        let selected_ids = SparqlGraphSelectors::new(&self.store)
+            .select_derived_memories_by_thread(&selector_query)?
+            .into_iter()
+            .collect::<HashSet<_>>();
+
         let objects = lock(&self.objects)?.clone();
         let links = lock(&self.links)?.clone();
         Ok(derived_memories_by_thread(
             query,
-            objects.into_values(),
+            objects
+                .into_values()
+                .filter(|object| matches!(object, MemoryObject::DerivedMemory(memory) if selected_ids.contains(&memory.id))),
             links.into_values(),
         ))
     }
@@ -285,10 +316,52 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
         &self,
         query: &GraphExpansionQuery,
     ) -> Result<GraphExpansion, CustomError> {
+        let graph_refs =
+            SparqlGraphSelectors::new(&self.store).select_objects(&GraphObjectQuery {
+                object_refs: Vec::new(),
+                object_ids: Vec::new(),
+                object_types: Vec::new(),
+                limit: None,
+            })?;
+        let graph_ref_set = graph_refs.iter().copied().collect::<HashSet<_>>();
+        let graph_link_ids = graph_refs
+            .iter()
+            .filter(|object_ref| object_ref.object_type == ObjectType::MemoryLink)
+            .map(|object_ref| object_ref.object_id)
+            .collect::<HashSet<_>>();
+
         let objects = lock(&self.objects)?.clone();
         let links = lock(&self.links)?.clone();
-        bounded_expansion(query, objects.into_values(), links.into_values())
+        bounded_expansion(
+            query,
+            objects
+                .into_values()
+                .filter(|object| graph_ref_set.contains(&graph_object_ref(object))),
+            links.into_values().filter(|link| {
+                graph_link_ids.contains(&link.id)
+                    && graph_ref_set.contains(&GraphObjectRef::new(link.from_id, link.from_type))
+                    && graph_ref_set.contains(&GraphObjectRef::new(link.to_id, link.to_type))
+            }),
+        )
     }
+}
+
+fn graph_object_ref(object: &MemoryObject) -> GraphObjectRef {
+    let (object_id, object_type) = object_identity(object);
+    GraphObjectRef::new(object_id, object_type)
+}
+
+fn hydrate_objects_by_refs(
+    refs: &[GraphObjectRef],
+    objects: &HashMap<(MemoryId, ObjectType), MemoryObject>,
+) -> Vec<MemoryObject> {
+    refs.iter()
+        .filter_map(|object_ref| {
+            objects
+                .get(&(object_ref.object_id, object_ref.object_type))
+                .cloned()
+        })
+        .collect()
 }
 
 fn quad_for_triple(owner_graph_uri: &str, triple: &RdfTriple) -> Result<Quad, CustomError> {
@@ -365,8 +438,8 @@ mod tests {
         RetentionState, RetrievalContext, ThreadStatus,
     };
     use crate::internal::models::vector::{
-        EmbeddingInput, VectorCandidateMatch, VectorCandidateSearch, VectorRecordEmbedding,
-        VectorSurface,
+        memory_object_vector_record, EmbeddingInput, VectorCandidateMatch, VectorCandidateSearch,
+        VectorRecordEmbedding, VectorSurface,
     };
     use crate::internal::repositories::test_support::{
         high_fanout_graph_fixture, representative_fixtures,
@@ -484,6 +557,35 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
+    }
+
+    #[tokio::test]
+    async fn oxigraph_queries_select_from_rdf_before_cache_hydration() {
+        let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
+        let fixtures = representative_fixtures();
+        let episode_graph = graph_uri(ObjectType::Episode, fixtures.episode.id);
+
+        store
+            .upsert_objects(&[MemoryObject::Episode(fixtures.episode.clone())])
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .query_objects(&GraphObjectQuery::by_ids(vec![fixtures.episode.id]))
+                .await
+                .unwrap(),
+            vec![MemoryObject::Episode(fixtures.episode.clone())]
+        );
+
+        store.replace_triples(episode_graph, &[]).unwrap();
+
+        assert_eq!(
+            store
+                .query_objects(&GraphObjectQuery::by_ids(vec![fixtures.episode.id]))
+                .await
+                .unwrap(),
+            Vec::<MemoryObject>::new()
+        );
     }
 
     #[tokio::test]
@@ -612,6 +714,37 @@ mod tests {
                 .links,
             vec![updated_link]
         );
+    }
+
+    #[tokio::test]
+    async fn oxigraph_link_quads_are_owned_by_memory_link_named_graphs() {
+        let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
+        let fixtures = representative_fixtures();
+        let link = fixtures.soft_thread_link.clone();
+        let relation_triple = RdfTriple {
+            subject: graph_uri(link.from_type, link.from_id),
+            predicate: vocab::relation_predicate("part_of_thread"),
+            object: RdfObject::Resource(graph_uri(link.to_type, link.to_id)),
+        };
+
+        store.upsert_objects(&fixtures.objects()).await.unwrap();
+        store
+            .upsert_links(std::slice::from_ref(&link))
+            .await
+            .unwrap();
+
+        assert!(store
+            .contains_triple_in_graph(
+                &relation_triple,
+                &graph_uri(ObjectType::MemoryLink, link.id)
+            )
+            .unwrap());
+        assert!(!store
+            .contains_triple_in_graph(
+                &relation_triple,
+                &graph_uri(ObjectType::Observation, fixtures.salient_observation.id)
+            )
+            .unwrap());
     }
 
     #[tokio::test]
@@ -967,6 +1100,20 @@ mod tests {
             filtered.object_ref == GraphObjectRef::new(archived_thread.id, ObjectType::MemoryThread)
                 && filtered.reason == GraphExpansionFilteredReason::Archived
         }));
+
+        let default_thread_matches = store
+            .query_derived_memories_by_thread(
+                &GraphDerivedMemoryThreadQuery::by_threads(vec![fixtures.soft_thread.id])
+                    .with_limit(10),
+            )
+            .await
+            .unwrap();
+        assert!(!default_thread_matches
+            .iter()
+            .any(|memory| memory.id == superseded_memory.id));
+        assert!(!default_thread_matches
+            .iter()
+            .any(|memory| memory.id == non_current_memory.id));
     }
 
     #[tokio::test]
@@ -1305,7 +1452,12 @@ mod tests {
             .retrieve(RetrievalContext::new("store contract continuity").with_trace())
             .await
             .unwrap();
+        let repeated = pipeline
+            .retrieve(RetrievalContext::new("store contract continuity").with_trace())
+            .await
+            .unwrap();
         let trace = outcome.trace.as_ref().unwrap();
+        let repeated_trace = repeated.trace.as_ref().unwrap();
         let included_assignments = trace
             .section_assignments
             .iter()
@@ -1335,6 +1487,30 @@ mod tests {
         }));
         assert_eq!(trace.vector_candidates.len(), 1);
         assert_eq!(trace.vector_candidates[0].object.id, fixtures.hub_entity.id);
+        assert_eq!(
+            trace
+                .section_assignments
+                .iter()
+                .map(|assignment| (assignment.object.id, assignment.section, assignment.rank))
+                .collect::<Vec<_>>(),
+            repeated_trace
+                .section_assignments
+                .iter()
+                .map(|assignment| (assignment.object.id, assignment.section, assignment.rank))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            trace
+                .graph_relations
+                .iter()
+                .map(|relation| (relation.from.id, relation.to.id, relation.relation))
+                .collect::<Vec<_>>(),
+            repeated_trace
+                .graph_relations
+                .iter()
+                .map(|relation| (relation.from.id, relation.to.id, relation.relation))
+                .collect::<Vec<_>>()
+        );
         assert!(trace.graph_relations.iter().any(|relation| {
             relation.from.id == fixtures.hub_entity.id
                 && relation.to.id == fixtures.episode.id
@@ -1344,6 +1520,43 @@ mod tests {
             assignment.object.id == fixtures.derived_reflection.id
                 && assignment.section == ContextPackSection::DerivedMemories
         }));
+    }
+
+    #[tokio::test]
+    async fn oxigraph_memory_links_are_graph_only_not_vector_indexed_records() {
+        let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
+        let fixtures = representative_fixtures();
+        let link = fixtures.soft_thread_link.clone();
+
+        store.upsert_objects(&fixtures.objects()).await.unwrap();
+        store
+            .upsert_links(std::slice::from_ref(&link))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            memory_object_vector_record(&MemoryObject::MemoryLink(link.clone())),
+            None
+        );
+        let graph_refs = store
+            .query_objects(&GraphObjectQuery::by_refs(vec![GraphObjectRef::new(
+                link.id,
+                ObjectType::MemoryLink,
+            )]))
+            .await
+            .unwrap();
+        assert_eq!(graph_refs, Vec::<MemoryObject>::new());
+
+        let expansion = store
+            .expand_bounded(&GraphExpansionQuery::new(
+                fixtures.salient_observation.id,
+                ObjectType::Observation,
+                1,
+                4,
+            ))
+            .await
+            .unwrap();
+        assert!(expansion.links.contains(&link));
     }
 
     #[derive(Debug)]

--- a/src/internal/infrastructures/graph/oxigraph_authority_store.rs
+++ b/src/internal/infrastructures/graph/oxigraph_authority_store.rs
@@ -316,13 +316,25 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
         &self,
         query: &GraphExpansionQuery,
     ) -> Result<GraphExpansion, CustomError> {
+        let selectors = SparqlGraphSelectors::new(&self.store);
+        let root_ref = GraphObjectRef::new(query.root_id, query.root_type);
+        let root_refs = selectors.select_objects(&GraphObjectQuery::by_refs(vec![root_ref]))?;
+        if root_refs.is_empty() {
+            return Err(CustomError::GraphExpansionRootNotFound {
+                object_type: query.root_type,
+                object_id: query.root_id,
+            });
+        }
+
+        let objects = lock(&self.objects)?.clone();
+        let links = lock(&self.links)?.clone();
+        let expansion = bounded_expansion(
+            query,
+            objects.clone().into_values(),
+            links.clone().into_values(),
+        )?;
         let graph_refs =
-            SparqlGraphSelectors::new(&self.store).select_objects(&GraphObjectQuery {
-                object_refs: Vec::new(),
-                object_ids: Vec::new(),
-                object_types: Vec::new(),
-                limit: None,
-            })?;
+            selectors.select_objects(&GraphObjectQuery::by_refs(expansion_refs(&expansion)))?;
         let graph_ref_set = graph_refs.iter().copied().collect::<HashSet<_>>();
         let graph_link_ids = graph_refs
             .iter()
@@ -330,8 +342,6 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
             .map(|object_ref| object_ref.object_id)
             .collect::<HashSet<_>>();
 
-        let objects = lock(&self.objects)?.clone();
-        let links = lock(&self.links)?.clone();
         bounded_expansion(
             query,
             objects
@@ -357,11 +367,50 @@ fn hydrate_objects_by_refs(
 ) -> Vec<MemoryObject> {
     refs.iter()
         .filter_map(|object_ref| {
-            objects
-                .get(&(object_ref.object_id, object_ref.object_type))
-                .cloned()
+            match objects.get(&(object_ref.object_id, object_ref.object_type)) {
+                Some(object) => Some(object.clone()),
+                None if object_ref.object_type == ObjectType::MemoryLink => None,
+                None => {
+                    debug_assert!(
+                        false,
+                        "SPARQL selected {object_ref:?} but canonical object cache could not hydrate it"
+                    );
+                    None
+                }
+            }
         })
         .collect()
+}
+
+fn expansion_refs(expansion: &GraphExpansion) -> Vec<GraphObjectRef> {
+    let mut refs = expansion
+        .objects
+        .iter()
+        .map(graph_object_ref)
+        .collect::<Vec<_>>();
+    refs.extend(
+        expansion
+            .links
+            .iter()
+            .map(|link| GraphObjectRef::new(link.id, ObjectType::MemoryLink)),
+    );
+    refs.extend(
+        expansion
+            .filtered_nodes
+            .iter()
+            .map(|filtered| filtered.object_ref),
+    );
+    for relation in &expansion.relations {
+        refs.push(relation.from);
+        refs.push(relation.to);
+        refs.push(GraphObjectRef::new(
+            relation.link_id,
+            ObjectType::MemoryLink,
+        ));
+    }
+    refs.sort_by_key(|object_ref| stable_node_key((object_ref.object_id, object_ref.object_type)));
+    refs.dedup();
+    refs
 }
 
 fn quad_for_triple(owner_graph_uri: &str, triple: &RdfTriple) -> Result<Quad, CustomError> {

--- a/src/internal/infrastructures/graph/oxigraph_authority_store.rs
+++ b/src/internal/infrastructures/graph/oxigraph_authority_store.rs
@@ -318,29 +318,32 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
     ) -> Result<GraphExpansion, CustomError> {
         let selectors = SparqlGraphSelectors::new(&self.store);
         let root_ref = GraphObjectRef::new(query.root_id, query.root_type);
-        let root_refs = selectors.select_objects(&GraphObjectQuery::by_refs(vec![root_ref]))?;
-        if root_refs.is_empty() {
+        let graph_refs = selectors.select_objects(&GraphObjectQuery::by_types(
+            vec![
+                ObjectType::Episode,
+                ObjectType::Observation,
+                ObjectType::Entity,
+                ObjectType::MemoryThread,
+                ObjectType::DerivedMemory,
+                ObjectType::MemoryLink,
+            ],
+            None,
+        ))?;
+        let graph_ref_set = graph_refs.iter().copied().collect::<HashSet<_>>();
+        if !graph_ref_set.contains(&root_ref) {
             return Err(CustomError::GraphExpansionRootNotFound {
                 object_type: query.root_type,
                 object_id: query.root_id,
             });
         }
 
-        let objects = lock(&self.objects)?.clone();
-        let links = lock(&self.links)?.clone();
-        let expansion = bounded_expansion(
-            query,
-            objects.clone().into_values(),
-            links.clone().into_values(),
-        )?;
-        let graph_refs =
-            selectors.select_objects(&GraphObjectQuery::by_refs(expansion_refs(&expansion)))?;
-        let graph_ref_set = graph_refs.iter().copied().collect::<HashSet<_>>();
         let graph_link_ids = graph_refs
             .iter()
             .filter(|object_ref| object_ref.object_type == ObjectType::MemoryLink)
             .map(|object_ref| object_ref.object_id)
             .collect::<HashSet<_>>();
+        let objects = lock(&self.objects)?.clone();
+        let links = lock(&self.links)?.clone();
 
         bounded_expansion(
             query,
@@ -380,37 +383,6 @@ fn hydrate_objects_by_refs(
             }
         })
         .collect()
-}
-
-fn expansion_refs(expansion: &GraphExpansion) -> Vec<GraphObjectRef> {
-    let mut refs = expansion
-        .objects
-        .iter()
-        .map(graph_object_ref)
-        .collect::<Vec<_>>();
-    refs.extend(
-        expansion
-            .links
-            .iter()
-            .map(|link| GraphObjectRef::new(link.id, ObjectType::MemoryLink)),
-    );
-    refs.extend(
-        expansion
-            .filtered_nodes
-            .iter()
-            .map(|filtered| filtered.object_ref),
-    );
-    for relation in &expansion.relations {
-        refs.push(relation.from);
-        refs.push(relation.to);
-        refs.push(GraphObjectRef::new(
-            relation.link_id,
-            ObjectType::MemoryLink,
-        ));
-    }
-    refs.sort_by_key(|object_ref| stable_node_key((object_ref.object_id, object_ref.object_type)));
-    refs.dedup();
-    refs
 }
 
 fn quad_for_triple(owner_graph_uri: &str, triple: &RdfTriple) -> Result<Quad, CustomError> {
@@ -946,6 +918,46 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![traversed_link.id]
         );
+    }
+
+    #[tokio::test]
+    async fn oxigraph_expansion_applies_bounds_after_graph_visibility_filtering() {
+        let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
+        let fixtures = representative_fixtures();
+        let graph_visible_link = fixtures.hub_links[1].clone();
+        let mut stale_cache_only_link = graph_visible_link.clone();
+        stale_cache_only_link.id = MemoryId::from_u128(0x550e_8400_e29b_41d4_a716_4466_5500_0001);
+        stale_cache_only_link.to_id = fixtures.episode.id;
+        stale_cache_only_link.to_type = ObjectType::Episode;
+        stale_cache_only_link.relation = RelationType::About;
+        stale_cache_only_link.rationale =
+            Some("Cache-only stale link should not consume fanout.".to_owned());
+
+        store.upsert_objects(&fixtures.objects()).await.unwrap();
+        store
+            .upsert_links(std::slice::from_ref(&graph_visible_link))
+            .await
+            .unwrap();
+        lock(&store.links)
+            .unwrap()
+            .insert(stale_cache_only_link.id, stale_cache_only_link.clone());
+
+        let expansion = store
+            .expand_bounded(
+                &GraphExpansionQuery::new(fixtures.hub_entity.id, ObjectType::Entity, 1, 3)
+                    .with_max_fanout_per_node(1),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(expansion.links, vec![graph_visible_link.clone()]);
+        assert!(!expansion.links.contains(&stale_cache_only_link));
+        assert!(expansion
+            .objects
+            .contains(&MemoryObject::Entity(fixtures.hub_entity.clone())));
+        assert!(expansion.objects.contains(&MemoryObject::DerivedMemory(
+            fixtures.derived_reflection.clone()
+        )));
     }
 
     #[tokio::test]

--- a/src/internal/infrastructures/graph/oxigraph_authority_store.rs
+++ b/src/internal/infrastructures/graph/oxigraph_authority_store.rs
@@ -318,45 +318,109 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
     ) -> Result<GraphExpansion, CustomError> {
         let selectors = SparqlGraphSelectors::new(&self.store);
         let root_ref = GraphObjectRef::new(query.root_id, query.root_type);
-        let graph_refs = selectors.select_objects(&GraphObjectQuery::by_types(
-            vec![
-                ObjectType::Episode,
-                ObjectType::Observation,
-                ObjectType::Entity,
-                ObjectType::MemoryThread,
-                ObjectType::DerivedMemory,
-                ObjectType::MemoryLink,
-            ],
-            None,
-        ))?;
-        let graph_ref_set = graph_refs.iter().copied().collect::<HashSet<_>>();
-        if !graph_ref_set.contains(&root_ref) {
+        let root_refs = selectors.select_objects(&GraphObjectQuery::by_refs(vec![root_ref]))?;
+        if root_refs.is_empty() {
             return Err(CustomError::GraphExpansionRootNotFound {
                 object_type: query.root_type,
                 object_id: query.root_id,
             });
         }
 
-        let graph_link_ids = graph_refs
-            .iter()
-            .filter(|object_ref| object_ref.object_type == ObjectType::MemoryLink)
-            .map(|object_ref| object_ref.object_id)
-            .collect::<HashSet<_>>();
-        let objects = lock(&self.objects)?.clone();
-        let links = lock(&self.links)?.clone();
+        let (graph_ref_set, graph_link_ids, lifecycle_link_ids) =
+            bounded_graph_visible_refs(&selectors, root_ref, query)?;
+        let objects = {
+            let objects = lock(&self.objects)?;
+            hydrate_objects_by_ref_set(&graph_ref_set, &objects)
+        };
+        let links = {
+            let links = lock(&self.links)?;
+            hydrate_links_by_id_sets(&graph_link_ids, &lifecycle_link_ids, &graph_ref_set, &links)
+        };
 
-        bounded_expansion(
-            query,
-            objects
-                .into_values()
-                .filter(|object| graph_ref_set.contains(&graph_object_ref(object))),
-            links.into_values().filter(|link| {
-                graph_link_ids.contains(&link.id)
-                    && graph_ref_set.contains(&GraphObjectRef::new(link.from_id, link.from_type))
-                    && graph_ref_set.contains(&GraphObjectRef::new(link.to_id, link.to_type))
-            }),
-        )
+        bounded_expansion(query, objects, links)
     }
+}
+
+fn bounded_graph_visible_refs(
+    selectors: &SparqlGraphSelectors<'_>,
+    root_ref: GraphObjectRef,
+    query: &GraphExpansionQuery,
+) -> Result<
+    (
+        HashSet<GraphObjectRef>,
+        HashSet<MemoryId>,
+        HashSet<MemoryId>,
+    ),
+    CustomError,
+> {
+    let mut graph_refs = HashSet::from([root_ref]);
+    let mut graph_link_ids = HashSet::new();
+    let mut frontier = vec![root_ref];
+
+    for _ in 0..query.max_depth {
+        let link_refs = selectors.select_links_touching(&frontier)?;
+        let mut next_frontier = Vec::new();
+        for link_ref in link_refs {
+            graph_link_ids.insert(link_ref.link_id);
+            for endpoint in [link_ref.from, link_ref.to] {
+                if graph_refs.insert(endpoint) {
+                    next_frontier.push(endpoint);
+                }
+            }
+        }
+
+        if next_frontier.is_empty() {
+            break;
+        }
+        frontier = next_frontier;
+    }
+
+    let candidate_refs = graph_refs.iter().copied().collect::<Vec<_>>();
+    let lifecycle_link_ids = selectors
+        .select_links_touching(&candidate_refs)?
+        .into_iter()
+        .filter(|link_ref| {
+            link_ref.relation == crate::api::types::RelationType::Supersedes
+                && link_ref.to.object_type == ObjectType::DerivedMemory
+                && graph_refs.contains(&link_ref.to)
+        })
+        .map(|link_ref| link_ref.link_id)
+        .collect::<HashSet<_>>();
+
+    Ok((graph_refs, graph_link_ids, lifecycle_link_ids))
+}
+
+fn hydrate_objects_by_ref_set(
+    refs: &HashSet<GraphObjectRef>,
+    objects: &HashMap<(MemoryId, ObjectType), MemoryObject>,
+) -> Vec<MemoryObject> {
+    refs.iter()
+        .filter_map(|object_ref| {
+            objects
+                .get(&(object_ref.object_id, object_ref.object_type))
+                .cloned()
+        })
+        .collect()
+}
+
+fn hydrate_links_by_id_sets(
+    graph_link_ids: &HashSet<MemoryId>,
+    lifecycle_link_ids: &HashSet<MemoryId>,
+    graph_ref_set: &HashSet<GraphObjectRef>,
+    links: &HashMap<MemoryId, MemoryLink>,
+) -> Vec<MemoryLink> {
+    graph_link_ids
+        .union(lifecycle_link_ids)
+        .filter_map(|link_id| links.get(link_id))
+        .filter(|link| {
+            let endpoints_in_graph = graph_ref_set
+                .contains(&GraphObjectRef::new(link.from_id, link.from_type))
+                && graph_ref_set.contains(&GraphObjectRef::new(link.to_id, link.to_type));
+            (graph_link_ids.contains(&link.id) && endpoints_in_graph)
+                || lifecycle_link_ids.contains(&link.id)
+        })
+        .cloned()
+        .collect()
 }
 
 fn graph_object_ref(object: &MemoryObject) -> GraphObjectRef {
@@ -958,6 +1022,104 @@ mod tests {
         assert!(expansion.objects.contains(&MemoryObject::DerivedMemory(
             fixtures.derived_reflection.clone()
         )));
+    }
+
+    #[tokio::test]
+    async fn oxigraph_expansion_uses_targeted_supersession_evidence_outside_frontier() {
+        let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
+        let fixtures = representative_fixtures();
+        let superseded_memory = fixtures.user_preference.clone();
+        let replacement = fixtures.correction.clone();
+        let hub_link = crate::api::types::MemoryLink {
+            id: MemoryId::from_u128(0x550e_8400_e29b_41d4_a716_4466_5500_0002),
+            object_type: ObjectType::MemoryLink,
+            from_id: fixtures.hub_entity.id,
+            from_type: ObjectType::Entity,
+            to_id: superseded_memory.id,
+            to_type: ObjectType::DerivedMemory,
+            relation: RelationType::About,
+            confidence: 1.0,
+            rationale: Some("Hub reaches a superseded memory.".to_owned()),
+            created_at: superseded_memory.created_at,
+            schema_version: superseded_memory.schema_version.clone(),
+        };
+        let supersedes_link = crate::api::types::MemoryLink {
+            id: MemoryId::from_u128(0x550e_8400_e29b_41d4_a716_4466_5500_0003),
+            object_type: ObjectType::MemoryLink,
+            from_id: replacement.id,
+            from_type: ObjectType::DerivedMemory,
+            to_id: superseded_memory.id,
+            to_type: ObjectType::DerivedMemory,
+            relation: RelationType::Supersedes,
+            confidence: 1.0,
+            rationale: Some("Replacement supersedes candidate memory.".to_owned()),
+            created_at: replacement.created_at,
+            schema_version: replacement.schema_version.clone(),
+        };
+
+        store
+            .upsert_objects(&[
+                MemoryObject::Entity(fixtures.hub_entity.clone()),
+                MemoryObject::DerivedMemory(superseded_memory.clone()),
+                MemoryObject::DerivedMemory(replacement.clone()),
+            ])
+            .await
+            .unwrap();
+        store
+            .upsert_links(&[hub_link.clone(), supersedes_link])
+            .await
+            .unwrap();
+
+        let depth_zero_root = store
+            .expand_bounded(&GraphExpansionQuery::new(
+                superseded_memory.id,
+                ObjectType::DerivedMemory,
+                0,
+                3,
+            ))
+            .await
+            .unwrap();
+        assert!(depth_zero_root.objects.is_empty());
+        assert!(depth_zero_root.filtered_nodes.iter().any(|filtered| {
+            filtered.object_ref
+                == GraphObjectRef::new(superseded_memory.id, ObjectType::DerivedMemory)
+                && filtered.reason == GraphExpansionFilteredReason::Superseded
+        }));
+
+        let depth_one_neighbor = store
+            .expand_bounded(&GraphExpansionQuery::new(
+                fixtures.hub_entity.id,
+                ObjectType::Entity,
+                1,
+                3,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            depth_one_neighbor.objects,
+            vec![MemoryObject::Entity(fixtures.hub_entity.clone())]
+        );
+        assert!(depth_one_neighbor.links.is_empty());
+        assert!(depth_one_neighbor.filtered_nodes.iter().any(|filtered| {
+            filtered.object_ref
+                == GraphObjectRef::new(superseded_memory.id, ObjectType::DerivedMemory)
+                && filtered.reason == GraphExpansionFilteredReason::Superseded
+        }));
+
+        let historical_neighbor = store
+            .expand_bounded(
+                &GraphExpansionQuery::new(fixtures.hub_entity.id, ObjectType::Entity, 1, 3)
+                    .with_lifecycle_policy(GraphExpansionLifecyclePolicy {
+                        include_superseded: true,
+                        ..GraphExpansionLifecyclePolicy::default()
+                    }),
+            )
+            .await
+            .unwrap();
+        assert!(historical_neighbor
+            .objects
+            .contains(&MemoryObject::DerivedMemory(superseded_memory)));
+        assert_eq!(historical_neighbor.links, vec![hub_link]);
     }
 
     #[tokio::test]

--- a/src/internal/infrastructures/graph/oxigraph_authority_store.rs
+++ b/src/internal/infrastructures/graph/oxigraph_authority_store.rs
@@ -326,33 +326,37 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
             });
         }
 
-        let (graph_ref_set, graph_link_ids, lifecycle_link_ids) =
-            bounded_graph_visible_refs(&selectors, root_ref, query)?;
+        let visibility = bounded_graph_visible_refs(&selectors, root_ref, query)?;
         let objects = {
             let objects = lock(&self.objects)?;
-            hydrate_objects_by_ref_set(&graph_ref_set, &objects)
+            hydrate_objects_by_ref_set(&visibility.object_refs, &objects)
         };
         let links = {
             let links = lock(&self.links)?;
-            hydrate_links_by_id_sets(&graph_link_ids, &lifecycle_link_ids, &graph_ref_set, &links)
+            hydrate_links_by_id_sets(
+                &visibility.traversal_link_ids,
+                &visibility.lifecycle_link_ids,
+                &visibility.object_refs,
+                &links,
+            )
         };
 
         bounded_expansion(query, objects, links)
     }
 }
 
+#[derive(Debug, Default)]
+struct BoundedGraphVisibility {
+    object_refs: HashSet<GraphObjectRef>,
+    traversal_link_ids: HashSet<MemoryId>,
+    lifecycle_link_ids: HashSet<MemoryId>,
+}
+
 fn bounded_graph_visible_refs(
     selectors: &SparqlGraphSelectors<'_>,
     root_ref: GraphObjectRef,
     query: &GraphExpansionQuery,
-) -> Result<
-    (
-        HashSet<GraphObjectRef>,
-        HashSet<MemoryId>,
-        HashSet<MemoryId>,
-    ),
-    CustomError,
-> {
+) -> Result<BoundedGraphVisibility, CustomError> {
     let mut graph_refs = HashSet::from([root_ref]);
     let mut graph_link_ids = HashSet::new();
     let mut frontier = vec![root_ref];
@@ -387,7 +391,11 @@ fn bounded_graph_visible_refs(
         .map(|link_ref| link_ref.link_id)
         .collect::<HashSet<_>>();
 
-    Ok((graph_refs, graph_link_ids, lifecycle_link_ids))
+    Ok(BoundedGraphVisibility {
+        object_refs: graph_refs,
+        traversal_link_ids: graph_link_ids,
+        lifecycle_link_ids,
+    })
 }
 
 fn hydrate_objects_by_ref_set(

--- a/src/internal/infrastructures/graph/sparql_selectors.rs
+++ b/src/internal/infrastructures/graph/sparql_selectors.rs
@@ -1,0 +1,519 @@
+// Internal SPARQL selectors for the embedded Oxigraph authority. These helpers
+// return backend-neutral IDs/refs; canonical object hydration stays in the cache.
+#![allow(dead_code)]
+
+use std::collections::HashSet;
+
+use oxigraph::model::Term;
+use oxigraph::sparql::{QueryResults, QuerySolution, SparqlEvaluator};
+use oxigraph::store::Store;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::api::types::{graph_uri, MemoryId, ObjectType};
+use crate::errors::CustomError;
+use crate::internal::repositories::{
+    GraphDerivedMemoryProvenanceQuery, GraphDerivedMemoryThreadQuery, GraphObjectQuery,
+    GraphObjectRef,
+};
+
+use super::vocabulary as vocab;
+
+pub(crate) struct SparqlGraphSelectors<'a> {
+    store: &'a Store,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LifecycleCurrentnessPredicates {
+    pub(crate) retention_state: &'static str,
+    pub(crate) is_current: &'static str,
+    pub(crate) thread_status: &'static str,
+    pub(crate) supersedes: &'static str,
+    pub(crate) supersedes_relation: &'static str,
+}
+
+impl<'a> SparqlGraphSelectors<'a> {
+    pub(crate) fn new(store: &'a Store) -> Self {
+        Self { store }
+    }
+
+    pub(crate) fn select_objects(
+        &self,
+        query: &GraphObjectQuery,
+    ) -> Result<Vec<GraphObjectRef>, CustomError> {
+        let mut refs = self.select_object_refs(
+            r#"
+            SELECT DISTINCT ?id ?objectType WHERE {
+              GRAPH ?g {
+                ?subject <urn:cmem:vocab:objectId> ?id ;
+                         <urn:cmem:vocab:objectType> ?objectType .
+              }
+            }
+            "#,
+        )?;
+
+        refs.retain(|object_ref| object_matches_query(*object_ref, query));
+        sort_object_refs(&mut refs);
+        refs.dedup();
+        if let Some(limit) = query.limit {
+            refs.truncate(limit);
+        }
+        Ok(refs)
+    }
+
+    pub(crate) fn select_derived_memories_by_provenance(
+        &self,
+        query: &GraphDerivedMemoryProvenanceQuery,
+    ) -> Result<Vec<MemoryId>, CustomError> {
+        let sources = query
+            .episode_ids
+            .iter()
+            .map(|id| graph_uri(ObjectType::Episode, *id))
+            .chain(
+                query
+                    .observation_ids
+                    .iter()
+                    .map(|id| graph_uri(ObjectType::Observation, *id)),
+            )
+            .collect::<Vec<_>>();
+
+        if sources.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let values = sparql_iri_values("source", sources.iter().map(String::as_str));
+        let query_text = format!(
+            r#"
+            SELECT DISTINCT ?id WHERE {{
+              {values}
+              GRAPH ?memoryGraph {{
+                ?memory a <{derived_class}> ;
+                        <{object_id}> ?id .
+              }}
+              GRAPH ?provenanceGraph {{
+                {{
+                  ?memory <{derived_from_episode}> ?source .
+                }} UNION {{
+                  ?memory <{derived_from_observation}> ?source .
+                }} UNION {{
+                  ?memory <{derived_from_relation}> ?source .
+                }} UNION {{
+                  ?source <{derived_from_relation}> ?memory .
+                }}
+              }}
+            }}
+            "#,
+            derived_class = vocab::CLASS_DERIVED_MEMORY,
+            object_id = vocab::OBJECT_ID,
+            derived_from_episode = vocab::DERIVED_FROM_EPISODE,
+            derived_from_observation = vocab::DERIVED_FROM_OBSERVATION,
+            derived_from_relation = vocab::relation_predicate("derived_from"),
+        );
+
+        self.select_memory_ids(&query_text, query.limit)
+    }
+
+    pub(crate) fn select_derived_memories_by_thread(
+        &self,
+        query: &GraphDerivedMemoryThreadQuery,
+    ) -> Result<Vec<MemoryId>, CustomError> {
+        let threads = query
+            .thread_ids
+            .iter()
+            .map(|id| graph_uri(ObjectType::MemoryThread, *id))
+            .collect::<Vec<_>>();
+
+        if threads.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        self.select_derived_memories_by_resource_predicate(
+            vocab::PART_OF_THREAD,
+            threads.iter().map(String::as_str),
+            query.limit,
+        )
+    }
+
+    pub(crate) fn select_derived_memories_by_entity(
+        &self,
+        entity_ids: &[MemoryId],
+        limit: Option<usize>,
+    ) -> Result<Vec<MemoryId>, CustomError> {
+        let entities = entity_ids
+            .iter()
+            .map(|id| graph_uri(ObjectType::Entity, *id))
+            .collect::<Vec<_>>();
+
+        if entities.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        self.select_derived_memories_by_resource_predicate(
+            vocab::ABOUT_ENTITY,
+            entities.iter().map(String::as_str),
+            limit,
+        )
+    }
+
+    pub(crate) const fn lifecycle_currentness_predicates() -> LifecycleCurrentnessPredicates {
+        LifecycleCurrentnessPredicates {
+            retention_state: vocab::RETENTION_STATE,
+            is_current: vocab::IS_CURRENT,
+            thread_status: vocab::THREAD_STATUS,
+            supersedes: vocab::SUPERSEDES,
+            supersedes_relation: "urn:cmem:relation:supersedes",
+        }
+    }
+
+    pub(crate) fn select_superseded_derived_memory_ids(
+        &self,
+    ) -> Result<Vec<MemoryId>, CustomError> {
+        let query_text = format!(
+            r#"
+            SELECT DISTINCT ?id WHERE {{
+              GRAPH ?memoryGraph {{
+                ?memory a <{derived_class}> ;
+                        <{object_id}> ?id .
+              }}
+              GRAPH ?supersessionGraph {{
+                {{
+                  ?replacement <{supersedes}> ?memory .
+                }} UNION {{
+                  ?replacement <{supersedes_relation}> ?memory .
+                }}
+              }}
+            }}
+            "#,
+            derived_class = vocab::CLASS_DERIVED_MEMORY,
+            object_id = vocab::OBJECT_ID,
+            supersedes = vocab::SUPERSEDES,
+            supersedes_relation = vocab::relation_predicate("supersedes"),
+        );
+
+        self.select_memory_ids(&query_text, None)
+    }
+
+    fn select_derived_memories_by_resource_predicate<'b>(
+        &self,
+        predicate: &str,
+        resources: impl Iterator<Item = &'b str>,
+        limit: Option<usize>,
+    ) -> Result<Vec<MemoryId>, CustomError> {
+        let values = sparql_iri_values("resource", resources);
+        let query_text = format!(
+            r#"
+            SELECT DISTINCT ?id WHERE {{
+              {values}
+              GRAPH ?g {{
+                ?memory a <{derived_class}> ;
+                        <{object_id}> ?id ;
+                        <{predicate}> ?resource .
+              }}
+            }}
+            "#,
+            derived_class = vocab::CLASS_DERIVED_MEMORY,
+            object_id = vocab::OBJECT_ID,
+        );
+
+        self.select_memory_ids(&query_text, limit)
+    }
+
+    fn select_object_refs(&self, query_text: &str) -> Result<Vec<GraphObjectRef>, CustomError> {
+        let mut refs = Vec::new();
+        for solution in self.query_solutions(query_text)? {
+            let id = memory_id_binding(&solution, "id")?;
+            let object_type = enum_binding(&solution, "objectType")?;
+            refs.push(GraphObjectRef::new(id, object_type));
+        }
+        Ok(refs)
+    }
+
+    fn select_memory_ids(
+        &self,
+        query_text: &str,
+        limit: Option<usize>,
+    ) -> Result<Vec<MemoryId>, CustomError> {
+        let mut ids = Vec::new();
+        let mut seen = HashSet::new();
+        for solution in self.query_solutions(query_text)? {
+            let id = memory_id_binding(&solution, "id")?;
+            if seen.insert(id) {
+                ids.push(id);
+            }
+        }
+
+        ids.sort();
+        if let Some(limit) = limit {
+            ids.truncate(limit);
+        }
+        Ok(ids)
+    }
+
+    fn query_solutions(&self, query_text: &str) -> Result<Vec<QuerySolution>, CustomError> {
+        let results = SparqlEvaluator::new()
+            .parse_query(query_text)
+            .map_err(oxigraph_sparql_error)?
+            .on_store(self.store)
+            .execute()
+            .map_err(oxigraph_sparql_error)?;
+
+        let QueryResults::Solutions(solutions) = results else {
+            return Err(CustomError::DatabaseError(
+                "Oxigraph SPARQL selector expected SELECT solutions".to_owned(),
+            ));
+        };
+
+        solutions
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(oxigraph_sparql_error)
+    }
+}
+
+fn object_matches_query(object_ref: GraphObjectRef, query: &GraphObjectQuery) -> bool {
+    (query.object_refs.is_empty() || query.object_refs.contains(&object_ref))
+        && (query.object_ids.is_empty() || query.object_ids.contains(&object_ref.object_id))
+        && (query.object_types.is_empty() || query.object_types.contains(&object_ref.object_type))
+}
+
+fn memory_id_binding(solution: &QuerySolution, name: &str) -> Result<MemoryId, CustomError> {
+    let value = literal_binding(solution, name)?;
+    value.parse::<MemoryId>().map_err(|error| {
+        CustomError::DatabaseError(format!(
+            "Oxigraph SPARQL invalid MemoryId binding {name}: {error}"
+        ))
+    })
+}
+
+fn enum_binding<T: DeserializeOwned>(
+    solution: &QuerySolution,
+    name: &str,
+) -> Result<T, CustomError> {
+    let value = literal_binding(solution, name)?;
+    serde_json::from_value(Value::String(value.to_owned())).map_err(|error| {
+        CustomError::DatabaseError(format!(
+            "Oxigraph SPARQL invalid enum binding {name}: {error}"
+        ))
+    })
+}
+
+fn literal_binding<'a>(solution: &'a QuerySolution, name: &str) -> Result<&'a str, CustomError> {
+    match solution.get(name) {
+        Some(Term::Literal(literal)) => Ok(literal.value()),
+        Some(value) => Err(CustomError::DatabaseError(format!(
+            "Oxigraph SPARQL binding {name} expected literal, got {value}"
+        ))),
+        None => Err(CustomError::DatabaseError(format!(
+            "Oxigraph SPARQL missing binding {name}"
+        ))),
+    }
+}
+
+fn sparql_iri_values<'a>(variable: &str, values: impl Iterator<Item = &'a str>) -> String {
+    let values = values
+        .map(|value| format!("<{}>", sparql_iri(value)))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("VALUES ?{variable} {{ {values} }}")
+}
+
+fn sparql_iri(value: &str) -> String {
+    value.replace('>', "%3E")
+}
+
+fn sort_object_refs(refs: &mut [GraphObjectRef]) {
+    refs.sort_by_key(|object_ref| stable_node_key(object_ref.object_id, object_ref.object_type));
+}
+
+fn stable_node_key(object_id: MemoryId, object_type: ObjectType) -> (MemoryId, u8) {
+    (object_id, object_type_rank(object_type))
+}
+
+fn object_type_rank(object_type: ObjectType) -> u8 {
+    match object_type {
+        ObjectType::Episode => 0,
+        ObjectType::Observation => 1,
+        ObjectType::Entity => 2,
+        ObjectType::MemoryThread => 3,
+        ObjectType::DerivedMemory => 4,
+        ObjectType::MemoryLink => 5,
+    }
+}
+
+fn oxigraph_sparql_error(error: impl std::fmt::Display) -> CustomError {
+    CustomError::DatabaseError(format!("Oxigraph SPARQL selector error: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use oxigraph::model::{GraphName, Literal, NamedNode, NamedOrBlankNode, Quad};
+
+    use super::*;
+    use crate::api::types::{graph_uri, MemoryObject};
+    use crate::internal::infrastructures::graph::rdf_mapping::{
+        rdf_triples_for_link, rdf_triples_for_object, RdfObject, RdfTriple,
+    };
+    use crate::internal::repositories::test_support::representative_fixtures;
+
+    #[test]
+    fn sparql_selectors_find_objects_by_id_and_type_across_named_graphs() {
+        let store = store_with_representative_fixture();
+        let fixtures = representative_fixtures();
+        let selectors = SparqlGraphSelectors::new(&store);
+
+        let selected = selectors
+            .select_objects(&GraphObjectQuery {
+                object_refs: Vec::new(),
+                object_ids: vec![fixtures.episode.id, fixtures.correction.id],
+                object_types: vec![ObjectType::Episode, ObjectType::DerivedMemory],
+                limit: None,
+            })
+            .unwrap();
+
+        assert_eq!(
+            selected,
+            vec![
+                GraphObjectRef::new(fixtures.episode.id, ObjectType::Episode),
+                GraphObjectRef::new(fixtures.correction.id, ObjectType::DerivedMemory),
+            ]
+        );
+    }
+
+    #[test]
+    fn sparql_selectors_ignore_default_graph_object_identity_triples() {
+        let store = Store::new().unwrap();
+        let fixtures = representative_fixtures();
+        let episode = MemoryObject::Episode(fixtures.episode.clone());
+        for triple in rdf_triples_for_object(&episode).unwrap() {
+            store
+                .insert(&default_graph_quad_for_triple(&triple).unwrap())
+                .unwrap();
+        }
+
+        let selected = SparqlGraphSelectors::new(&store)
+            .select_objects(&GraphObjectQuery::by_ids(vec![fixtures.episode.id]))
+            .unwrap();
+
+        assert_eq!(selected, Vec::<GraphObjectRef>::new());
+    }
+
+    #[test]
+    fn sparql_selectors_find_derived_memories_by_provenance_thread_and_entity() {
+        let store = store_with_representative_fixture();
+        let fixtures = representative_fixtures();
+        let selectors = SparqlGraphSelectors::new(&store);
+
+        let by_provenance = selectors
+            .select_derived_memories_by_provenance(&GraphDerivedMemoryProvenanceQuery::by_sources(
+                vec![fixtures.episode.id],
+                vec![fixtures.salient_observation.id],
+            ))
+            .unwrap();
+        let by_thread = selectors
+            .select_derived_memories_by_thread(&GraphDerivedMemoryThreadQuery::by_threads(vec![
+                fixtures.soft_thread.id,
+            ]))
+            .unwrap();
+        let by_entity = selectors
+            .select_derived_memories_by_entity(&[fixtures.user_entity.id], None)
+            .unwrap();
+
+        assert!(by_provenance.contains(&fixtures.correction.id));
+        assert!(by_provenance.contains(&fixtures.derived_reflection.id));
+        assert!(by_thread.contains(&fixtures.correction.id));
+        assert!(by_entity.contains(&fixtures.correction.id));
+    }
+
+    #[test]
+    fn sparql_selectors_expose_lifecycle_predicates_and_superseded_ids() {
+        let store = store_with_representative_fixture();
+        let fixtures = representative_fixtures();
+        let selectors = SparqlGraphSelectors::new(&store);
+        let predicates = SparqlGraphSelectors::lifecycle_currentness_predicates();
+
+        assert_eq!(predicates.retention_state, vocab::RETENTION_STATE);
+        assert_eq!(predicates.is_current, vocab::IS_CURRENT);
+        assert_eq!(predicates.thread_status, vocab::THREAD_STATUS);
+        assert_eq!(predicates.supersedes, vocab::SUPERSEDES);
+        assert_eq!(
+            predicates.supersedes_relation,
+            "urn:cmem:relation:supersedes"
+        );
+        assert!(selectors
+            .select_superseded_derived_memory_ids()
+            .unwrap()
+            .contains(&fixtures.suppressed_seed.id));
+    }
+
+    fn store_with_representative_fixture() -> Store {
+        let store = Store::new().unwrap();
+        let fixtures = representative_fixtures();
+        for object in fixtures.objects() {
+            let (object_id, object_type) = object_identity(&object);
+            insert_triples(
+                &store,
+                &graph_uri(object_type, object_id),
+                &rdf_triples_for_object(&object).unwrap(),
+            );
+        }
+        for link in fixtures.links() {
+            insert_triples(
+                &store,
+                &graph_uri(ObjectType::MemoryLink, link.id),
+                &rdf_triples_for_link(&link).unwrap(),
+            );
+        }
+        store
+    }
+
+    fn insert_triples(store: &Store, owner_graph_uri: &str, triples: &[RdfTriple]) {
+        for triple in triples {
+            store
+                .insert(&quad_for_triple(owner_graph_uri, triple).unwrap())
+                .unwrap();
+        }
+    }
+
+    fn quad_for_triple(owner_graph_uri: &str, triple: &RdfTriple) -> Result<Quad, CustomError> {
+        let subject = NamedNode::new(triple.subject.as_str())?;
+        let predicate = NamedNode::new(triple.predicate.as_str())?;
+        let graph_name = NamedNode::new(owner_graph_uri)?;
+        let object = match &triple.object {
+            RdfObject::Resource(value) => Term::NamedNode(NamedNode::new(value.as_str())?),
+            RdfObject::Literal(value) => Term::Literal(Literal::new_simple_literal(value.as_str())),
+        };
+
+        Ok(Quad::new(
+            NamedOrBlankNode::NamedNode(subject),
+            predicate,
+            object,
+            GraphName::NamedNode(graph_name),
+        ))
+    }
+
+    fn default_graph_quad_for_triple(triple: &RdfTriple) -> Result<Quad, CustomError> {
+        let subject = NamedNode::new(triple.subject.as_str())?;
+        let predicate = NamedNode::new(triple.predicate.as_str())?;
+        let object = match &triple.object {
+            RdfObject::Resource(value) => Term::NamedNode(NamedNode::new(value.as_str())?),
+            RdfObject::Literal(value) => Term::Literal(Literal::new_simple_literal(value.as_str())),
+        };
+
+        Ok(Quad::new(
+            NamedOrBlankNode::NamedNode(subject),
+            predicate,
+            object,
+            GraphName::DefaultGraph,
+        ))
+    }
+
+    fn object_identity(object: &MemoryObject) -> (MemoryId, ObjectType) {
+        match object {
+            MemoryObject::Episode(object) => (object.id, object.object_type),
+            MemoryObject::Observation(object) => (object.id, object.object_type),
+            MemoryObject::Entity(object) => (object.id, object.object_type),
+            MemoryObject::MemoryThread(object) => (object.id, object.object_type),
+            MemoryObject::DerivedMemory(object) => (object.id, object.object_type),
+            MemoryObject::MemoryLink(object) => (object.id, object.object_type),
+        }
+    }
+}

--- a/src/internal/infrastructures/graph/sparql_selectors.rs
+++ b/src/internal/infrastructures/graph/sparql_selectors.rs
@@ -10,7 +10,7 @@ use oxigraph::store::Store;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
-use crate::api::types::{graph_uri, MemoryId, ObjectType};
+use crate::api::types::{graph_uri, MemoryId, ObjectType, RelationType};
 use crate::errors::CustomError;
 use crate::internal::repositories::{
     GraphDerivedMemoryProvenanceQuery, GraphDerivedMemoryThreadQuery, GraphObjectQuery,
@@ -21,6 +21,14 @@ use super::vocabulary as vocab;
 
 pub(crate) struct SparqlGraphSelectors<'a> {
     store: &'a Store,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct SparqlLinkRef {
+    pub(crate) link_id: MemoryId,
+    pub(crate) from: GraphObjectRef,
+    pub(crate) to: GraphObjectRef,
+    pub(crate) relation: RelationType,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -211,6 +219,81 @@ impl<'a> SparqlGraphSelectors<'a> {
         self.select_memory_ids(&query_text, None)
     }
 
+    pub(crate) fn select_links_touching(
+        &self,
+        object_refs: &[GraphObjectRef],
+    ) -> Result<Vec<SparqlLinkRef>, CustomError> {
+        if object_refs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let node_values = sparql_node_iri_values("node", object_refs);
+        let query_text = format!(
+            r#"
+            SELECT DISTINCT ?linkId ?fromId ?fromType ?toId ?toType ?relation WHERE {{
+              {node_values}
+              GRAPH ?linkGraph {{
+                ?link a <{link_class}> ;
+                      <{object_id}> ?linkId ;
+                      <{from}> ?from ;
+                      <{to}> ?to ;
+                      <{relation}> ?relation .
+                {{
+                  ?link <{from}> ?node .
+                }} UNION {{
+                  ?link <{to}> ?node .
+                }}
+              }}
+              GRAPH ?fromGraph {{
+                ?from <{object_id}> ?fromId ;
+                      <{object_type}> ?fromType .
+              }}
+              GRAPH ?toGraph {{
+                ?to <{object_id}> ?toId ;
+                    <{object_type}> ?toType .
+              }}
+            }}
+            "#,
+            link_class = vocab::CLASS_MEMORY_LINK,
+            object_id = vocab::OBJECT_ID,
+            object_type = vocab::OBJECT_TYPE,
+            from = vocab::FROM,
+            to = vocab::TO,
+            relation = vocab::RELATION,
+        );
+
+        let mut refs = Vec::new();
+        let mut seen = HashSet::new();
+        for solution in self.query_solutions(&query_text)? {
+            let link_ref = SparqlLinkRef {
+                link_id: memory_id_binding(&solution, "linkId")?,
+                from: GraphObjectRef::new(
+                    memory_id_binding(&solution, "fromId")?,
+                    enum_binding(&solution, "fromType")?,
+                ),
+                to: GraphObjectRef::new(
+                    memory_id_binding(&solution, "toId")?,
+                    enum_binding(&solution, "toType")?,
+                ),
+                relation: enum_binding(&solution, "relation")?,
+            };
+            if seen.insert(link_ref) {
+                refs.push(link_ref);
+            }
+        }
+        refs.sort_by_key(|link_ref| {
+            (
+                link_ref.to.object_id,
+                link_ref.from.object_id,
+                link_ref.link_id,
+                object_type_rank(link_ref.to.object_type),
+                object_type_rank(link_ref.from.object_type),
+                relation_type_rank(link_ref.relation),
+            )
+        });
+        Ok(refs)
+    }
+
     fn select_derived_memories_by_resource_predicate<'b>(
         &self,
         predicate: &str,
@@ -337,6 +420,21 @@ fn sparql_iri_values<'a>(variable: &str, values: impl Iterator<Item = &'a str>) 
     format!("VALUES ?{variable} {{ {values} }}")
 }
 
+fn sparql_node_iri_values(variable: &str, object_refs: &[GraphObjectRef]) -> String {
+    let values = object_refs
+        .iter()
+        .map(|object_ref| {
+            let graph_uri = graph_uri(object_ref.object_type, object_ref.object_id);
+            format!("<{}>", sparql_iri(&graph_uri))
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    if values.is_empty() {
+        return String::new();
+    }
+    format!("VALUES ?{variable} {{ {values} }}")
+}
+
 fn sparql_iri(value: &str) -> String {
     value.replace('>', "%3E")
 }
@@ -397,6 +495,25 @@ fn object_type_rank(object_type: ObjectType) -> u8 {
         ObjectType::MemoryThread => 3,
         ObjectType::DerivedMemory => 4,
         ObjectType::MemoryLink => 5,
+    }
+}
+
+fn relation_type_rank(relation_type: RelationType) -> u8 {
+    match relation_type {
+        RelationType::HasObservation => 0,
+        RelationType::ObservedIn => 1,
+        RelationType::Mentions => 2,
+        RelationType::Involves => 3,
+        RelationType::About => 4,
+        RelationType::DerivedFrom => 5,
+        RelationType::PartOfThread => 6,
+        RelationType::Supports => 7,
+        RelationType::Contradicts => 8,
+        RelationType::Supersedes => 9,
+        RelationType::Resolves => 10,
+        RelationType::CreatesOpenLoop => 11,
+        RelationType::FulfillsCommitment => 12,
+        RelationType::AssociatedWith => 13,
     }
 }
 
@@ -518,6 +635,31 @@ mod tests {
         assert!(by_provenance.contains(&fixtures.derived_reflection.id));
         assert!(by_thread.contains(&fixtures.correction.id));
         assert!(by_entity.contains(&fixtures.correction.id));
+    }
+
+    #[test]
+    fn sparql_selectors_find_only_links_touching_frontier_refs() {
+        let store = store_with_representative_fixture();
+        let fixtures = representative_fixtures();
+        let selected = SparqlGraphSelectors::new(&store)
+            .select_links_touching(&[GraphObjectRef::new(
+                fixtures.hub_entity.id,
+                ObjectType::Entity,
+            )])
+            .unwrap();
+
+        let selected_ids = selected
+            .iter()
+            .map(|link_ref| link_ref.link_id)
+            .collect::<Vec<_>>();
+
+        assert!(selected_ids.contains(&fixtures.hub_links[0].id));
+        assert!(selected_ids.contains(&fixtures.hub_links[1].id));
+        assert!(!selected_ids.contains(&fixtures.soft_thread_link.id));
+        assert!(selected.iter().all(|link_ref| {
+            link_ref.from == GraphObjectRef::new(fixtures.hub_entity.id, ObjectType::Entity)
+                || link_ref.to == GraphObjectRef::new(fixtures.hub_entity.id, ObjectType::Entity)
+        }));
     }
 
     #[test]

--- a/src/internal/infrastructures/graph/sparql_selectors.rs
+++ b/src/internal/infrastructures/graph/sparql_selectors.rs
@@ -51,10 +51,6 @@ impl<'a> SparqlGraphSelectors<'a> {
                 .map(|object_type| enum_value(*object_type)),
         );
         let ref_values = sparql_object_ref_values(&query.object_refs);
-        let limit_clause = query
-            .limit
-            .map(|limit| format!("LIMIT {limit}"))
-            .unwrap_or_default();
         let select_query = format!(
             r#"
             SELECT DISTINCT ?id ?objectType WHERE {{
@@ -67,7 +63,6 @@ impl<'a> SparqlGraphSelectors<'a> {
               }}
             }}
             ORDER BY ?id ?objectType
-            {limit_clause}
             "#,
             object_id = vocab::OBJECT_ID,
             object_type = vocab::OBJECT_TYPE,
@@ -441,6 +436,42 @@ mod tests {
                 GraphObjectRef::new(fixtures.episode.id, ObjectType::Episode),
                 GraphObjectRef::new(fixtures.correction.id, ObjectType::DerivedMemory),
             ]
+        );
+    }
+
+    #[test]
+    fn sparql_selectors_apply_limit_after_stable_rust_ordering() {
+        let store = Store::new().unwrap();
+        let fixtures = representative_fixtures();
+        let mut entity_with_episode_id = fixtures.project_entity.clone();
+        entity_with_episode_id.id = fixtures.episode.id;
+
+        insert_triples(
+            &store,
+            &graph_uri(ObjectType::Episode, fixtures.episode.id),
+            &rdf_triples_for_object(&MemoryObject::Episode(fixtures.episode.clone())).unwrap(),
+        );
+        insert_triples(
+            &store,
+            &graph_uri(ObjectType::Entity, entity_with_episode_id.id),
+            &rdf_triples_for_object(&MemoryObject::Entity(entity_with_episode_id)).unwrap(),
+        );
+
+        let selected = SparqlGraphSelectors::new(&store)
+            .select_objects(&GraphObjectQuery {
+                object_refs: Vec::new(),
+                object_ids: vec![fixtures.episode.id],
+                object_types: vec![ObjectType::Episode, ObjectType::Entity],
+                limit: Some(1),
+            })
+            .unwrap();
+
+        assert_eq!(
+            selected,
+            vec![GraphObjectRef::new(
+                fixtures.episode.id,
+                ObjectType::Episode
+            )]
         );
     }
 

--- a/src/internal/infrastructures/graph/sparql_selectors.rs
+++ b/src/internal/infrastructures/graph/sparql_selectors.rs
@@ -41,16 +41,39 @@ impl<'a> SparqlGraphSelectors<'a> {
         &self,
         query: &GraphObjectQuery,
     ) -> Result<Vec<GraphObjectRef>, CustomError> {
-        let mut refs = self.select_object_refs(
+        let id_values =
+            sparql_literal_values("id", query.object_ids.iter().map(|id| id.to_string()));
+        let type_values = sparql_literal_values(
+            "objectType",
+            query
+                .object_types
+                .iter()
+                .map(|object_type| enum_value(*object_type)),
+        );
+        let ref_values = sparql_object_ref_values(&query.object_refs);
+        let limit_clause = query
+            .limit
+            .map(|limit| format!("LIMIT {limit}"))
+            .unwrap_or_default();
+        let select_query = format!(
             r#"
-            SELECT DISTINCT ?id ?objectType WHERE {
-              GRAPH ?g {
-                ?subject <urn:cmem:vocab:objectId> ?id ;
-                         <urn:cmem:vocab:objectType> ?objectType .
-              }
-            }
+            SELECT DISTINCT ?id ?objectType WHERE {{
+              {id_values}
+              {type_values}
+              {ref_values}
+              GRAPH ?g {{
+                ?subject <{object_id}> ?id ;
+                         <{object_type}> ?objectType .
+              }}
+            }}
+            ORDER BY ?id ?objectType
+            {limit_clause}
             "#,
-        )?;
+            object_id = vocab::OBJECT_ID,
+            object_type = vocab::OBJECT_TYPE,
+        );
+
+        let mut refs = self.select_object_refs(&select_query)?;
 
         refs.retain(|object_ref| object_matches_query(*object_ref, query));
         sort_object_refs(&mut refs);
@@ -161,7 +184,7 @@ impl<'a> SparqlGraphSelectors<'a> {
             is_current: vocab::IS_CURRENT,
             thread_status: vocab::THREAD_STATUS,
             supersedes: vocab::SUPERSEDES,
-            supersedes_relation: "urn:cmem:relation:supersedes",
+            supersedes_relation: vocab::RELATION_SUPERSEDES,
         }
     }
 
@@ -187,7 +210,7 @@ impl<'a> SparqlGraphSelectors<'a> {
             derived_class = vocab::CLASS_DERIVED_MEMORY,
             object_id = vocab::OBJECT_ID,
             supersedes = vocab::SUPERSEDES,
-            supersedes_relation = vocab::relation_predicate("supersedes"),
+            supersedes_relation = vocab::RELATION_SUPERSEDES,
         );
 
         self.select_memory_ids(&query_text, None)
@@ -313,11 +336,54 @@ fn sparql_iri_values<'a>(variable: &str, values: impl Iterator<Item = &'a str>) 
         .map(|value| format!("<{}>", sparql_iri(value)))
         .collect::<Vec<_>>()
         .join(" ");
+    if values.is_empty() {
+        return String::new();
+    }
     format!("VALUES ?{variable} {{ {values} }}")
 }
 
 fn sparql_iri(value: &str) -> String {
     value.replace('>', "%3E")
+}
+
+fn sparql_literal_values(variable: &str, values: impl Iterator<Item = String>) -> String {
+    let values = values
+        .map(|value| sparql_string_literal(&value))
+        .collect::<Vec<_>>()
+        .join(" ");
+    if values.is_empty() {
+        return String::new();
+    }
+    format!("VALUES ?{variable} {{ {values} }}")
+}
+
+fn sparql_object_ref_values(object_refs: &[GraphObjectRef]) -> String {
+    let values = object_refs
+        .iter()
+        .map(|object_ref| {
+            format!(
+                "({} {})",
+                sparql_string_literal(&object_ref.object_id.to_string()),
+                sparql_string_literal(&enum_value(object_ref.object_type)),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    if values.is_empty() {
+        return String::new();
+    }
+    format!("VALUES (?id ?objectType) {{ {values} }}")
+}
+
+fn sparql_string_literal(value: &str) -> String {
+    serde_json::to_string(value).expect("serializing a SPARQL string literal cannot fail")
+}
+
+fn enum_value(value: impl serde::Serialize) -> String {
+    serde_json::to_value(value)
+        .ok()
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .unwrap_or_default()
 }
 
 fn sort_object_refs(refs: &mut [GraphObjectRef]) {
@@ -434,10 +500,7 @@ mod tests {
         assert_eq!(predicates.is_current, vocab::IS_CURRENT);
         assert_eq!(predicates.thread_status, vocab::THREAD_STATUS);
         assert_eq!(predicates.supersedes, vocab::SUPERSEDES);
-        assert_eq!(
-            predicates.supersedes_relation,
-            "urn:cmem:relation:supersedes"
-        );
+        assert_eq!(predicates.supersedes_relation, vocab::RELATION_SUPERSEDES);
         assert!(selectors
             .select_superseded_derived_memory_ids()
             .unwrap()

--- a/src/internal/infrastructures/graph/vocabulary.rs
+++ b/src/internal/infrastructures/graph/vocabulary.rs
@@ -58,3 +58,37 @@ pub(crate) const RATIONALE: &str = "urn:cmem:vocab:rationale";
 pub(crate) fn relation_predicate(name: &str) -> String {
     format!("urn:cmem:relation:{name}")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vocabulary_uris_pin_graph_selection_and_lifecycle_contract() {
+        assert_eq!(RDF_TYPE, "http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
+        assert_eq!(CLASS_DERIVED_MEMORY, "urn:cmem:vocab:DerivedMemory");
+        assert_eq!(CLASS_MEMORY_LINK, "urn:cmem:vocab:MemoryLink");
+        assert_eq!(OBJECT_ID, "urn:cmem:vocab:objectId");
+        assert_eq!(OBJECT_TYPE, "urn:cmem:vocab:objectType");
+        assert_eq!(GRAPH_URI, "urn:cmem:vocab:graphUri");
+        assert_eq!(RETENTION_STATE, "urn:cmem:vocab:retentionState");
+        assert_eq!(THREAD_STATUS, "urn:cmem:vocab:threadStatus");
+        assert_eq!(DERIVED_FROM_EPISODE, "urn:cmem:vocab:derivedFromEpisode");
+        assert_eq!(
+            DERIVED_FROM_OBSERVATION,
+            "urn:cmem:vocab:derivedFromObservation"
+        );
+        assert_eq!(PART_OF_THREAD, "urn:cmem:vocab:partOfThread");
+        assert_eq!(ABOUT_ENTITY, "urn:cmem:vocab:aboutEntity");
+        assert_eq!(IS_CURRENT, "urn:cmem:vocab:isCurrent");
+        assert_eq!(SUPERSEDES, "urn:cmem:vocab:supersedes");
+        assert_eq!(
+            relation_predicate("supersedes"),
+            "urn:cmem:relation:supersedes"
+        );
+        assert_eq!(
+            relation_predicate("part_of_thread"),
+            "urn:cmem:relation:part_of_thread"
+        );
+    }
+}

--- a/src/internal/infrastructures/graph/vocabulary.rs
+++ b/src/internal/infrastructures/graph/vocabulary.rs
@@ -54,6 +54,7 @@ pub(crate) const TO: &str = "urn:cmem:vocab:to";
 pub(crate) const TO_TYPE: &str = "urn:cmem:vocab:toType";
 pub(crate) const RELATION: &str = "urn:cmem:vocab:relation";
 pub(crate) const RATIONALE: &str = "urn:cmem:vocab:rationale";
+pub(crate) const RELATION_SUPERSEDES: &str = "urn:cmem:relation:supersedes";
 
 pub(crate) fn relation_predicate(name: &str) -> String {
     format!("urn:cmem:relation:{name}")
@@ -82,10 +83,8 @@ mod tests {
         assert_eq!(ABOUT_ENTITY, "urn:cmem:vocab:aboutEntity");
         assert_eq!(IS_CURRENT, "urn:cmem:vocab:isCurrent");
         assert_eq!(SUPERSEDES, "urn:cmem:vocab:supersedes");
-        assert_eq!(
-            relation_predicate("supersedes"),
-            "urn:cmem:relation:supersedes"
-        );
+        assert_eq!(relation_predicate("supersedes"), RELATION_SUPERSEDES);
+        assert_eq!(RELATION_SUPERSEDES, "urn:cmem:relation:supersedes");
         assert_eq!(
             relation_predicate("part_of_thread"),
             "urn:cmem:relation:part_of_thread"


### PR DESCRIPTION
### Motivation and Context

Implements the v0.1 SPARQL-backed Oxigraph query helper plan. The graph store already materialized RDF quads, but query behavior still depended on sidecar maps without SPARQL-backed regression coverage.

### Description

- Adds private SPARQL selectors under graph infrastructure that return backend-neutral IDs/object refs.
- Routes Oxigraph object, derived-memory provenance/thread, and bounded-expansion candidate selection through SPARQL while preserving cache hydration.
- Adds regression coverage for named graph ownership, predicate drift, lifecycle filtering, deterministic retrieval, and graph-only memory links.
- Keeps persistent Oxigraph, reconciliation, typed-literal migration, and public SPARQL APIs out of scope.
- Completes the execution plan by moving it from active to completed.

### Checklist

- [x] Service-free compile check passes
      `cargo check`
- [x] Service-free test target compilation passes
      `cargo test --no-run`
- [x] **Clippy** passes with warnings denied
      `cargo clippy --all-targets -- -D warnings`
- [x] Rust formatting check passes
      `cargo fmt --check`
- [x] Full Qdrant-backed integration tests pass in trusted same-repository CI or with local service configuration
      `cargo test --verbose`
- [x] Documentation updated where needed
- [x] BREAKING CHANGE? **No**
- [x] I didn’t break anyone

### Additional Notes

Reviewer approved with no findings. `cargo test --verbose` passed; Cargo emitted a non-fatal readonly global cache last-use warning after tests completed.