### PR TITLE
🩹 Harden raw reference boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ This is useful when you want to:
 
 The default implementation is backed by Qdrant and embedded, in-memory Oxigraph.
 
-Qdrant is used for vector candidate recall. Embedded Oxigraph is the graph authority for memory objects, links, provenance, currentness, and lifecycle filtering within the running process. Persistent Oxigraph storage configuration is future work.
+Qdrant is used for vector candidate recall. Embedded Oxigraph is the graph authority for memory objects, links, provenance, currentness, and lifecycle filtering within the running process. Persistent Oxigraph storage configuration is v0.1.1 future work.
+
+Raw source material, such as chat or voice transcripts, is caller-owned in v0.1 and is not stored by the default graph/vector backends. Memory objects may preserve `raw_ref` source pointers for provenance, but those pointers are not the transcript content and do not imply a public raw-resolution API.
 
 Integration tests that exercise external vector storage require a local Qdrant instance reachable over gRPC.
 
@@ -173,3 +175,5 @@ Character Memory is under active development.
 The v0.1 public architecture is graph-authoritative episodic continuity memory: public construction and facades compose an embedder, Qdrant candidate recall, and embedded Oxigraph graph authority.
 
 v0.1 does not store raw transcripts directly in graph/vector storage, run a reflection scheduler, implement a normalized belief ontology, support multimodal memory, or perform physical redaction/delete as a default lifecycle operation.
+
+Production raw transcript storage is caller-owned and deferred. No public raw-reference resolution API is part of v0.1. Persistent graph storage authority and graph/vector reconciliation remain v0.1.1 future work rather than v0.1 behavior.

--- a/docs/coding-agent/plans/active/v0-1-raw-reference-boundary-plan.md
+++ b/docs/coding-agent/plans/active/v0-1-raw-reference-boundary-plan.md
@@ -1,0 +1,196 @@
+# Plan: v0.1 Raw Reference Boundary Hardening
+
+- status: draft
+- generated: 2026-05-01
+- last_updated: 2026-05-01
+- work_type: mixed
+
+## Goal
+- Harden and document the v0.1 raw-reference boundary: raw source material stays external, `raw_ref` pointers are preserved, unresolved refs are representable, and graph/vector stores do not become raw transcript stores.
+
+## Definition of Done
+- Tests prove domain, RDF, Qdrant payload, and retrieval surfaces preserve `raw_ref` pointers without storing raw transcript fields.
+- `RawReferenceResolver` behavior clearly distinguishes unavailable references from resolver errors.
+- Documentation states that production raw storage is caller-owned/deferred and that v0.1 stores stable source pointers only.
+- No production raw transcript store is added.
+
+## Scope / Non-goals
+- Scope:
+  - Raw-reference preservation tests.
+  - Optional resolver unavailable/error behavior tests.
+  - Documentation alignment if wording implies graph/vector raw transcript storage.
+- Non-goals:
+  - Implementing a production raw store.
+  - Adding public raw-resolution APIs.
+  - Changing remember/retrieve public DTO shapes unless tests expose a concrete mismatch.
+  - Persistent Oxigraph or Qdrant/Oxigraph reconciliation.
+
+## Context (workspace)
+- Related files/areas:
+  - `src/api/types/domain.rs`
+  - `src/api/types/draft.rs`
+  - `src/api/types/retrieval.rs`
+  - `src/internal/repositories/raw_reference_resolver.rs`
+  - `src/internal/repositories/test_support.rs`
+  - `src/internal/infrastructures/graph/rdf_mapping.rs`
+  - `src/internal/infrastructures/external_services/qdrant_payload.rs`
+  - `docs/design/roadmap-phases/v0_1_storage_and_backend_contracts.md`
+  - `docs/design/database/vector_payload_design.md`
+  - `docs/design/database/graph_schema_design.md`
+  - `README.md`
+- Existing patterns or references:
+  - `raw_ref` exists on source domain objects and is preserved in RDF/Qdrant payloads.
+  - Existing resolver is an internal trait with test fixtures.
+  - v0.1 contract says graph/vector layers store summaries, excerpts, derived memories, and stable pointers, not raw transcripts.
+- Repo reference docs consulted:
+  - `docs/coding-agent/rules/index.md`
+  - `docs/coding-agent/rules/common.md`
+  - `docs/coding-agent/rules/orchestrator.md`
+  - `docs/coding-agent/lessons.md`
+  - `docs/decisions/design/ADR-D-0008-preserve-source-references.md`
+  - `docs/design/roadmap-phases/v0_1_storage_and_backend_contracts.md`
+
+## Open Questions (max 3)
+- Q1: Should the internal `RawReferenceResolver` remain test/support-only for now, or should it become an injectable internal dependency in a later plan?
+
+## Assumptions
+- A1: This plan hardens the boundary; it does not add production raw transcript storage.
+- A2: Unavailable raw refs should be represented as `Ok(None)`, while resolver failures remain `Err`.
+- A3: Public APIs should not be expanded unless existing v0.1 acceptance cannot be met without doing so.
+
+## Tasks
+
+### Task_1: Audit And Test Raw Reference Preservation
+- type: test
+- owns:
+  - `src/api/types/domain/tests.rs`
+  - `src/api/types/retrieval.rs`
+  - `src/internal/infrastructures/graph/rdf_mapping.rs`
+  - `src/internal/infrastructures/external_services/qdrant_payload.rs`
+- depends_on: []
+- description: |
+  Add or tighten tests proving `raw_ref` pointers are preserved where intended and raw transcript content does not appear as graph/vector payload fields.
+- acceptance:
+  - Domain serialization preserves source `raw_ref` values.
+  - RDF mapping includes source pointers without full raw transcript content.
+  - Qdrant payload includes `raw_ref` and excludes raw transcript fields.
+  - Retrieval context pack preserves source refs needed for provenance display.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo fmt --check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test api::types::domain --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::infrastructures::external_services::qdrant_payload --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::infrastructures::graph::rdf_mapping --lib"
+
+### Task_2: Harden RawReferenceResolver Unavailable Behavior
+- type: test
+- owns:
+  - `src/internal/repositories/raw_reference_resolver.rs`
+  - `src/internal/repositories/test_support.rs`
+- depends_on: []
+- description: |
+  Ensure the internal raw-reference resolver boundary distinguishes unavailable references from resolver errors and has deterministic test fixture behavior.
+- acceptance:
+  - Resolver tests cover successful resolution.
+  - Resolver tests cover unavailable reference as `Ok(None)`.
+  - Resolver behavior remains internal and does not imply production raw storage.
+  - Fixture resolver remains deterministic and file-system independent unless a fixture explicitly models a file reference.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::repositories::raw_reference_resolver --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::repositories::test_support --lib"
+
+### Task_3: Align Raw Reference Documentation
+- type: docs
+- owns:
+  - `README.md`
+  - `docs/design/roadmap-phases/v0_1_storage_and_backend_contracts.md`
+  - `docs/design/database/vector_payload_design.md`
+  - `docs/design/database/graph_schema_design.md`
+- depends_on: [Task_1, Task_2]
+- description: |
+  Review and update docs only where wording implies that graph/vector stores own raw transcript storage. Keep docs aligned with the v0.1 boundary: pointers are stored, raw source material is external.
+- acceptance:
+  - Docs explicitly state that production raw storage is caller-owned/deferred.
+  - Docs distinguish `raw_ref` source pointers from raw transcript content.
+  - Docs do not promise public raw resolution unless implemented.
+  - Persistent graph authority and reconciliation remain assigned to v0.1.1 docs.
+- validation:
+  - kind: review
+    required: true
+    owner: worker
+    detail: "Manual doc diff review for raw storage wording"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --no-run"
+
+### Task_4: Reviewer Gate
+- type: review
+- owns: []
+- depends_on: [Task_1, Task_2, Task_3]
+- description: |
+  Review the raw-reference boundary for scope control and storage-contract accuracy.
+- acceptance:
+  - Reviewer status is APPROVED.
+  - Review confirms no production raw transcript store was added.
+  - Review confirms tests and docs distinguish raw pointers from raw content.
+- validation:
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Diff review against ADR-D-0008 and v0.1 storage/backend contract"
+
+## Task Waves (explicit parallel dispatch sets)
+
+- Wave 1 (parallel): [Task_1, Task_2]
+- Wave 2 (parallel): [Task_3]
+- Wave 3 (parallel): [Task_4]
+
+## E2E / Visual Validation Spec
+
+- Not applicable. Rust library/storage behavior only.
+
+## Rollback / Safety
+- Treat any public raw-resolution API pressure as a replan trigger.
+- Documentation updates should be limited to boundary clarification, not roadmap expansion.
+
+## Progress Log (append-only)
+
+- 2026-05-01 00:00 Draft created.
+  - Summary: Split raw-reference boundary hardening into its own v0.1 backend-contract plan.
+  - Validation evidence: Not run; plan only.
+  - Notes: Awaiting user approval before implementation.
+
+## Decision Log (append-only; re-plans and major discoveries)
+
+- 2026-05-01 00:00 Decision:
+  - Trigger / new insight: Prior repository assessment found raw refs are mostly present, but production raw-store boundaries and unavailable-resolution behavior should be hardened separately from graph/query work.
+  - Plan delta (what changed): Created a standalone raw-reference boundary plan.
+  - Tradeoffs considered: A production raw transcript store is excluded because it conflicts with the v0.1 contract boundary and would be a larger API/storage design.
+  - User approval: no
+
+## Notes
+- Risks:
+  - The phrase "raw store" can be misread as a request to implement transcript persistence; this plan intentionally avoids that.
+  - Docs may already be accurate, in which case Task_3 should record no-op evidence rather than churn.
+- Edge cases:
+  - `raw_ref` on episode vs observation.
+  - Resolver returns unavailable vs error.
+  - Payload fields named `raw_transcript` or `transcript` accidentally appearing in vector payloads.

--- a/docs/coding-agent/plans/completed/v0-1-raw-reference-boundary-plan.md
+++ b/docs/coding-agent/plans/completed/v0-1-raw-reference-boundary-plan.md
@@ -1,6 +1,6 @@
 # Plan: v0.1 Raw Reference Boundary Hardening
 
-- status: draft
+- status: done
 - generated: 2026-05-01
 - last_updated: 2026-05-01
 - work_type: mixed
@@ -51,7 +51,7 @@
   - `docs/design/roadmap-phases/v0_1_storage_and_backend_contracts.md`
 
 ## Open Questions (max 3)
-- Q1: Should the internal `RawReferenceResolver` remain test/support-only for now, or should it become an injectable internal dependency in a later plan?
+- Resolved: Keep `RawReferenceResolver` internal/test-support-only for this plan; do not add a public or injectable raw-store API.
 
 ## Assumptions
 - A1: This plan hardens the boundary; it does not add production raw transcript storage.
@@ -178,6 +178,21 @@
   - Validation evidence: Not run; plan only.
   - Notes: Awaiting user approval before implementation.
 
+- 2026-05-01 03:25 Wave 1 completed: [Task_1, Task_2]
+  - Summary: Added raw_ref preservation tests across domain, retrieval, RDF, and Qdrant payload surfaces; added resolver success, unavailable, and error behavior tests.
+  - Validation evidence: Task_2 reported `cargo test internal::repositories::raw_reference_resolver --lib` and `cargo test internal::repositories::test_support --lib` passed. Task_1 reported all required targeted tests passed; Orchestrator resolved a parallel formatting conflict and reran `cargo fmt --check`, `cargo test api::types::domain --lib`, `cargo test internal::infrastructures::external_services::qdrant_payload --lib`, and `cargo test internal::infrastructures::graph::rdf_mapping --lib` successfully.
+  - Notes: Initial Task_1 `cargo fmt --check` was blocked by parallel Task_2 edits in an unowned file; integrated formatting resolved it.
+
+- 2026-05-01 03:45 Wave 2 completed: [Task_3]
+  - Summary: Aligned README and storage/backend docs with the v0.1 raw-reference boundary: production raw storage is caller-owned/deferred, `raw_ref`/`rawRef` values are source pointers rather than transcript content, and public raw-resolution APIs are not promised.
+  - Validation evidence: Worker manually reviewed the scoped doc diff and ran `cargo test --no-run` successfully.
+  - Notes: Persistent graph storage authority and graph/vector reconciliation remain documented as v0.1.1 future work.
+
+- 2026-05-01 04:05 Wave 3 completed: [Task_4]
+  - Summary: Reviewer approved the raw-reference boundary changes with no findings.
+  - Validation evidence: Reviewer reran `cargo fmt --check`, `cargo test api::types::domain --lib`, `cargo test api::types::retrieval --lib`, `cargo test internal::infrastructures::external_services::qdrant_payload --lib`, `cargo test internal::infrastructures::graph::rdf_mapping --lib`, `cargo test internal::repositories::raw_reference_resolver --lib`, `cargo test internal::repositories::test_support --lib`, and `cargo test --no-run` successfully.
+  - Notes: Reviewer confirmed no production raw transcript store, no public raw-resolution API, and no injectable raw-store API were added.
+
 ## Decision Log (append-only; re-plans and major discoveries)
 
 - 2026-05-01 00:00 Decision:
@@ -185,6 +200,12 @@
   - Plan delta (what changed): Created a standalone raw-reference boundary plan.
   - Tradeoffs considered: A production raw transcript store is excluded because it conflicts with the v0.1 contract boundary and would be a larger API/storage design.
   - User approval: no
+
+- 2026-05-01 03:10 Decision:
+  - Trigger / new insight: User approved implementation and resolved open questions before work.
+  - Plan delta (what changed): Marked the plan in progress; resolved raw resolver scope to internal/test-support-only.
+  - Tradeoffs considered: Avoiding an injectable/public raw-store API keeps this plan focused on pointer preservation and unavailable-reference behavior.
+  - User approval: yes
 
 ## Notes
 - Risks:

--- a/docs/design/database/graph_schema_design.md
+++ b/docs/design/database/graph_schema_design.md
@@ -21,9 +21,11 @@ Those questions are graph questions. The schema therefore prioritizes stable ide
 
 ## Backend Boundary
 
-Embedded in-memory Oxigraph is the default graph authority. Persistent Oxigraph storage configuration is future work.
+Embedded in-memory Oxigraph is the default graph authority. Persistent Oxigraph storage configuration is v0.1.1 future work.
 
 The public domain model does not expose Oxigraph types. Domain objects are mapped into RDF at the infrastructure edge. This keeps the public API stable if the backing graph implementation changes later.
+
+Raw transcript storage remains outside the graph boundary in v0.1. The graph may carry source pointers, but production raw storage is caller-owned/deferred and raw-reference resolution is not a public graph API.
 
 ## Identity Model
 
@@ -94,7 +96,7 @@ derivedFromObservation
 
 This is intentionally narrower than a generic "source" blob. Corrections and forget operations need to find derived memories affected by a source episode or source observation. Dedicated provenance predicates make that query direct and keep source-cascade behavior deterministic.
 
-Raw source material is not stored in the graph. Objects may carry `rawRef` pointers so callers can resolve original transcript material elsewhere.
+Raw source material is not stored in the graph. Objects may carry `rawRef` pointers so callers can associate memories with original transcript material elsewhere. A `rawRef` is a source pointer, not the transcript content.
 
 ## Lifecycle Shape
 
@@ -223,7 +225,7 @@ It keeps the graph authority simple and deterministic:
 - tests can validate graph behavior without committing to full SPARQL object hydration yet
 - RDF triples still exist for relationship mapping and future query expansion
 
-Persistent graph storage can later move more responsibility into SPARQL-backed queries without changing the public object model.
+Persistent graph storage can later move more responsibility into SPARQL-backed queries without changing the public object model. That persistent authority work remains scoped to v0.1.1-era follow-up, not the v0.1 in-memory boundary.
 
 ## Cross-Store Contract
 
@@ -240,7 +242,7 @@ This is why the vector payload intentionally duplicates some graph-derived hints
 
 Revisit this design when:
 
-- persistent Oxigraph storage becomes configurable
+- v0.1.1 persistent Oxigraph storage becomes configurable
 - SPARQL query helpers replace more in-memory object-side reads
 - belief/claim tracking adds richer factual rigor semantics
 - some relation types become important enough to deserve specialized objects

--- a/docs/design/database/vector_payload_design.md
+++ b/docs/design/database/vector_payload_design.md
@@ -84,7 +84,7 @@ content_text
 
 `embedding_text` is the exact text used to generate the vector. `content_text` is a compact readable payload for debugging, inspection, and possible re-indexing workflows. Neither field is a raw transcript store.
 
-Raw interaction material should be addressed through `raw_ref` pointers owned by a raw store or caller-managed transcript system.
+Raw interaction material should be addressed through `raw_ref` pointers owned by a caller-managed transcript system. Production raw storage is deferred in v0.1 and is not part of the Qdrant payload contract.
 
 ### Object-Specific Filter Hints
 
@@ -149,7 +149,7 @@ Time filters support recency and episode/thread constraints without embedding ti
 raw_ref
 ```
 
-`raw_ref` preserves a pointer to source material without storing the full raw chat or voice transcript in Qdrant. This keeps the memory substrate transcript-compatible while avoiding a premature raw-storage policy.
+`raw_ref` preserves a pointer to source material without storing the full raw chat or voice transcript in Qdrant. The pointer is provenance metadata, not raw transcript content, and it does not promise that the vector layer can resolve the source publicly.
 
 ## Indexing Policy
 
@@ -214,7 +214,7 @@ If Qdrant is stale, retrieval may do extra work, but it should not return stale 
 
 Revisit this design when:
 
-- persistent Oxigraph configuration lands and cross-process graph/vector consistency needs stronger operational guarantees
+- v0.1.1 persistent Oxigraph configuration lands and cross-process graph/vector reconciliation needs stronger operational guarantees
 - multiple vector surfaces per object become common enough to require public surface policy
 - spatial/location retrieval becomes a real product requirement
 - a belief/claim subsystem introduces new indexable object types

--- a/docs/design/roadmap-phases/v0_1_storage_and_backend_contracts.md
+++ b/docs/design/roadmap-phases/v0_1_storage_and_backend_contracts.md
@@ -9,20 +9,20 @@ Default stack:
 ```text
 Qdrant   = vector candidate recall + payload filtering
 Oxigraph = embedded in-memory RDF/SPARQL graph authority
-RawStore = source conversation/transcript references
+Raw refs = stable pointers to caller-owned source material
 ```
 
 The implementation should remain backend-abstract where practical.
 
-Public construction and facades compose an embedder, a Qdrant vector candidate store, and an embedded in-memory Oxigraph graph authority store. Qdrant results are candidates only; Oxigraph is authoritative for memory objects and relationships within the running process. Persistent Oxigraph storage configuration remains future work.
+Public construction and facades compose an embedder, a Qdrant vector candidate store, and an embedded in-memory Oxigraph graph authority store. Qdrant results are candidates only; Oxigraph is authoritative for memory objects and relationships within the running process. Persistent Oxigraph storage configuration remains v0.1.1 future work.
 
 ---
 
 # 1. Store responsibilities
 
-## 1.1 Raw store
+## 1.1 Raw source material
 
-Stores or references original interaction material outside the graph/vector memory stores.
+Production raw storage is caller-owned and deferred in v0.1. The graph/vector memory stores preserve source pointers, but they do not own the original interaction material.
 
 Examples:
 
@@ -33,7 +33,7 @@ source conversation log
 selected excerpts
 ```
 
-The graph/vector layer does not store raw transcripts as v0.1 memory content. It stores summaries, excerpts, derived memories, and stable pointers.
+The graph/vector layer does not store raw transcripts as v0.1 memory content. It stores summaries, excerpts, derived memories, and stable `raw_ref` pointers. A `raw_ref` identifies where source material can be found by the caller's transcript system; it is not the transcript content itself.
 
 ```json
 {
@@ -56,7 +56,7 @@ retention state
 currentness
 ```
 
-Default: embedded in-memory Oxigraph RDF/SPARQL. Persistent Oxigraph storage configuration remains future work.
+Default: embedded in-memory Oxigraph RDF/SPARQL. Persistent Oxigraph storage configuration remains v0.1.1 future work.
 
 ## 1.3 Vector store
 
@@ -113,7 +113,7 @@ Acceptance criteria:
 ```text
 same object always maps to same graph URI
 vector payload stores graph_uri and object id
-raw_ref can be resolved or reported unavailable
+raw_ref pointers are preserved and unresolved refs remain representable
 ```
 
 ---

--- a/src/api/types/domain/tests.rs
+++ b/src/api/types/domain/tests.rs
@@ -276,9 +276,21 @@ fn raw_references_are_preserved_as_external_reference_strings() {
     let episode = representative_episode();
     let observation = representative_observation();
 
+    let serialized_episode = serde_json::to_value(&episode).unwrap();
+    let serialized_observation = serde_json::to_value(&observation).unwrap();
     let round_tripped_episode: Episode = round_trip(&episode);
     let round_tripped_observation: Observation = round_trip(&observation);
 
+    assert_eq!(
+        serialized_episode["raw_ref"],
+        episode.raw_ref.as_deref().unwrap()
+    );
+    assert_eq!(
+        serialized_observation["raw_ref"],
+        observation.raw_ref.as_deref().unwrap()
+    );
+    assert!(serialized_episode.get("raw_transcript").is_none());
+    assert!(serialized_observation.get("raw_transcript").is_none());
     assert_eq!(round_tripped_episode.raw_ref, episode.raw_ref);
     assert_eq!(round_tripped_observation.raw_ref, observation.raw_ref);
 }

--- a/src/api/types/retrieval.rs
+++ b/src/api/types/retrieval.rs
@@ -579,7 +579,6 @@ mod tests {
     #[test]
     fn context_pack_preserves_source_references_without_raw_transcript_storage() {
         let episode_id = memory_id("550e8400-e29b-41d4-a716-446655442030");
-        let raw_transcript = "verbatim raw transcript text should not be packed";
         let derived = derived_memory(
             memory_id("550e8400-e29b-41d4-a716-446655442031"),
             episode_id,
@@ -593,6 +592,7 @@ mod tests {
         ));
         pack.preferences.push(included);
 
+        let encoded_value = serde_json::to_value(&pack).unwrap();
         let encoded = serde_json::to_string(&pack).unwrap();
         let decoded: ContinuityContextPack = serde_json::from_str(&encoded).unwrap();
 
@@ -610,11 +610,27 @@ mod tests {
             derived.derived_from_observation_ids
         );
         assert_eq!(decoded.preferences[0].memory.text, derived.text);
-        assert!(decoded
-            .salient_observations
-            .iter()
-            .all(|observation| observation.raw_ref.as_deref() != Some(raw_transcript)));
-        assert!(!encoded.contains(raw_transcript));
+        for raw_content_key in [
+            "raw_transcript",
+            "raw_text",
+            "transcript",
+            "source_transcript",
+        ] {
+            assert!(!json_contains_key(&encoded_value, raw_content_key));
+        }
+    }
+
+    fn json_contains_key(value: &serde_json::Value, key: &str) -> bool {
+        match value {
+            serde_json::Value::Object(object) => {
+                object.contains_key(key)
+                    || object.values().any(|value| json_contains_key(value, key))
+            }
+            serde_json::Value::Array(values) => {
+                values.iter().any(|value| json_contains_key(value, key))
+            }
+            _ => false,
+        }
     }
 
     #[test]

--- a/src/api/types/retrieval.rs
+++ b/src/api/types/retrieval.rs
@@ -420,6 +420,23 @@ mod tests {
         }
     }
 
+    fn observation(id: MemoryId, episode_id: MemoryId) -> Observation {
+        Observation {
+            id,
+            object_type: ObjectType::Observation,
+            episode_id,
+            speaker_entity_id: None,
+            observed_at: Some(timestamp("2026-04-29T10:01:00Z")),
+            modality: Modality::Chat,
+            text: "Concise observation excerpt.".to_owned(),
+            raw_ref: Some("raw://conversation/42#turn-2".to_owned()),
+            salience_score: 0.7,
+            retention_state: RetentionState::Active,
+            created_at: timestamp("2026-04-29T10:06:01Z"),
+            schema_version: "test_schema".to_owned(),
+        }
+    }
+
     fn derived_memory(id: MemoryId, source_episode_id: MemoryId) -> DerivedMemory {
         DerivedMemory {
             id,
@@ -562,6 +579,7 @@ mod tests {
     #[test]
     fn context_pack_preserves_source_references_without_raw_transcript_storage() {
         let episode_id = memory_id("550e8400-e29b-41d4-a716-446655442030");
+        let raw_transcript = "verbatim raw transcript text should not be packed";
         let derived = derived_memory(
             memory_id("550e8400-e29b-41d4-a716-446655442031"),
             episode_id,
@@ -569,6 +587,10 @@ mod tests {
         let included = IncludedDerivedMemory::from(derived.clone());
         let mut pack = ContinuityContextPack::empty();
         pack.relevant_episodes.push(episode(episode_id));
+        pack.salient_observations.push(observation(
+            memory_id("550e8400-e29b-41d4-a716-446655442010"),
+            episode_id,
+        ));
         pack.preferences.push(included);
 
         let encoded = serde_json::to_string(&pack).unwrap();
@@ -578,12 +600,21 @@ mod tests {
             decoded.relevant_episodes[0].raw_ref.as_deref(),
             Some("raw://conversation/42#episode")
         );
+        assert_eq!(
+            decoded.salient_observations[0].raw_ref.as_deref(),
+            Some("raw://conversation/42#turn-2")
+        );
         assert_eq!(decoded.preferences[0].source_episode_ids, vec![episode_id]);
         assert_eq!(
             decoded.preferences[0].source_observation_ids,
             derived.derived_from_observation_ids
         );
         assert_eq!(decoded.preferences[0].memory.text, derived.text);
+        assert!(decoded
+            .salient_observations
+            .iter()
+            .all(|observation| observation.raw_ref.as_deref() != Some(raw_transcript)));
+        assert!(!encoded.contains(raw_transcript));
     }
 
     #[test]

--- a/src/internal/infrastructures/external_services/qdrant_payload.rs
+++ b/src/internal/infrastructures/external_services/qdrant_payload.rs
@@ -383,9 +383,6 @@ mod tests {
         assert!(payload.get("raw_text").is_none());
         assert!(payload.get("transcript").is_none());
         assert!(payload.get("source_transcript").is_none());
-        assert!(!payload
-            .values()
-            .any(|value| value == "verbatim raw transcript text"));
     }
 
     #[test]

--- a/src/internal/infrastructures/external_services/qdrant_payload.rs
+++ b/src/internal/infrastructures/external_services/qdrant_payload.rs
@@ -380,7 +380,12 @@ mod tests {
             json!("raw://conversation/chat_123#turn_42")
         );
         assert!(payload.get("raw_transcript").is_none());
+        assert!(payload.get("raw_text").is_none());
         assert!(payload.get("transcript").is_none());
+        assert!(payload.get("source_transcript").is_none());
+        assert!(!payload
+            .values()
+            .any(|value| value == "verbatim raw transcript text"));
     }
 
     #[test]

--- a/src/internal/infrastructures/graph/rdf_mapping.rs
+++ b/src/internal/infrastructures/graph/rdf_mapping.rs
@@ -488,7 +488,6 @@ mod tests {
     #[test]
     fn rdf_mapping_preserves_source_pointers_without_raw_transcript_literals() {
         let fixtures = representative_fixtures();
-        let raw_transcript = "verbatim raw transcript text must remain external";
         let mut episode = fixtures.episode.clone();
         episode.raw_ref = Some("file:fixtures/raw/source-episode.txt".to_owned());
         episode.summary = "Summarized source episode.".to_owned();
@@ -511,8 +510,6 @@ mod tests {
             vocab::RAW_REF,
             "file:fixtures/raw/source-observation.txt",
         );
-        assert_no_literal_value_contains(&episode_triples, raw_transcript);
-        assert_no_literal_value_contains(&observation_triples, raw_transcript);
         assert!(!episode_triples
             .iter()
             .any(|triple| triple.predicate.contains("rawTranscript")));
@@ -590,13 +587,6 @@ mod tests {
     fn assert_contains_resource(triples: &[RdfTriple], predicate: &'static str, value: &str) {
         assert!(triples.iter().any(|triple| {
             triple.predicate == predicate && triple.object == RdfObject::Resource(value.to_owned())
-        }));
-    }
-
-    fn assert_no_literal_value_contains(triples: &[RdfTriple], forbidden: &str) {
-        assert!(triples.iter().all(|triple| match &triple.object {
-            RdfObject::Literal(value) => !value.contains(forbidden),
-            RdfObject::Resource(_) => true,
         }));
     }
 

--- a/src/internal/infrastructures/graph/rdf_mapping.rs
+++ b/src/internal/infrastructures/graph/rdf_mapping.rs
@@ -510,12 +510,8 @@ mod tests {
             vocab::RAW_REF,
             "file:fixtures/raw/source-observation.txt",
         );
-        assert!(!episode_triples
-            .iter()
-            .any(|triple| triple.predicate.contains("rawTranscript")));
-        assert!(!observation_triples
-            .iter()
-            .any(|triple| triple.predicate.contains("rawTranscript")));
+        assert_no_raw_content_predicates(&episode_triples);
+        assert_no_raw_content_predicates(&observation_triples);
     }
 
     #[test]
@@ -587,6 +583,15 @@ mod tests {
     fn assert_contains_resource(triples: &[RdfTriple], predicate: &'static str, value: &str) {
         assert!(triples.iter().any(|triple| {
             triple.predicate == predicate && triple.object == RdfObject::Resource(value.to_owned())
+        }));
+    }
+
+    fn assert_no_raw_content_predicates(triples: &[RdfTriple]) {
+        assert!(triples.iter().all(|triple| {
+            let predicate = triple.predicate.as_str();
+            let normalized = predicate.to_ascii_lowercase();
+            predicate == vocab::RAW_REF
+                || (!normalized.contains("raw") && !normalized.contains("transcript"))
         }));
     }
 

--- a/src/internal/infrastructures/graph/rdf_mapping.rs
+++ b/src/internal/infrastructures/graph/rdf_mapping.rs
@@ -486,6 +486,42 @@ mod tests {
     }
 
     #[test]
+    fn rdf_mapping_preserves_source_pointers_without_raw_transcript_literals() {
+        let fixtures = representative_fixtures();
+        let raw_transcript = "verbatim raw transcript text must remain external";
+        let mut episode = fixtures.episode.clone();
+        episode.raw_ref = Some("file:fixtures/raw/source-episode.txt".to_owned());
+        episode.summary = "Summarized source episode.".to_owned();
+        let mut observation = fixtures.salient_observation.clone();
+        observation.raw_ref = Some("file:fixtures/raw/source-observation.txt".to_owned());
+        observation.text = "A concise observation excerpt.".to_owned();
+
+        let episode_triples =
+            rdf_triples_for_object(&MemoryObject::Episode(episode)).expect("current schema maps");
+        let observation_triples = rdf_triples_for_object(&MemoryObject::Observation(observation))
+            .expect("current schema maps");
+
+        assert_contains_literal(
+            &episode_triples,
+            vocab::RAW_REF,
+            "file:fixtures/raw/source-episode.txt",
+        );
+        assert_contains_literal(
+            &observation_triples,
+            vocab::RAW_REF,
+            "file:fixtures/raw/source-observation.txt",
+        );
+        assert_no_literal_value_contains(&episode_triples, raw_transcript);
+        assert_no_literal_value_contains(&observation_triples, raw_transcript);
+        assert!(!episode_triples
+            .iter()
+            .any(|triple| triple.predicate.contains("rawTranscript")));
+        assert!(!observation_triples
+            .iter()
+            .any(|triple| triple.predicate.contains("rawTranscript")));
+    }
+
+    #[test]
     fn rdf_mapping_reifies_memory_links_and_adds_typed_relation_triples() {
         let fixtures = representative_fixtures();
         let link = fixtures.soft_thread_link;
@@ -554,6 +590,13 @@ mod tests {
     fn assert_contains_resource(triples: &[RdfTriple], predicate: &'static str, value: &str) {
         assert!(triples.iter().any(|triple| {
             triple.predicate == predicate && triple.object == RdfObject::Resource(value.to_owned())
+        }));
+    }
+
+    fn assert_no_literal_value_contains(triples: &[RdfTriple], forbidden: &str) {
+        assert!(triples.iter().all(|triple| match &triple.object {
+            RdfObject::Literal(value) => !value.contains(forbidden),
+            RdfObject::Resource(_) => true,
         }));
     }
 

--- a/src/internal/repositories/raw_reference_resolver.rs
+++ b/src/internal/repositories/raw_reference_resolver.rs
@@ -37,11 +37,79 @@ impl<T: RawReferenceResolver + ?Sized> RawReferenceResolver for Box<T> {
 mod tests {
     use super::*;
 
+    #[derive(Debug)]
+    struct StaticRawReferenceResolver {
+        result: Result<Option<RawReference>, CustomError>,
+    }
+
+    #[async_trait]
+    impl RawReferenceResolver for StaticRawReferenceResolver {
+        async fn resolve(&self, _reference: &str) -> Result<Option<RawReference>, CustomError> {
+            match &self.result {
+                Ok(raw_reference) => Ok(raw_reference.clone()),
+                Err(CustomError::DatabaseError(message)) => {
+                    Err(CustomError::DatabaseError(message.clone()))
+                }
+                Err(error) => panic!("unexpected fixture error variant: {error}"),
+            }
+        }
+    }
+
     #[test]
     fn raw_reference_is_resolved_content_not_storage_configuration() {
         let raw = RawReference::new("chat://conversation/1#turn=2", "hello");
 
         assert_eq!(raw.reference, "chat://conversation/1#turn=2");
         assert_eq!(raw.text, "hello");
+    }
+
+    #[tokio::test]
+    async fn raw_reference_resolver_can_resolve_internal_source_content() {
+        let resolver = StaticRawReferenceResolver {
+            result: Ok(Some(RawReference::new(
+                "raw://conversation/1#turn=2",
+                "resolved fixture text",
+            ))),
+        };
+
+        let resolved = resolver
+            .resolve("raw://conversation/1#turn=2")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(resolved.reference, "raw://conversation/1#turn=2");
+        assert_eq!(resolved.text, "resolved fixture text");
+    }
+
+    #[tokio::test]
+    async fn raw_reference_resolver_reports_unavailable_reference_as_none() {
+        let resolver = StaticRawReferenceResolver { result: Ok(None) };
+
+        let resolved = resolver
+            .resolve("raw://conversation/missing#turn=9")
+            .await
+            .unwrap();
+
+        assert_eq!(resolved, None);
+    }
+
+    #[tokio::test]
+    async fn raw_reference_resolver_propagates_resolver_failures_as_errors() {
+        let resolver = StaticRawReferenceResolver {
+            result: Err(CustomError::DatabaseError(
+                "resolver unavailable".to_owned(),
+            )),
+        };
+
+        let error = resolver
+            .resolve("raw://conversation/1#turn=2")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            CustomError::DatabaseError(message) if message == "resolver unavailable"
+        ));
     }
 }

--- a/src/internal/repositories/raw_reference_resolver.rs
+++ b/src/internal/repositories/raw_reference_resolver.rs
@@ -39,18 +39,27 @@ mod tests {
 
     #[derive(Debug)]
     struct StaticRawReferenceResolver {
-        result: Result<Option<RawReference>, CustomError>,
+        result: StaticRawReferenceResult,
+    }
+
+    #[derive(Debug)]
+    enum StaticRawReferenceResult {
+        Resolved(Option<RawReference>),
+        DatabaseError(String),
+        MemoryValidation(String),
     }
 
     #[async_trait]
     impl RawReferenceResolver for StaticRawReferenceResolver {
         async fn resolve(&self, _reference: &str) -> Result<Option<RawReference>, CustomError> {
             match &self.result {
-                Ok(raw_reference) => Ok(raw_reference.clone()),
-                Err(CustomError::DatabaseError(message)) => {
+                StaticRawReferenceResult::Resolved(raw_reference) => Ok(raw_reference.clone()),
+                StaticRawReferenceResult::DatabaseError(message) => {
                     Err(CustomError::DatabaseError(message.clone()))
                 }
-                Err(error) => panic!("unexpected fixture error variant: {error}"),
+                StaticRawReferenceResult::MemoryValidation(message) => {
+                    Err(CustomError::MemoryValidation(message.clone()))
+                }
             }
         }
     }
@@ -66,7 +75,7 @@ mod tests {
     #[tokio::test]
     async fn raw_reference_resolver_can_resolve_internal_source_content() {
         let resolver = StaticRawReferenceResolver {
-            result: Ok(Some(RawReference::new(
+            result: StaticRawReferenceResult::Resolved(Some(RawReference::new(
                 "raw://conversation/1#turn=2",
                 "resolved fixture text",
             ))),
@@ -84,7 +93,9 @@ mod tests {
 
     #[tokio::test]
     async fn raw_reference_resolver_reports_unavailable_reference_as_none() {
-        let resolver = StaticRawReferenceResolver { result: Ok(None) };
+        let resolver = StaticRawReferenceResolver {
+            result: StaticRawReferenceResult::Resolved(None),
+        };
 
         let resolved = resolver
             .resolve("raw://conversation/missing#turn=9")
@@ -97,9 +108,7 @@ mod tests {
     #[tokio::test]
     async fn raw_reference_resolver_propagates_resolver_failures_as_errors() {
         let resolver = StaticRawReferenceResolver {
-            result: Err(CustomError::DatabaseError(
-                "resolver unavailable".to_owned(),
-            )),
+            result: StaticRawReferenceResult::DatabaseError("resolver unavailable".to_owned()),
         };
 
         let error = resolver
@@ -110,6 +119,23 @@ mod tests {
         assert!(matches!(
             error,
             CustomError::DatabaseError(message) if message == "resolver unavailable"
+        ));
+    }
+
+    #[tokio::test]
+    async fn raw_reference_resolver_fixture_can_return_non_database_errors() {
+        let resolver = StaticRawReferenceResolver {
+            result: StaticRawReferenceResult::MemoryValidation("invalid raw ref".to_owned()),
+        };
+
+        let error = resolver
+            .resolve("raw://conversation/1#turn=2")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            CustomError::MemoryValidation(message) if message == "invalid raw ref"
         ));
     }
 }

--- a/src/internal/repositories/test_support.rs
+++ b/src/internal/repositories/test_support.rs
@@ -1586,6 +1586,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn raw_reference_resolver_resolves_in_memory_fixture_content() {
+        let resolver = FixtureRawReferenceResolver::new();
+
+        resolver
+            .insert("raw://fixture/conversation#turn=1", "raw fixture text")
+            .unwrap();
+        let resolved = resolver
+            .resolve("raw://fixture/conversation#turn=1")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(resolved.reference, "raw://fixture/conversation#turn=1");
+        assert_eq!(resolved.text, "raw fixture text");
+    }
+
+    #[tokio::test]
+    async fn raw_reference_resolver_reports_unavailable_reference_as_none() {
+        let resolver = FixtureRawReferenceResolver::new();
+
+        resolver
+            .insert("raw://fixture/conversation#turn=1", "raw fixture text")
+            .unwrap();
+        let resolved = resolver
+            .resolve("raw://fixture/conversation#turn=2")
+            .await
+            .unwrap();
+
+        assert_eq!(resolved, None);
+    }
+
+    #[tokio::test]
+    async fn raw_reference_resolver_overwrites_duplicate_references_deterministically() {
+        let resolver = FixtureRawReferenceResolver::new();
+
+        resolver
+            .insert("raw://fixture/conversation#turn=1", "first fixture text")
+            .unwrap();
+        resolver
+            .insert("raw://fixture/conversation#turn=1", "updated fixture text")
+            .unwrap();
+
+        let first = resolver
+            .resolve("raw://fixture/conversation#turn=1")
+            .await
+            .unwrap();
+        let second = resolver
+            .resolve("raw://fixture/conversation#turn=1")
+            .await
+            .unwrap();
+
+        assert_eq!(first, second);
+        let resolved = first.unwrap();
+        assert_eq!(resolved.reference, "raw://fixture/conversation#turn=1");
+        assert_eq!(resolved.text, "updated fixture text");
+    }
+
+    #[tokio::test]
     async fn raw_reference_resolver_uses_fixture_backed_file_content() {
         let resolver = FixtureRawReferenceResolver::new();
         let path = std::env::temp_dir().join(format!("cmem-raw-ref-{}.txt", Uuid::new_v4()));


### PR DESCRIPTION
### Motivation and Context

v0.1 raw source material should stay external while memory objects preserve stable `raw_ref` pointers for provenance. This hardens that boundary so graph/vector payloads do not become raw transcript stores and unavailable raw references remain representable.

### Description

- Adds regression coverage that domain serialization, retrieval context packs, RDF mapping, and Qdrant payloads preserve `raw_ref` pointers without storing raw transcript fields.
- Adds internal resolver tests for successful resolution, unavailable references as `Ok(None)`, resolver failures as `Err`, and deterministic fixture behavior.
- Clarifies docs that production raw storage is caller-owned/deferred, public raw-reference resolution is not part of v0.1, and persistent graph authority/reconciliation remain v0.1.1 work.
- Completes and moves the raw-reference boundary plan to `docs/coding-agent/plans/completed/`.

### Checklist

- [x] Service-free compile check passes
      `cargo check`
- [x] Service-free test target compilation passes
      `cargo test --no-run`
- [x] **Clippy** passes with warnings denied
      `cargo clippy --all-targets -- -D warnings`
- [x] Rust formatting check passes
      `cargo fmt --check`
- [x] Full Qdrant-backed integration tests pass in trusted same-repository CI or with local service configuration
      `cargo test --verbose`
- [x] Documentation updated where needed
- [x] BREAKING CHANGE? **No**
- [x] I didn't break anyone

### Additional Notes (optional)

Reviewer gate approved with no findings. Full validation passed locally. `cargo test --verbose` exited 0; Cargo emitted a non-fatal readonly global cache last-use warning after test completion.