### PR TITLE
⚡ Implement persistent graph authority

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
 QDRANT_CONNECTION_STRING="http://localhost:6334"
 OXIGRAPH_CONNECTION_STRING="http://localhost:7878"
+OXIGRAPH_TEST_CONNECTION_STRING="http://localhost:7879"
+# Oxigraph service mode is the application default. Set GRAPH_STORE_MODE="in_memory"
+# for tests/fixtures, or "persistent" for embedded filesystem persistence.
+GRAPH_STORE_MODE="service"
 OPENAI_API_KEY="YOUR_OPENAI_KEY"
 EMBEDDING_MODEL="text-embedding-3-small"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +224,15 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -251,6 +280,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -735,6 +775,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1146,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1212,6 +1267,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1333,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,6 +1385,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +1437,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "oxrdfio",
+ "oxrocksdb-sys",
  "oxsdatatypes",
  "rand 0.9.2",
  "rustc-hash",
@@ -1433,6 +1515,16 @@ dependencies = [
  "oxrdf",
  "quick-xml",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "oxrocksdb-sys"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff3a2dc533741be5f94411d715bfe42b7d1b99f9eab9a9461cd8f6cb7633faa"
+dependencies = [
+ "bindgen",
+ "cc",
 ]
 
 [[package]]
@@ -1675,7 +1767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ secrecy = { version = "0.10.3", features = ["serde"] }
 
 # Database
 qdrant-client = "1.17.0"
-oxigraph = { version = "0.5.7", default-features = false }
+oxigraph = { version = "0.5.7", default-features = false, features = ["rocksdb"] }
 serde_json = "1.0.138"
 
 # Async Runtime

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ An episode is a remembered event or interaction. Each episode can be connected t
 Retrieval is graph-authoritative and hybrid:
 
 - **Vector candidate recall:** uses Qdrant to find semantically similar memory objects
-- **Graph expansion:** uses embedded Oxigraph as the authority for entities, threads, provenance, lifecycle state, and links
+- **Graph expansion:** uses Oxigraph as the authority for entities, threads, provenance, lifecycle state, and links
 - **Temporal retrieval:** includes memories based on when they happened
 - **Entity-based retrieval:** includes memories involving the same people, projects, places, or concepts
 - **Continuity retrieval:** returns a structured `ContinuityContextPack` rather than a generic ranked list
@@ -97,7 +97,7 @@ By default, this uses:
 
 - OpenAI for embeddings
 - Qdrant for vector candidate recall and payload filtering
-- embedded Oxigraph for graph-authoritative memory objects, relationships, provenance, and lifecycle state
+- Oxigraph service mode for graph-authoritative memory objects, relationships, provenance, and lifecycle state
 
 ```rust
 let memory = CharacterMemory::new(settings, "my-assistant-memory".to_owned()).await?;
@@ -124,9 +124,9 @@ This is useful when you want to:
 
 ## Backends
 
-The default implementation is backed by Qdrant and embedded, in-memory Oxigraph.
+The default implementation is backed by Qdrant and an Oxigraph HTTP service.
 
-Qdrant is used for vector candidate recall. Embedded Oxigraph is the graph authority for memory objects, links, provenance, currentness, and lifecycle filtering within the running process. Persistent Oxigraph storage configuration is v0.1.1 future work.
+Qdrant is used for vector candidate recall. Oxigraph is the graph authority for memory objects, links, provenance, currentness, and lifecycle filtering. Local application construction defaults to `GRAPH_STORE_MODE=service` with `OXIGRAPH_CONNECTION_STRING=http://localhost:7878`. Embedded filesystem persistence remains available with `GRAPH_STORE_MODE=persistent`; deterministic tests and fixtures use `GRAPH_STORE_MODE=in_memory`.
 
 Raw source material, such as chat or voice transcripts, is caller-owned in v0.1 and is not stored by the default graph/vector backends. Memory objects may preserve `raw_ref` source pointers for provenance, but those pointers are not the transcript content and do not imply a public raw-resolution API.
 
@@ -150,6 +150,22 @@ Or using Docker Compose:
 docker compose -f docker-compose.qdrant.yml up -d
 ```
 
+### Start Oxigraph with Docker
+
+```sh
+docker compose -f docker-compose.oxigraph.yml up -d
+```
+
+The default Oxigraph HTTP endpoint is `http://localhost:7878`.
+
+Live Oxigraph smoke tests use a separate container, port, and volume:
+
+```sh
+docker compose -f docker-compose.oxigraph.test.yml up -d
+```
+
+The default live-test Oxigraph endpoint is `http://localhost:7879`. The smoke test cleans up the named graphs it creates.
+
 ## Running tests
 
 1. Copy `.env.example` to `.env`:
@@ -172,8 +188,8 @@ Do not commit your `.env` file.
 
 Character Memory is under active development.
 
-The v0.1 public architecture is graph-authoritative episodic continuity memory: public construction and facades compose an embedder, Qdrant candidate recall, and embedded Oxigraph graph authority.
+The v0.1 public architecture is graph-authoritative episodic continuity memory: public construction and facades compose an embedder, Qdrant candidate recall, and Oxigraph graph authority.
 
 v0.1 does not store raw transcripts directly in graph/vector storage, run a reflection scheduler, implement a normalized belief ontology, support multimodal memory, or perform physical redaction/delete as a default lifecycle operation.
 
-Production raw transcript storage is caller-owned and deferred. No public raw-reference resolution API is part of v0.1. Persistent graph storage authority and graph/vector reconciliation remain v0.1.1 future work rather than v0.1 behavior.
+Production raw transcript storage is caller-owned and deferred. No public raw-reference resolution API is part of v0.1.

--- a/docker-compose.oxigraph.test.yml
+++ b/docker-compose.oxigraph.test.yml
@@ -1,6 +1,6 @@
 services:
   oxigraph-test:
-    image: ghcr.io/oxigraph/oxigraph:0.5.7
+    image: ghcr.io/oxigraph/oxigraph:0.5.8
     command: ["serve", "--location", "/data", "--bind", "0.0.0.0:7878"]
     ports:
       - "7879:7878" # Dedicated live-test Oxigraph endpoint

--- a/docker-compose.oxigraph.test.yml
+++ b/docker-compose.oxigraph.test.yml
@@ -1,0 +1,11 @@
+services:
+  oxigraph-test:
+    image: ghcr.io/oxigraph/oxigraph:0.5.7
+    command: ["serve", "--location", "/data", "--bind", "0.0.0.0:7878"]
+    ports:
+      - "7879:7878" # Dedicated live-test Oxigraph endpoint
+    volumes:
+      - oxigraph_test_storage:/data
+
+volumes:
+  oxigraph_test_storage:

--- a/docker-compose.oxigraph.yml
+++ b/docker-compose.oxigraph.yml
@@ -1,0 +1,11 @@
+services:
+  oxigraph:
+    image: ghcr.io/oxigraph/oxigraph:0.5.7
+    command: ["serve", "--location", "/data", "--bind", "0.0.0.0:7878"]
+    ports:
+      - "7878:7878" # SPARQL and Graph Store HTTP Protocol
+    volumes:
+      - oxigraph_storage:/data
+
+volumes:
+  oxigraph_storage:

--- a/docker-compose.oxigraph.yml
+++ b/docker-compose.oxigraph.yml
@@ -1,6 +1,6 @@
 services:
   oxigraph:
-    image: ghcr.io/oxigraph/oxigraph:0.5.7
+    image: ghcr.io/oxigraph/oxigraph:0.5.8
     command: ["serve", "--location", "/data", "--bind", "0.0.0.0:7878"]
     ports:
       - "7878:7878" # SPARQL and Graph Store HTTP Protocol

--- a/docs/coding-agent/lessons.md
+++ b/docs/coding-agent/lessons.md
@@ -21,6 +21,30 @@ Purpose:
 
 ## Entries
 
+## 2026-05-03 - Keep Schema References Separate From Configuration Docs  [tags: documentation, scope-ownership, planning]
+
+Context:
+- Plan: v0.1.1 persistent graph authority
+- Task/Wave: documentation follow-up after PR creation
+- Roles involved: Orchestrator
+
+Symptom:
+- Added `GRAPH_STORE_MODE` and `OXIGRAPH_CONNECTION_STRING` explanations to `docs/design/database/schema_cheat_sheet.md`.
+- User clarified that the schema cheat sheet should reference actual database designs, not general database-related configuration.
+
+Root cause:
+- Treated all database-adjacent setup information as acceptable for the schema reference instead of preserving the document's narrower database-design purpose.
+
+Fix applied:
+- Removed graph-store configuration settings from the schema cheat sheet and left configuration explanation in README/design/roadmap planning docs.
+
+Prevention:
+- Keep schema reference docs focused on stored fields, graph classes/predicates, join keys, authority boundaries, and retrieval rules.
+- Put runtime service/configuration instructions in README, environment examples, operational docs, or phase plans.
+
+Evidence:
+- `docs/design/database/schema_cheat_sheet.md` no longer contains `GRAPH_STORE_MODE` or `OXIGRAPH_CONNECTION_STRING`.
+
 ## 2026-05-02 - Replan Before Implementation Direction Changes  [tags: workflow, planning, scope-ownership, validation]
 
 Context:

--- a/docs/coding-agent/lessons.md
+++ b/docs/coding-agent/lessons.md
@@ -21,6 +21,54 @@ Purpose:
 
 ## Entries
 
+## 2026-05-02 - Replan Before Implementation Direction Changes  [tags: workflow, planning, scope-ownership, validation]
+
+Context:
+- Plan: v0.1.1 persistent graph authority
+- Task/Wave: follow-up change from embedded persistence default to Docker-backed Oxigraph service default
+- Roles involved: Orchestrator
+
+Symptom:
+- Began changing code for Oxigraph service mode before updating the active execution plan.
+- User corrected the workflow: "Apply the required adjustments to the plan as well. Don't veer off plan and be fine with it."
+
+Root cause:
+- Treated a follow-up implementation preference as a local adjustment instead of a plan-changing requirement under the active harness workflow.
+
+Fix applied:
+- Updated the active plan scope, resolved decisions, task acceptance criteria, validation expectations, progress log, and decision log to make Oxigraph service mode the default and embedded filesystem persistence explicit.
+
+Prevention:
+- When a user changes implementation direction under an active plan, stop implementation first and update the plan's decisions, owns scopes, acceptance criteria, and validation gates before further code edits.
+- Do not treat passing local checks as sufficient if the plan no longer describes the current implementation direction.
+
+Evidence:
+- Active plan now records Docker-backed Oxigraph service mode, explicit embedded persistent mode, and prerequisite-gated live Oxigraph smoke validation.
+
+## 2026-05-01 - Confirm Repository Branch Convention Before Branch Creation  [tags: git, tooling, workflow]
+
+Context:
+- Plan: persistent graph authority planning branch
+- Task/Wave: branch creation before plan drafting
+- Roles involved: Orchestrator
+
+Symptom:
+- Tried generic agent-style branch names before following the repository branch naming convention.
+- User corrected the workflow: "Follow the repository branch name conventions."
+
+Root cause:
+- Used the desktop default branch prefix before consulting repo-local lessons and branch naming history.
+
+Fix applied:
+- Created the plan branch with the repository convention: `feature/2026-05-01/persistent-graph-authority-plan`.
+
+Prevention:
+- Before creating a branch, inspect repo-local rules, lessons, and visible branch naming patterns.
+- Prefer the repository convention over generic agent defaults unless the user explicitly asks for a different branch name.
+
+Evidence:
+- Current branch: `feature/2026-05-01/persistent-graph-authority-plan`.
+
 ## 2026-05-01 - Verify Copilot Re-Review Requests Against Repo Rule Before Trusting Them  [tags: tooling, review, git, workflow]
 
 Context:

--- a/docs/coding-agent/plans/active/service-remote-sparql-graph-authority-plan.md
+++ b/docs/coding-agent/plans/active/service-remote-sparql-graph-authority-plan.md
@@ -1,0 +1,313 @@
+# Plan: Service Remote SPARQL Graph Authority
+
+- status: draft
+- generated: 2026-05-03
+- last_updated: 2026-05-03
+- work_type: code
+
+## Goal
+
+- Replace the Oxigraph HTTP service adapter's whole-dataset snapshot bridge with targeted remote SPARQL query/update behavior while preserving graph-authoritative retrieval, RDF-backed hydration, lifecycle/currentness filtering, bounded expansion semantics, and embedded Oxigraph parity.
+
+## Definition of Done
+
+- Service-mode reads no longer execute an unbounded `SELECT ?g ?s ?p ?o WHERE { GRAPH ?g { ?s ?p ?o } }` for ordinary object queries, provenance queries, thread queries, bounded expansion, or diagnostics.
+- Service-mode graph reads use targeted SPARQL queries scoped by object refs, object types, provenance IDs, thread IDs, frontier refs, graph URIs, or diagnostic categories as appropriate.
+- Embedded persistent/in-memory Oxigraph behavior remains unchanged except for any shared query contract improvements needed to preserve parity.
+- Unit tests cover remote query construction or HTTP request bodies for each service read path using an in-repo test seam/fake client. Adding an external mock HTTP dependency is out of scope unless the plan is explicitly updated to own `Cargo.toml` and `Cargo.lock`.
+- Live Oxigraph smoke validation proves service-mode retrieval and cleanup still work against the dedicated test container.
+- Documentation and active roadmap notes identify the snapshot bridge as removed, not merely tracked.
+
+## Scope / Non-goals
+
+- Scope:
+  - `Cargo.toml` and `Cargo.lock` only if Task_1 explicitly replans to allow a test-only HTTP mocking dependency
+  - `src/internal/infrastructures/graph/oxigraph_authority_store.rs`
+  - `src/internal/infrastructures/graph/**`
+  - `src/internal/infrastructures/graph/sparql_selectors.rs`
+  - `src/internal/repositories/graph_authority_store.rs`
+  - `src/internal/repositories/reconciliation.rs`
+  - `docs/design/database/graph_schema_design.md`
+  - `docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md`
+  - `docs/coding-agent/plans/active/v0-1-1-persistent-graph-authority-plan.md`
+  - tests adjacent to changed production modules
+- Non-goals:
+  - Changing public `CharacterMemory` APIs or graph store mode names.
+  - Reintroducing persisted sidecar hydration or Qdrant-payload authority.
+  - Adding distributed transactions across Qdrant and Oxigraph.
+  - Replacing embedded Oxigraph with HTTP service mode in unit tests that should stay deterministic.
+  - Building a public/admin reconciliation facade.
+
+## Context (workspace)
+
+- Related files/areas:
+  - Current HTTP adapter: `src/internal/infrastructures/graph/oxigraph_authority_store.rs`
+  - Shared embedded selectors: `src/internal/infrastructures/graph/sparql_selectors.rs`
+  - Graph contract and bounded expansion helpers: `src/internal/repositories/graph_authority_store.rs`
+  - Reconciliation diagnostics: `src/internal/repositories/reconciliation.rs`
+- Existing patterns or references:
+  - Embedded Oxigraph uses `SparqlGraphSelectors` over an in-process `Store`.
+  - HTTP service mode currently snapshots all named graphs into an in-memory `Store`, then reuses embedded selector/hydration logic.
+  - The current bridge is correctness-preserving for small/local datasets but is not acceptable as the long-term service adapter for larger graph datasets.
+  - Live Oxigraph validation uses `docker-compose.oxigraph.test.yml` and `OXIGRAPH_TEST_CONNECTION_STRING=http://localhost:7879`.
+- Repo reference docs consulted:
+  - `docs/coding-agent/rules/index.md`
+  - `docs/coding-agent/rules/common.md`
+  - `docs/coding-agent/rules/orchestrator.md`
+  - `docs/coding-agent/lessons.md`
+  - `docs/design/database/graph_schema_design.md`
+  - `docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md`
+  - `docs/coding-agent/plans/active/v0-1-1-persistent-graph-authority-plan.md`
+
+## Open Questions (max 3)
+
+- Q1: Should service-mode remote query helpers live beside `OxigraphHttpGraphAuthorityStore`, or should selector abstractions be split into embedded and remote backends under `src/internal/infrastructures/graph/`?
+- Q2: Should service-mode diagnostics remain full-scan by category for this refactor, or should they be paginated/streamed to avoid large in-memory diagnostic result sets?
+- Q3: Should live Oxigraph smoke validation assert the absence of the whole-dataset snapshot query through test instrumentation, or is unit-level HTTP request-body verification sufficient?
+
+## Assumptions
+
+- A1: RDF/Oxigraph remains the only canonical graph authority for service and embedded modes.
+- A2: Domain hydration from RDF remains required; service mode may hydrate only the subset needed for each request.
+- A3: The dedicated test Oxigraph service on port 7879 remains the live-service validation target.
+- A4: This refactor should preserve public API behavior and retrieval outputs for existing tests.
+
+## Tasks
+
+### Task_1: Design Remote Query Boundary
+
+- type: design
+- owns:
+  - `docs/coding-agent/plans/active/service-remote-sparql-graph-authority-plan.md`
+  - `src/internal/infrastructures/graph/oxigraph_authority_store.rs`
+  - `src/internal/infrastructures/graph/sparql_selectors.rs`
+- depends_on: []
+- description: |
+  Decide the internal boundary for service-mode remote SPARQL helpers and map each current `snapshot_store()` read path to targeted remote query requirements. Record the final query-helper shape before implementation.
+- acceptance:
+  - Each service read path has an explicit targeted query strategy: `query_objects`, provenance lookup, thread lookup, bounded expansion, diagnostic objects, and diagnostic links.
+  - The plan identifies which logic stays shared with embedded selectors and which logic becomes service-specific.
+  - The plan records whether diagnostic reads are category-scoped, paginated, or temporarily bounded.
+  - The plan records how unit tests will assert the whole-dataset snapshot query is gone.
+  - The plan records the HTTP query test strategy: in-repo fake client/test seam by default, or an explicit replan that adds `Cargo.toml` and `Cargo.lock` to the owned scope for a test-only mock dependency.
+- validation:
+  - kind: review
+    required: true
+    owner: orchestrator
+    detail: "Plan decision log updated with remote query boundary, query strategy per read path, and test strategy"
+
+### Task_2: Add Targeted Service Query Helpers
+
+- type: impl
+- owns:
+  - `src/internal/infrastructures/graph/**`
+  - `src/internal/repositories/graph_authority_store.rs`
+  - `src/internal/repositories/reconciliation.rs`
+  - tests adjacent to changed production modules
+  - `Cargo.toml` and `Cargo.lock` only if Task_1 explicitly approves a test-only HTTP mocking dependency
+- depends_on: [Task_1]
+- description: |
+  Implement HTTP service query helpers that POST targeted SPARQL to `/query`, parse SPARQL JSON results, and hydrate only the objects/links needed by each service read path.
+- acceptance:
+  - `query_objects` fetches only requested refs/ids/types and honors limits without snapshotting unrelated graphs.
+  - Provenance and thread lookup fetch candidate derived memories plus only links needed for currentness/lifecycle/provenance filtering.
+  - Bounded expansion fetches graph frontier/link evidence iteratively or through bounded targeted queries, not through full graph snapshot.
+  - Diagnostic object/link reads do not use the whole-dataset snapshot bridge.
+  - Request-body tests or query-builder tests fail if any ordinary service read path emits the unbounded `SELECT ?g ?s ?p ?o WHERE { GRAPH ?g { ?s ?p ?o } }`.
+  - Existing service update behavior continues to replace named graphs atomically enough for current phase expectations.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --lib internal::infrastructures::graph::oxigraph_authority_store"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --lib live_smoke_endpoint_guard_allows_only_local_test_service"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "rg -n 'SELECT \\?g \\?s \\?p \\?o WHERE \\{ GRAPH \\?g \\{ \\?s \\?p \\?o \\} \\}' src/internal/infrastructures/graph should return no matches"
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Review HTTP service read paths and confirm the full graph snapshot query is not used for ordinary reads"
+
+### Task_3: Preserve Embedded/Service Parity
+
+- type: test
+- owns:
+  - `src/internal/infrastructures/graph/oxigraph_authority_store.rs`
+  - `src/internal/infrastructures/graph/sparql_selectors.rs`
+  - `src/internal/repositories/retrieve_pipeline.rs`
+  - `src/internal/repositories/reconciliation.rs`
+- depends_on: [Task_2]
+- description: |
+  Add parity tests that compare embedded and service-targeted query behavior for representative graph authority operations without requiring broad public API changes.
+- acceptance:
+  - Tests cover object query, provenance query, thread query, bounded expansion, lifecycle/currentness filtering, supersession filtering, and diagnostic reads.
+  - Tests include at least one stale/unrelated named graph that must not be fetched for a targeted object query.
+  - Retrieval behavior remains graph-authoritative when vector candidates reference missing, suppressed, non-current, or superseded memories.
+  - Reconciliation diagnostics still report vector-only, graph-only, URI mismatch, stale lifecycle/currentness, unsupported schema, and missing provenance.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --lib internal::infrastructures::graph"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --lib internal::repositories::reconciliation"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --lib internal::repositories::retrieve_pipeline"
+
+### Task_4: Live Service Validation
+
+- type: test
+- owns:
+  - `docker-compose.oxigraph.test.yml`
+  - `src/internal/infrastructures/graph/oxigraph_authority_store.rs`
+  - `docs/coding-agent/plans/active/service-remote-sparql-graph-authority-plan.md`
+- depends_on: [Task_2, Task_3]
+- description: |
+  Validate the targeted remote query implementation against the dedicated Oxigraph test container and record cleanup evidence.
+- acceptance:
+  - Live smoke uses only `OXIGRAPH_TEST_CONNECTION_STRING=http://localhost:7879`.
+  - Live smoke writes representative objects/links, exercises retrieval and lifecycle filters, and cleans up every named graph it creates.
+  - Post-smoke count for smoke graph URIs is zero.
+  - Validation evidence records the Oxigraph container image and endpoint used.
+- validation:
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "docker compose -f docker-compose.oxigraph.test.yml up -d"
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "OXIGRAPH_TEST_CONNECTION_STRING=http://localhost:7879 cargo test --lib oxigraph_http_service_live_smoke_upserts_queries_and_filters -- --ignored"
+  - kind: manual
+    required: true
+    owner: orchestrator
+    detail: "Verify smoke graph quad count is zero after cleanup"
+
+### Task_5: Documentation And Debt Removal
+
+- type: docs
+- owns:
+  - `docs/design/database/graph_schema_design.md`
+  - `docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md`
+  - `docs/coding-agent/plans/active/v0-1-1-persistent-graph-authority-plan.md`
+  - `docs/coding-agent/plans/active/service-remote-sparql-graph-authority-plan.md`
+- depends_on: [Task_2, Task_3, Task_4]
+- description: |
+  Update documentation to say the service adapter uses targeted remote SPARQL reads, and remove or close the currently tracked snapshot-bridge debt note.
+- acceptance:
+  - Docs no longer describe full-graph service snapshots as current behavior.
+  - Any remaining limits are described as explicit operational constraints rather than hidden debt.
+  - The original persistent graph authority plan references this follow-up as completed or superseded.
+  - Schema docs remain focused on database design and do not gain runtime configuration clutter.
+- validation:
+  - kind: review
+    required: true
+    owner: worker
+    detail: "Documentation cross-check against current implementation behavior and schema-cheat-sheet scope"
+
+### Task_6: Closeout Review
+
+- type: review
+- owns: []
+- depends_on: [Task_2, Task_3, Task_4, Task_5]
+- description: |
+  Review the implementation against graph authority invariants, scale/performance risk, and plan acceptance criteria.
+- acceptance:
+  - Reviewer confirms no ordinary service read path uses the whole-dataset snapshot query.
+  - Reviewer confirms no sidecar hydration or Qdrant-payload authority was introduced.
+  - Reviewer confirms service and embedded graph behavior remain aligned for covered operations.
+  - Required validation evidence is complete or explicitly waived.
+- validation:
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo fmt --check"
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo test --no-run"
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo test --lib"
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo clippy --all-targets -- -D warnings"
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "rg -n 'SELECT \\?g \\?s \\?p \\?o WHERE \\{ GRAPH \\?g \\{ \\?s \\?p \\?o \\} \\}' src/internal/infrastructures/graph should return no matches"
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Full diff review against this plan and the v0.1.1 graph-authority roadmap"
+
+## Task Waves (explicit parallel dispatch sets)
+
+Interpretation:
+- Tasks listed in the same wave are intended to be dispatched in parallel by default when `owns` are disjoint and dependencies are met.
+- Waves are executed sequentially.
+
+- Wave 1 (sequential): [Task_1]
+- Wave 2 (sequential): [Task_2]
+- Wave 3 (parallel): [Task_3]
+- Wave 4 (sequential): [Task_4]
+- Wave 5 (parallel): [Task_5]
+- Wave 6 (sequential): [Task_6]
+
+## E2E / Visual Validation Spec
+
+- Not applicable. No UI or browser-visible behavior is in scope.
+
+## Rollback / Safety
+
+- Keep embedded Oxigraph behavior as the known-good parity baseline.
+- Keep service writes scoped to named graph replacement behavior already covered by the persistent graph authority phase.
+- Live tests must use the dedicated test service endpoint on port 7879 and must keep per-test cleanup.
+- If targeted service reads cannot preserve bounded expansion/lifecycle parity cleanly, stop and replan around a shared query abstraction before changing public construction defaults.
+
+## Progress Log (append-only)
+
+- 2026-05-03 00:00 Plan drafted: [Task_1, Task_2, Task_3, Task_4, Task_5, Task_6]
+  - Summary: Created future-work plan to replace the Oxigraph HTTP service full-graph snapshot bridge with targeted remote SPARQL reads.
+  - Validation evidence: Plan-format checklist applied; implementation intentionally not started.
+  - Notes: Current worktree already contains review-fix edits from the persistent graph authority PR; this plan is a separate future-work artifact.
+
+## Decision Log (append-only; re-plans and major discoveries)
+
+- 2026-05-03 00:00 Decision:
+  - Trigger / new insight: Review accepted the service snapshot bridge as tracked debt, but requested a concrete future plan to remove it.
+  - Plan delta (what changed): Added a dedicated follow-up plan for targeted remote SPARQL service reads and validation.
+  - Tradeoffs considered: A single broad implementation task would be too risky because object query, provenance, bounded expansion, diagnostics, and live-service validation have different query shapes.
+  - User approval: pending
+
+- 2026-05-03 00:00 Decision:
+  - Trigger / new insight: Plan review found Task_2 owns was too narrow, no hard no-snapshot validation was required, and mock HTTP dependency scope was unspecified.
+  - Plan delta (what changed): Expanded Task_2 owns to graph infrastructure plus graph contract/reconciliation files, added required `rg` validation for the forbidden snapshot query, and required an in-repo fake/test seam unless a replan explicitly owns dependency changes.
+  - Tradeoffs considered: Keeping the test seam in-repo avoids adding dependencies for a future refactor plan; allowing a replan path keeps the option open if request-body testing becomes awkward without a mock server.
+  - User approval: pending
+
+## Notes
+
+- Risks:
+  - Remote SPARQL query construction can drift from embedded selector semantics if parity tests are too narrow.
+  - Bounded expansion may need iterative remote calls; a single large query could recreate the same scale problem in a different form.
+  - Diagnostics may still need pagination or streaming if graph size grows beyond local memory expectations.
+  - SPARQL JSON literal handling currently preserves lexical values; typed/language literal support should be revisited if external writers add richer RDF terms.
+- Edge cases:
+  - Missing graph roots.
+  - Vector-only candidates.
+  - Suppressed, deleted, archived, non-current, and superseded derived memories.
+  - Hub nodes with high fanout.
+  - Duplicate relation triples owned by different memory link graphs.
+  - Legacy or malformed vector payload diagnostics.

--- a/docs/coding-agent/plans/active/v0-1-1-persistent-graph-authority-plan.md
+++ b/docs/coding-agent/plans/active/v0-1-1-persistent-graph-authority-plan.md
@@ -466,7 +466,7 @@
 
 - 2026-05-03 00:50 Live Oxigraph Docker service verified.
   - Summary: Started `docker-compose.oxigraph.yml`, verified the container is running, verified the HTTP `/query` endpoint responds, and ran the ignored live Oxigraph graph-authority smoke test.
-  - Validation evidence: `docker compose -f docker-compose.oxigraph.yml up -d` pulled `ghcr.io/oxigraph/oxigraph:0.5.7` and started `charactermemory-oxigraph-1`; `docker compose -f docker-compose.oxigraph.yml ps` reported `Up` with `0.0.0.0:7878->7878/tcp`; POST `ASK { ?s ?p ?o }` to `http://localhost:7878/query` returned a SPARQL JSON response; `OXIGRAPH_CONNECTION_STRING=http://localhost:7878 cargo test --lib oxigraph_http_service_live_smoke_upserts_queries_and_filters -- --ignored` passed with 1 passed.
+  - Validation evidence: Superseded by the later `0.5.8` Docker validation entry below. The original default-service smoke started `charactermemory-oxigraph-1`, verified `0.0.0.0:7878->7878/tcp`, verified the `/query` endpoint, and passed the then-current ignored live smoke before the smoke was moved to the dedicated test service.
   - Notes: The Oxigraph container remains running after verification.
 
 - 2026-05-03 01:05 Separate Oxigraph test service and per-test cleanup verified.

--- a/docs/coding-agent/plans/active/v0-1-1-persistent-graph-authority-plan.md
+++ b/docs/coding-agent/plans/active/v0-1-1-persistent-graph-authority-plan.md
@@ -91,6 +91,7 @@
 - `OXIGRAPH_CONNECTION_STRING` is treated as the Oxigraph HTTP endpoint for service graph mode and as the filesystem path only for embedded persistent graph mode.
   - `OXIGRAPH_TEST_CONNECTION_STRING` is treated as the Oxigraph HTTP endpoint for live smoke tests and defaults to a separate local test service.
 - Tests that create durable external-service or filesystem-backed data must clean up the data they created, either per test case or within an explicitly bounded test case group.
+- Docker-backed Oxigraph services use `ghcr.io/oxigraph/oxigraph:0.5.8`.
 - `GRAPH_STORE_MODE=service` is the default application mode.
 - `GRAPH_STORE_MODE=persistent` is the explicit embedded filesystem-backed persistent mode.
 - `GRAPH_STORE_MODE=in_memory` is the explicit environment/config override for in-memory graph authority.
@@ -473,11 +474,10 @@
   - Validation evidence: `docker compose -f docker-compose.oxigraph.test.yml config` passed; `docker compose -f docker-compose.oxigraph.test.yml up -d` started `charactermemory-oxigraph-test-1` on `0.0.0.0:7879->7878/tcp`; `OXIGRAPH_TEST_CONNECTION_STRING=http://localhost:7879 cargo test --lib oxigraph_http_service_live_smoke_upserts_queries_and_filters -- --ignored` passed with 1 passed; `SELECT (COUNT(*) AS ?count) WHERE { GRAPH ?g { ?s ?p ?o } }` against `http://localhost:7879/query` returned `0` after the smoke; `cargo fmt --check`, `cargo check`, `cargo test internal::infrastructures::graph::oxigraph_authority_store --lib`, `cargo test --lib`, and `cargo clippy --all-targets -- -D warnings` passed.
   - Notes: The production/default service on port 7878 and the test service on port 7879 are separate containers and volumes. Both containers remain running after verification.
 
-- 2026-05-03 00:00 Decision:
-  - Trigger / new insight: User asked whether production usage and tests can go to different Docker containers.
-  - Plan delta (what changed): Added a separate Oxigraph test Docker service and endpoint variable for live smoke tests so test writes do not target the application/default Oxigraph service, and required tests to clean up the durable data they create.
-  - Tradeoffs considered: A separate test container/volume plus per-test cleanup is safer than deleting known fixture graphs from the application service because it avoids accidental cleanup against production-like data and avoids accumulating test residue.
-  - User approval: yes
+- 2026-05-03 00:00 Follow-up image/doc-scope correction applied.
+  - Summary: Updated Docker-backed Oxigraph services to `ghcr.io/oxigraph/oxigraph:0.5.8` and removed runtime graph-store configuration settings from the schema cheat sheet.
+  - Validation evidence: `docker compose -f docker-compose.oxigraph.yml config` and `docker compose -f docker-compose.oxigraph.test.yml config` both resolve `ghcr.io/oxigraph/oxigraph:0.5.8`; stale schema-cheat-sheet config grep found no `GRAPH_STORE_MODE` or `OXIGRAPH_CONNECTION_STRING`; `docker compose -f docker-compose.oxigraph.test.yml up -d` pulled/recreated the test service with `0.5.8`; `OXIGRAPH_TEST_CONNECTION_STRING=http://localhost:7879 cargo test --lib oxigraph_http_service_live_smoke_upserts_queries_and_filters -- --ignored` passed with 1 passed; test endpoint count returned `0` quads after smoke cleanup; `docker compose -f docker-compose.oxigraph.yml up -d` recreated the default service with `0.5.8`; default endpoint responded to SPARQL `ASK`; both default and test containers report image `ghcr.io/oxigraph/oxigraph:0.5.8`.
+  - Notes: Runtime configuration belongs in README/env/operational docs and the active phase plan, not in the schema cheat sheet.
 
 ## Decision Log (append-only; re-plans and major discoveries)
 
@@ -545,6 +545,18 @@
   - Trigger / new insight: User corrected the workflow after implementation started drifting ahead of the active plan.
   - Plan delta (what changed): Updated plan scope, decisions, task acceptance, validation expectations, and progress log before continuing further implementation/validation.
   - Tradeoffs considered: Continuing code edits without plan alignment would make validation evidence ambiguous and violate the harness workflow.
+  - User approval: yes
+
+- 2026-05-03 00:00 Decision:
+  - Trigger / new insight: User asked whether production usage and tests can go to different Docker containers.
+  - Plan delta (what changed): Added a separate Oxigraph test Docker service and endpoint variable for live smoke tests so test writes do not target the application/default Oxigraph service, and required tests to clean up the durable data they create.
+  - Tradeoffs considered: A separate test container/volume plus per-test cleanup is safer than deleting known fixture graphs from the application service because it avoids accidental cleanup against production-like data and avoids accumulating test residue.
+  - User approval: yes
+
+- 2026-05-03 00:00 Decision:
+  - Trigger / new insight: User requested Oxigraph container version `0.5.8` and clarified that schema cheat sheet should not carry runtime configuration explanations.
+  - Plan delta (what changed): Docker Compose Oxigraph image tags are updated to `ghcr.io/oxigraph/oxigraph:0.5.8`; schema cheat sheet is restored to database schema/design reference scope.
+  - Tradeoffs considered: Keeping configuration in operational docs avoids diluting the schema reference and makes service setup easier to find in README/env docs.
   - User approval: yes
 
 ## Notes

--- a/docs/coding-agent/plans/active/v0-1-1-persistent-graph-authority-plan.md
+++ b/docs/coding-agent/plans/active/v0-1-1-persistent-graph-authority-plan.md
@@ -1,0 +1,565 @@
+# Plan: v0.1.1 Persistent Graph Authority
+
+- status: in_progress
+- generated: 2026-05-01
+- last_updated: 2026-05-01
+- work_type: mixed
+
+## Goal
+- Make the Oxigraph graph authority configurable and durable across restarts while preserving graph-authoritative retrieval, lifecycle/currentness filtering, provenance validation, bounded graph expansion, and Qdrant-as-candidate-only behavior.
+
+## Definition of Done
+- Persistent and in-memory graph modes are configurable without exposing backend-specific types through public/domain contracts.
+- Persistent graph mode survives restart for objects, links, provenance, suppression, supersession, currentness, and bounded expansion.
+- Retrieval after graph restart rejects vector-only candidates and excludes suppressed, deleted, non-current, and superseded records by default.
+- Reconciliation diagnostics report vector-only, graph-only, graph URI mismatch, stale lifecycle/currentness hints, unsupported schema, and missing-provenance cases.
+- Partial-persistence behavior is explicit: degraded state may be repairable, but ungrounded vector-only memory must not influence behavior.
+- Required Rust checks, targeted restart/reconciliation tests, reviewer approval, and gated Qdrant/Oxigraph smoke-test expectations are recorded.
+
+## Scope / Non-goals
+- Scope:
+  - Graph store mode/settings with Oxigraph service graph authority as the application default, embedded persistent mode as an explicit filesystem-backed option, and in-memory mode available for tests or explicit environment configuration.
+  - Docker-backed Oxigraph service configuration aligned with the existing Qdrant service pattern.
+  - Separate Docker-backed Oxigraph test service configuration for live smoke tests so production/default service data is not touched by tests.
+  - Test cleanup for durable external-service and filesystem-backed data created by each test.
+  - Persistent Oxigraph construction and restart-safe graph-authority behavior for both service-backed and embedded persistent modes.
+  - Durable RDF/Oxigraph-backed canonical object/link hydration for reopened graph stores.
+  - Restart-safe retrieval and lifecycle/currentness regression coverage.
+  - Diagnostic Qdrant/Oxigraph reconciliation.
+  - Documentation for persistent graph setup and partial-persistence policy.
+- Non-goals:
+  - New memory object types or v0.2 continuity/reflection concepts.
+  - Distributed transactions across Qdrant and Oxigraph.
+  - Physical hard-delete/redaction policy beyond existing lifecycle semantics.
+  - Public SPARQL APIs or backend-specific public DTOs.
+  - Full raw transcript storage in graph/vector stores.
+  - Automated drift repair beyond diagnostics unless explicitly replanned.
+  - Persisted sidecar stores for canonical object/link hydration.
+
+## Context (workspace)
+- Related files/areas:
+  - `Cargo.toml`
+  - `Cargo.lock`
+  - `.env.example`
+  - `docker-compose.oxigraph.yml`
+  - `docker-compose.oxigraph.test.yml`
+  - `src/lib.rs`
+  - `src/config/**`
+  - `src/internal/infrastructures/graph/**`
+  - `src/internal/infrastructures/external_services/qdrant_vector_candidate_store.rs`
+  - `src/internal/repositories/graph_authority_store.rs`
+  - `src/internal/repositories/vector_candidate_store.rs`
+  - `src/internal/repositories/retrieve_pipeline.rs`
+  - `src/internal/repositories/correction_forget_pipeline.rs`
+  - `tests/v0_1_public_facade_tests.rs`
+  - `docs/design/database/**`
+- Existing patterns or references:
+  - `CharacterMemory::new_with_embedding_provider` originally constructed `OxigraphGraphAuthorityStore::new_in_memory()`.
+  - Existing Qdrant live-service validation is configured through `docker-compose.qdrant.yml`.
+  - `OxigraphGraphAuthorityStore` materializes RDF quads into Oxigraph named graphs, but canonical object/link hydration still depends on sidecar in-memory maps.
+  - `RetrievePipeline` already treats Qdrant candidates as non-authoritative and omits missing graph roots.
+  - `CorrectionForgetPipeline` already mutates graph first and treats vector maintenance failures as degraded state.
+  - Oxigraph `Store::open` requires the `rocksdb` feature in the current dependency family.
+- Repo reference docs consulted:
+  - `docs/coding-agent/rules/index.md`
+  - `docs/coding-agent/rules/common.md`
+  - `docs/coding-agent/rules/orchestrator.md`
+  - `docs/coding-agent/lessons.md`
+  - `docs/roadmap/development_roadmap.md`
+  - `docs/design/project_philosophy.md`
+  - `docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md`
+  - `docs/design/database/graph_schema_design.md`
+  - `docs/design/database/vector_payload_design.md`
+  - `docs/design/database/schema_cheat_sheet.md`
+  - `docs/decisions/implementation/ADR-I-0003-qdrant-oxigraph-defaults.md`
+  - `docs/decisions/implementation/ADR-I-0005-qdrant-payload-vs-graph-authority.md`
+  - `docs/decisions/implementation/ADR-I-0006-bounded-graph-expansion.md`
+  - `docs/decisions/design/ADR-D-0006-supersession-and-suppression.md`
+  - `docs/decisions/design/ADR-D-0008-preserve-source-references.md`
+
+## Open Questions (max 3)
+- None.
+
+## Resolved Decisions
+- Oxigraph service graph authority is the application default when using public construction.
+- Live Oxigraph smoke tests use a separate test service endpoint, not the application default endpoint.
+- Embedded persistent graph authority remains available as an explicit filesystem-backed mode.
+- In-memory graph authority remains available for tests and for explicit environment configuration.
+- Durable canonical hydration must reconstruct domain objects and links from RDF/Oxigraph state.
+- Persisted sidecar hydration is not an acceptable implementation path for this phase.
+- Reconciliation diagnostics remain internal/admin-facing for this phase; public facade exposure is deferred unless separately planned.
+- `OXIGRAPH_CONNECTION_STRING` is treated as the Oxigraph HTTP endpoint for service graph mode and as the filesystem path only for embedded persistent graph mode.
+  - `OXIGRAPH_TEST_CONNECTION_STRING` is treated as the Oxigraph HTTP endpoint for live smoke tests and defaults to a separate local test service.
+- Tests that create durable external-service or filesystem-backed data must clean up the data they created, either per test case or within an explicitly bounded test case group.
+- `GRAPH_STORE_MODE=service` is the default application mode.
+- `GRAPH_STORE_MODE=persistent` is the explicit embedded filesystem-backed persistent mode.
+- `GRAPH_STORE_MODE=in_memory` is the explicit environment/config override for in-memory graph authority.
+- Oxigraph persistence support is enabled through the crate dependency feature required for `Store::open`.
+
+## Assumptions
+- A1: Stable object IDs and graph IRI mapping must remain unchanged.
+- A2: Backend-specific Oxigraph/Qdrant/RDF types stay inside infrastructure modules.
+- A3: In-memory graph mode remains available for deterministic unit tests and fast local fixtures.
+- A4: Qdrant and Oxigraph live smoke tests remain prerequisite-gated and documented, not mandatory for ordinary local unit-test completion.
+- A5: Roadmap version labels are acceptable in plan/docs artifacts, but durable production comments and identifiers should use stable domain language.
+
+## Tasks
+
+### Task_1: Select Persistence Boundary And Configuration Strategy
+- type: design
+- owns:
+  - `docs/coding-agent/plans/active/v0-1-1-persistent-graph-authority-plan.md`
+- depends_on: []
+- description: |
+  Resolve the remaining implementation boundary before code changes: graph store mode config names, Oxigraph service-vs-embedded persistence strategy, public constructor behavior, and diagnostic exposure boundary. Use implementation files as read-only decision inputs and record decisions in this plan before dispatching implementation tasks.
+- acceptance:
+  - Plan records the selected graph mode/config surface for service-backed persistent-by-default behavior, explicit embedded persistent mode, and explicit in-memory override.
+  - Plan records whether Oxigraph service mode, embedded `rocksdb`, or both are supported.
+  - Plan confirms RDF/Oxigraph-backed canonical hydration remains the only accepted restart-safe hydration strategy.
+  - Plan records whether reconciliation diagnostics remain internal/admin for this phase or require a separately scoped public exposure task.
+  - Decision explicitly rejects treating Qdrant payloads as authoritative fallback data.
+  - Decision explicitly rejects persisted sidecar hydration as a fallback path.
+- validation:
+  - kind: review
+    required: true
+    owner: orchestrator
+    detail: "Decision log updated with selected boundary, tradeoffs, and impact on later Task_X owns scopes"
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Review selected boundary against v0.1.1 design, backend ADRs, and repo rules before implementation dispatch"
+
+### Task_2: Add Graph Store Mode Configuration
+- type: impl
+- owns:
+  - `src/config/**`
+  - `.env.example`
+  - `docker-compose.oxigraph.yml`
+  - `docker-compose.oxigraph.test.yml`
+  - `src/lib.rs`
+- depends_on: [Task_1]
+- description: |
+  Add application settings for graph authority mode and Oxigraph endpoint/path, then wire public construction to select service-backed, embedded persistent, or in-memory graph authority without exposing backend-specific types through public/domain APIs.
+- acceptance:
+  - Settings can express service-backed persistent, embedded persistent, and in-memory graph authority modes.
+  - Service mode has a required, validated HTTP endpoint.
+  - Live smoke tests use a separate test endpoint setting and do not default to the production/application endpoint.
+  - Embedded persistent mode has a required, validated filesystem path.
+  - In-memory mode remains available for deterministic tests and fast fixtures.
+  - Existing v0.1 public APIs continue to compile and use service-backed Oxigraph when no graph mode is configured.
+  - `.env.example` documents the graph settings without implying Qdrant is authoritative.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo fmt --check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --lib config"
+
+### Task_3: Implement Persistent Oxigraph Authority Construction
+- type: impl
+- owns:
+  - `Cargo.toml`
+  - `Cargo.lock`
+  - `docker-compose.oxigraph.yml`
+  - `docker-compose.oxigraph.test.yml`
+  - `src/internal/infrastructures/graph/**`
+- depends_on: [Task_1, Task_2]
+- description: |
+  Add Oxigraph authority construction using the selected service-backed default and embedded persistent strategy. Preserve the in-memory constructor and keep Oxigraph/RDF details inside graph infrastructure.
+- acceptance:
+  - Service graph constructor targets a durable Oxigraph HTTP service at the configured endpoint.
+  - Embedded persistent graph constructor opens or creates a durable Oxigraph store at the configured path.
+  - Docker Compose configuration can start an Oxigraph service with a persistent volume.
+  - Docker Compose configuration can start a separate Oxigraph test service with a distinct port and volume.
+  - Live smoke test deletes its created smoke graphs before completing, including failure paths that can be represented without panicking before cleanup.
+  - Filesystem-backed persistence tests remove their temporary graph directories through cleanup guards.
+  - In-memory graph constructor remains available and used by tests that do not need persistence.
+  - Store initialization errors are surfaced through existing error patterns.
+  - Persistent mode does not require public API consumers to construct Oxigraph-specific values.
+  - Tests use isolated temporary graph paths and avoid Windows file-lock assumptions.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo fmt --check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::infrastructures::graph --lib"
+  - kind: command
+    required: false
+    owner: worker
+    detail: "docker compose -f docker-compose.oxigraph.test.yml up -d"
+  - kind: command
+    required: false
+    owner: worker
+    detail: "OXIGRAPH_TEST_CONNECTION_STRING=http://localhost:7879 cargo test --lib oxigraph_http_service_live_smoke_upserts_queries_and_filters -- --ignored"
+
+### Task_4: Make RDF/Oxigraph Hydration Restart-Safe
+- type: impl
+- owns:
+  - `src/internal/infrastructures/graph/oxigraph_authority_store.rs`
+  - `src/internal/infrastructures/graph/rdf_mapping.rs`
+  - `src/internal/infrastructures/graph/sparql_selectors.rs`
+  - `src/internal/infrastructures/graph/vocabulary.rs`
+- depends_on: [Task_3]
+- description: |
+  Remove the restart-safety gap where canonical objects and links only exist in sidecar in-memory maps. Reconstruct canonical objects and links from durable RDF/Oxigraph state so reopened embedded persistent graph stores and service-backed graph snapshots can satisfy graph-authority methods without persisted sidecar hydration.
+- acceptance:
+  - Reopened embedded graph store can retrieve stored Episode, Observation, Entity, MemoryThread, and DerivedMemory objects by ID.
+  - Service-backed graph store can retrieve stored Episode, Observation, Entity, MemoryThread, and DerivedMemory objects by ID through the HTTP-backed adapter.
+  - Reopened/service-backed graph store can retrieve MemoryLink relations needed for provenance, entity links, thread links, supersession, and bounded expansion.
+  - Suppression, deletion/retention state, currentness, and supersession state survive restart.
+  - Bounded expansion after restart returns graph-validated context using durable graph state.
+  - Hydration remains deterministic and preserves stable ID to graph IRI mapping.
+  - No persisted sidecar store is introduced for canonical object/link hydration.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::infrastructures::graph::oxigraph_authority_store --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::infrastructures::graph --lib"
+  - kind: test
+    required: true
+    owner: worker
+    detail: "Targeted persistent restart tests cover objects, links, provenance, lifecycle/currentness, supersession, and bounded expansion"
+
+### Task_5: Add Retrieval-After-Restart And Lifecycle Coverage
+- type: test
+- owns:
+  - `src/internal/repositories/retrieve_pipeline.rs`
+  - `src/internal/repositories/correction_forget_pipeline.rs`
+  - `src/internal/repositories/test_support.rs`
+  - `tests/**`
+- depends_on: [Task_4]
+- description: |
+  Add regression coverage that proves retrieval after graph restart still flows through graph validation and default lifecycle/currentness filtering. Use fake or fixture vector candidates where possible so graph behavior is deterministic without live Qdrant.
+- acceptance:
+  - Retrieval after graph restart returns current graph-valid records with provenance.
+  - Retrieval after graph restart excludes suppressed, deleted, non-current, and superseded records by default.
+  - Vector candidates whose graph objects are missing are rejected from normal retrieval.
+  - Stale vector lifecycle/currentness hints cannot override graph authority.
+  - Existing public facade behavior remains compatible with the new graph configuration.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::repositories::retrieve_pipeline --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::repositories::correction_forget_pipeline --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test --test v0_1_public_facade_tests"
+  - kind: test
+    required: true
+    owner: worker
+    detail: "Targeted retrieval-after-restart tests prove graph validation and lifecycle filtering"
+
+### Task_6: Add Qdrant/Oxigraph Reconciliation Diagnostics
+- type: impl
+- owns:
+  - `src/internal/repositories/graph_authority_store.rs`
+  - `src/internal/repositories/vector_candidate_store.rs`
+  - `src/internal/repositories.rs`
+  - `src/internal/repositories/**reconciliation**`
+  - `src/internal/infrastructures/external_services/qdrant_vector_candidate_store.rs`
+  - `src/internal/infrastructures/graph/**`
+- depends_on: [Task_1, Task_4]
+- description: |
+  Add internal/admin diagnostic reconciliation for cross-store drift. Prefer backend-neutral diagnostic DTOs and fake-store test coverage. Do not expose diagnostics through the public `CharacterMemory` facade in this task; if Task_1 selects public exposure, split that into a separate follow-up task with explicit public facade ownership.
+- acceptance:
+  - Diagnostics report Qdrant point exists but graph object is missing.
+  - Diagnostics report graph object exists but Qdrant point is missing.
+  - Diagnostics report Qdrant graph URI mismatch against canonical graph URI.
+  - Diagnostics report stale Qdrant lifecycle/currentness hints when graph says suppressed, superseded, deleted, or non-current.
+  - Diagnostics report unsupported vector payload schema versions.
+  - Diagnostics report graph objects with missing required provenance.
+  - Diagnostics are internal/admin-facing and do not alter normal retrieval behavior.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo fmt --check"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo check"
+  - kind: test
+    required: true
+    owner: worker
+    detail: "Fake-store reconciliation diagnostics tests cover all required drift classes"
+  - kind: command
+    required: false
+    owner: worker
+    detail: "docker compose -f docker-compose.qdrant.yml up -d"
+  - kind: command
+    required: false
+    owner: worker
+    detail: "QDRANT_CONNECTION_STRING=http://localhost:6334 cargo test --lib qdrant_candidate_store_live_smoke_upserts_filters_searches_and_deletes -- --ignored"
+
+### Task_7: Document Persistent Graph Setup And Partial-Persistence Policy
+- type: docs
+- owns:
+  - `.env.example`
+  - `docs/design/database/**`
+  - `docs/roadmap/development_roadmap.md`
+  - `docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md`
+  - `docs/coding-agent/plans/active/v0-1-1-persistent-graph-authority-plan.md`
+- depends_on: [Task_2, Task_3, Task_4, Task_5, Task_6]
+- description: |
+  Update operational documentation to explain persistent graph configuration, restart expectations, reconciliation diagnostics, and partial-persistence visibility rules.
+- acceptance:
+  - Docs show how to configure service-backed, embedded persistent, and in-memory graph modes.
+  - Docs show how to start Oxigraph with Docker Compose.
+  - Docs explain that Oxigraph is authoritative and Qdrant payloads are candidate hints only.
+  - Docs explain acceptable degraded states and unacceptable visible states.
+  - Docs document reconciliation diagnostic categories and the initial report-not-repair boundary.
+  - Roadmap/design docs remain aligned with the implemented behavior.
+- validation:
+  - kind: review
+    required: true
+    owner: worker
+    detail: "Documentation cross-check against v0.1.1 acceptance criteria"
+
+### Task_8: Full Validation And Reviewer Gate
+- type: review
+- owns: []
+- depends_on: [Task_2, Task_3, Task_4, Task_5, Task_6, Task_7]
+- description: |
+  Run closeout validation and review the implementation against the phase plan, roadmap acceptance criteria, and backend authority invariants.
+- acceptance:
+  - Required validation evidence is present for all implementation and test tasks.
+  - Reviewer status is APPROVED.
+  - Review confirms no v0.2 concepts, distributed transaction semantics, or backend-specific public leaks were introduced.
+  - Review confirms vector-only candidates cannot become behavior-influencing memory.
+  - Any skipped live Qdrant or Oxigraph smoke test is explicitly documented with prerequisites.
+- validation:
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo fmt --check"
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo check"
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo test --no-run"
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo test --lib"
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo clippy --all-targets -- -D warnings"
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Diff review against plan acceptance, v0.1.1 design, and graph-authority invariants"
+
+## Task Waves (explicit parallel dispatch sets)
+
+- Wave 1 (parallel): [Task_1]
+- Wave 2 (parallel): [Task_2]
+- Wave 3 (parallel): [Task_3]
+- Wave 4 (parallel): [Task_4]
+- Wave 5 (parallel): [Task_5, Task_6]
+- Wave 6 (parallel): [Task_7]
+- Wave 7 (parallel): [Task_8]
+
+## E2E / Visual Validation Spec
+
+- Not applicable. Rust library/storage behavior only.
+
+## Rollback / Safety
+- Keep in-memory graph mode as a test fixture mode and explicit environment-configured override only.
+- If Oxigraph persistent dependency enablement causes platform/build instability, stop after Task_1/Task_3 and replan dependency strategy before changing retrieval behavior.
+- If full RDF-to-domain hydration proves too broad, stop and replan scope or sequencing; do not introduce persisted sidecar hydration or vector payload authority as a fallback.
+- Reconciliation diagnostics must report drift before any repair behavior is added.
+
+## Progress Log (append-only)
+
+- 2026-05-01 19:43 Draft created.
+  - Summary: Created v0.1.1 persistent graph authority phase plan on `feature/2026-05-01/persistent-graph-authority-plan`.
+  - Validation evidence: Researcher completed repository context scan; plan-only change, commands not run.
+  - Notes: Awaiting user approval before implementation.
+
+- 2026-05-01 19:50 Reviewer revision completed.
+  - Summary: Narrowed Task_1 to plan-only decisions, constrained Task_6 to internal/admin diagnostics, added repository module ownership for reconciliation wiring, and kept retrieval behavior ownership in Task_5/Task_8.
+  - Validation evidence: Reviewer had returned NEEDS_REVISION before this update; follow-up review pending.
+  - Notes: No implementation dispatched.
+
+- 2026-05-02 00:00 User decision recorded.
+  - Summary: Recorded persistent graph authority as the default, explicit in-memory mode for tests/env configuration, and RDF/Oxigraph-backed hydration as the only accepted implementation path.
+  - Validation evidence: Plan-only update; commands not run.
+  - Notes: Persisted sidecar hydration is now an explicit non-goal.
+
+- 2026-05-02 00:00 Open questions resolved.
+  - Summary: Resolved the final open question by keeping reconciliation diagnostics internal/admin-facing for this phase.
+  - Validation evidence: Plan-only update; commands not run.
+  - Notes: Public diagnostics exposure would require a separate future plan/task.
+
+- 2026-05-02 00:00 Wave 1 completed: [Task_1]
+  - Summary: Marked the plan in progress and recorded the remaining implementation-boundary decisions for graph configuration, Oxigraph persistence support, RDF/Oxigraph hydration, and internal diagnostics.
+  - Validation evidence: Orchestrator reviewed the decision entries against the plan acceptance; reviewer check pending before implementation dispatch.
+  - Notes: No production code changed in Task_1.
+
+- 2026-05-02 00:00 Wave 2/3/4 partially implemented: [Task_2, Task_3, Task_4]
+  - Summary: Added graph store mode settings, persistent-by-default constructor wiring, Oxigraph persistent constructor, RocksDB-backed Oxigraph feature, RDF/Oxigraph-backed graph hydration, named-graph replacement after reopen, and a persistent reopen regression test.
+  - Validation evidence: `cargo fmt --check` passed. `cargo check` is blocked by `oxrocksdb-sys` requiring `libclang.dll`; Visual Studio developer environment is available, but no local libclang installation was found.
+  - Notes: Do not mark Task_2, Task_3, or Task_4 done until required Cargo validation runs successfully.
+
+- 2026-05-02 00:00 Wave 5 partially implemented: [Task_6]
+  - Summary: Added internal graph/vector reconciliation diagnostics, backend-neutral diagnostic records, Qdrant scroll-backed diagnostic enumeration, fake-store diagnostic support, Oxigraph diagnostic object/link listing, and fake-store coverage for vector-only, graph-only, graph URI mismatch, stale lifecycle/currentness hints, unsupported vector schema, and missing provenance drift classes.
+  - Validation evidence: `cargo fmt --check` passed; `git diff --check` passed with line-ending warnings only. `cargo check` remains blocked by `oxrocksdb-sys`/`bindgen` failing to find `clang.dll` or `libclang.dll`.
+  - Notes: Do not mark Task_6 done until required Cargo validation and reconciliation tests run successfully.
+
+- 2026-05-02 00:00 Native validation dependency installed.
+  - Summary: Installed LLVM 22.1.4 and persisted `LIBCLANG_PATH=C:\Program Files\LLVM\bin` so `bindgen` can load `libclang.dll`.
+  - Validation evidence: `cargo check -q` passed from the Visual Studio developer environment with `LIBCLANG_PATH` set.
+  - Notes: Continue with targeted Cargo tests before marking Task_2, Task_3, Task_4, or Task_6 complete.
+
+- 2026-05-02 00:00 Wave 2/3/4/5/6 implementation validated: [Task_2, Task_3, Task_4, Task_5, Task_6, Task_7]
+  - Summary: Completed persistent-by-default graph configuration, RocksDB-backed Oxigraph persistence, RDF/Oxigraph object and link hydration, restart-safe retrieval coverage, internal reconciliation diagnostics, and persistent graph setup/partial-persistence documentation updates.
+  - Validation evidence: `cargo fmt --check` passed; `cargo check` passed; `cargo test --lib config` passed; `cargo test internal::infrastructures::graph::oxigraph_authority_store --lib` passed; `cargo test internal::infrastructures::graph --lib` passed; `cargo test internal::repositories::retrieve_pipeline --lib` passed; `cargo test internal::repositories::correction_forget_pipeline --lib` passed; `cargo test --test v0_1_public_facade_tests` passed; `cargo test internal::repositories::reconciliation --lib` passed.
+  - Notes: Live Qdrant smoke test remains prerequisite-gated and was not run.
+
+- 2026-05-02 00:00 Closeout validation completed: [Task_8]
+  - Summary: Re-ran full local closeout validation after adding the restart-retrieval regression.
+  - Validation evidence: `cargo check` passed; `cargo test --no-run` passed; `cargo test --lib` passed with 217 passed and 1 ignored live Qdrant smoke test; `cargo clippy --all-targets -- -D warnings` passed.
+  - Notes: External reviewer approval is still pending; no subagent reviewer was dispatched under the current delegation policy.
+
+- 2026-05-02 00:00 Plan delta applied for Docker-backed Oxigraph service default.
+  - Summary: Replanned graph authority configuration to make Oxigraph HTTP service mode the application default, keep embedded filesystem persistence as explicit `GRAPH_STORE_MODE=persistent`, and keep in-memory as explicit test/fixture mode.
+  - Validation evidence: Plan updated before continuing further validation; `cargo check`, `cargo test --lib config`, `cargo test internal::infrastructures::graph::oxigraph_authority_store --lib`, and `cargo test --test v0_1_public_facade_tests` had passed for the current code direction before this plan correction. Full closeout rerun pending after docs and plan alignment.
+  - Notes: Live Oxigraph service smoke is prerequisite-gated with `docker compose -f docker-compose.oxigraph.yml up -d` and `OXIGRAPH_CONNECTION_STRING=http://localhost:7878`.
+
+- 2026-05-03 00:00 Plan delta applied for separate Oxigraph test service.
+  - Summary: Replanned live Oxigraph smoke validation to use a dedicated Docker Compose service, distinct port, distinct volume, and explicit per-test cleanup instead of the application/default Oxigraph service.
+  - Validation evidence: Plan updated before code changes; implementation and validation pending.
+  - Notes: Production/default service remains `docker-compose.oxigraph.yml` on port 7878; live smoke service is planned as `docker-compose.oxigraph.test.yml` on port 7879; tests that create durable data must clean up what they create.
+
+- 2026-05-02 00:00 Plan-aligned service default validation completed.
+  - Summary: Revalidated after aligning plan, implementation, README, database docs, and roadmap docs around Oxigraph service mode as the default and embedded filesystem persistence as explicit mode.
+  - Validation evidence: Stale-default grep found no remaining embedded/filesystem-default wording in current README/design/roadmap/active-plan docs; `docker compose -f docker-compose.oxigraph.yml config` passed with a Docker config-file access warning; `cargo fmt --check` passed; `cargo check` passed; `cargo test --lib config` passed; `cargo test internal::infrastructures::graph::oxigraph_authority_store --lib` passed with 25 passed and 1 ignored live Oxigraph smoke; `cargo test --test v0_1_public_facade_tests` passed; `cargo test internal::repositories::reconciliation --lib` passed; `cargo test --no-run` passed; `cargo test --lib` passed with 218 passed and 2 ignored live service smokes; `cargo clippy --all-targets -- -D warnings` passed.
+  - Notes: Live Qdrant and live Oxigraph smoke tests remain prerequisite-gated and were not run.
+
+- 2026-05-03 00:50 Live Oxigraph Docker service verified.
+  - Summary: Started `docker-compose.oxigraph.yml`, verified the container is running, verified the HTTP `/query` endpoint responds, and ran the ignored live Oxigraph graph-authority smoke test.
+  - Validation evidence: `docker compose -f docker-compose.oxigraph.yml up -d` pulled `ghcr.io/oxigraph/oxigraph:0.5.7` and started `charactermemory-oxigraph-1`; `docker compose -f docker-compose.oxigraph.yml ps` reported `Up` with `0.0.0.0:7878->7878/tcp`; POST `ASK { ?s ?p ?o }` to `http://localhost:7878/query` returned a SPARQL JSON response; `OXIGRAPH_CONNECTION_STRING=http://localhost:7878 cargo test --lib oxigraph_http_service_live_smoke_upserts_queries_and_filters -- --ignored` passed with 1 passed.
+  - Notes: The Oxigraph container remains running after verification.
+
+- 2026-05-03 01:05 Separate Oxigraph test service and per-test cleanup verified.
+  - Summary: Added dedicated `docker-compose.oxigraph.test.yml`, moved the live smoke to `OXIGRAPH_TEST_CONNECTION_STRING`, and made the live smoke clean up the named graphs it creates. Filesystem persistence tests now use a cleanup guard for temporary graph directories.
+  - Validation evidence: `docker compose -f docker-compose.oxigraph.test.yml config` passed; `docker compose -f docker-compose.oxigraph.test.yml up -d` started `charactermemory-oxigraph-test-1` on `0.0.0.0:7879->7878/tcp`; `OXIGRAPH_TEST_CONNECTION_STRING=http://localhost:7879 cargo test --lib oxigraph_http_service_live_smoke_upserts_queries_and_filters -- --ignored` passed with 1 passed; `SELECT (COUNT(*) AS ?count) WHERE { GRAPH ?g { ?s ?p ?o } }` against `http://localhost:7879/query` returned `0` after the smoke; `cargo fmt --check`, `cargo check`, `cargo test internal::infrastructures::graph::oxigraph_authority_store --lib`, `cargo test --lib`, and `cargo clippy --all-targets -- -D warnings` passed.
+  - Notes: The production/default service on port 7878 and the test service on port 7879 are separate containers and volumes. Both containers remain running after verification.
+
+- 2026-05-03 00:00 Decision:
+  - Trigger / new insight: User asked whether production usage and tests can go to different Docker containers.
+  - Plan delta (what changed): Added a separate Oxigraph test Docker service and endpoint variable for live smoke tests so test writes do not target the application/default Oxigraph service, and required tests to clean up the durable data they create.
+  - Tradeoffs considered: A separate test container/volume plus per-test cleanup is safer than deleting known fixture graphs from the application service because it avoids accidental cleanup against production-like data and avoids accumulating test residue.
+  - User approval: yes
+
+## Decision Log (append-only; re-plans and major discoveries)
+
+- 2026-05-01 19:43 Decision:
+  - Trigger / new insight: User requested a branch and concrete plan for the persistent graph authority phase.
+  - Plan delta (what changed): Created a dedicated active execution plan rather than splitting the phase into separate plan files.
+  - Tradeoffs considered: A single plan keeps config, persistence, retrieval, reconciliation, and docs tied to one graph-authority contract while still splitting execution into Task_X waves.
+  - User approval: no
+
+- 2026-05-01 19:43 Decision:
+  - Trigger / new insight: Research found the current Oxigraph adapter persists RDF quads but hydrates canonical objects/links from in-memory sidecar maps.
+  - Plan delta (what changed): Added a dedicated restart-safe canonical hydration task before retrieval-after-restart and reconciliation work.
+  - Tradeoffs considered: Treating persistent Oxigraph as only `Store::open` would not satisfy restart-safe graph-authority behavior.
+  - User approval: no
+
+- 2026-05-01 19:50 Decision:
+  - Trigger / new insight: Reviewer found Task_6 ownership and Wave 5 dependency risks, plus Task_1 overbroad owns for a design task.
+  - Plan delta (what changed): Task_1 now owns only the active plan, Task_6 is internal/admin diagnostics only and owns `src/internal/repositories.rs`, and retrieval behavior acceptance stays in Task_5/Task_8.
+  - Tradeoffs considered: Public diagnostics exposure may be useful later, but including it here would blur owns scopes and public API decisions before the persistence boundary is settled.
+  - User approval: no
+
+- 2026-05-02 00:00 Decision:
+  - Trigger / new insight: User resolved graph mode default and ruled out persisted sidecar hydration entirely.
+  - Plan delta (what changed): Added Resolved Decisions, made persistent graph authority the default, kept in-memory mode for tests or explicit environment configuration, and made RDF/Oxigraph-backed hydration mandatory.
+  - Tradeoffs considered: Persisted sidecar hydration may have reduced implementation effort, but it would split authority and weaken the v0.1.1 persistence contract.
+  - User approval: yes
+
+- 2026-05-02 00:00 Decision:
+  - Trigger / new insight: User accepted the remaining recommendations and asked to resolve the open question.
+  - Plan delta (what changed): Reconciliation diagnostics remain internal/admin-facing in this phase; public `CharacterMemory` facade exposure is deferred.
+  - Tradeoffs considered: Internal/admin diagnostics satisfy v0.1.1 drift detection without prematurely stabilizing a public maintenance API.
+  - User approval: yes
+
+- 2026-05-02 00:00 Decision:
+  - Trigger / new insight: Implementation started and Task_1 required concrete configuration/dependency decisions before code dispatch.
+  - Plan delta (what changed): `OXIGRAPH_CONNECTION_STRING` is the persistent path setting, `GRAPH_STORE_MODE=in_memory` is the explicit in-memory override, and Oxigraph persistence support is enabled through the dependency feature needed for `Store::open`.
+  - Tradeoffs considered: Reusing the existing Oxigraph setting avoids adding a second path variable; a mode override keeps tests/local fixtures deterministic while making persistence the application default.
+  - User approval: yes
+
+- 2026-05-02 00:00 Decision:
+  - Trigger / new insight: Local validation cannot compile `oxrocksdb-sys` because `bindgen` cannot find `clang.dll`/`libclang.dll`.
+  - Plan delta (what changed): Implementation can continue, but required validation is blocked until LLVM/libclang is installed or validation runs in an environment with `LIBCLANG_PATH` configured.
+  - Tradeoffs considered: Reverting the `rocksdb` feature would avoid the local native dependency but would violate the persistent graph authority requirement.
+  - User approval: no
+
+- 2026-05-02 00:00 Decision:
+  - Trigger / new insight: User authorized installing the missing native dependency.
+  - Plan delta (what changed): LLVM/libclang is installed locally and `LIBCLANG_PATH` is persisted for future shells.
+  - Tradeoffs considered: Keeping the RocksDB-backed Oxigraph feature now has a viable Windows validation path; no dependency-strategy replan is needed for this blocker.
+  - User approval: yes
+
+- 2026-05-02 00:00 Decision:
+  - Trigger / new insight: Task_6 needs cross-store drift detection without exposing an admin API through `CharacterMemory`.
+  - Plan delta (what changed): Added internal-only diagnostic listing methods to graph/vector store contracts and a repository-level reconciliation helper; public facade exposure remains deferred.
+  - Tradeoffs considered: The small internal contract extension lets Qdrant and Oxigraph adapters report drift without changing normal retrieval behavior or treating vector payloads as authority.
+  - User approval: yes
+
+- 2026-05-02 00:00 Decision:
+  - Trigger / new insight: User requested Docker-backed Oxigraph service configuration like the existing Qdrant setup.
+  - Plan delta (what changed): Changed the default application graph mode from embedded filesystem persistence to Oxigraph HTTP service mode, added explicit embedded persistent mode, added Docker Compose service expectations, and added prerequisite-gated live Oxigraph smoke validation.
+  - Tradeoffs considered: Service mode aligns local development with Qdrant and avoids application-owned database directory concerns; embedded persistent mode remains useful for isolated local tests and does not introduce vector-payload authority or sidecar hydration.
+  - User approval: yes
+
+- 2026-05-02 00:00 Decision:
+  - Trigger / new insight: User corrected the workflow after implementation started drifting ahead of the active plan.
+  - Plan delta (what changed): Updated plan scope, decisions, task acceptance, validation expectations, and progress log before continuing further implementation/validation.
+  - Tradeoffs considered: Continuing code edits without plan alignment would make validation evidence ambiguous and violate the harness workflow.
+  - User approval: yes
+
+## Notes
+- Risks:
+  - Oxigraph persistence requires a dependency feature decision and may affect build behavior.
+  - Oxigraph service mode requires HTTP snapshot/write behavior to remain graph-authoritative and may need live smoke validation against the official container before closeout.
+  - RDF/Oxigraph-to-domain hydration is the main architectural risk.
+  - Reconciliation diagnostic access is now implemented but still requires Cargo/test validation after the native RocksDB build blocker is resolved.
+  - Live Qdrant smoke tests require Docker and `QDRANT_CONNECTION_STRING`.
+  - Live Oxigraph smoke tests require Docker and `OXIGRAPH_CONNECTION_STRING`.
+  - Live Oxigraph smoke tests must use the test service endpoint (`OXIGRAPH_TEST_CONNECTION_STRING`) rather than the application/default endpoint.
+- Edge cases:
+  - Vector point exists but graph object is missing.
+  - Graph object exists but vector point is missing.
+  - Qdrant graph URI points to the wrong canonical graph object.
+  - Qdrant payload says active/current while graph says suppressed, deleted, superseded, or non-current.
+  - Derived memory exists without required provenance.
+  - Duplicate retry writes must not inflate salience or apparent recurrence.

--- a/docs/coding-agent/plans/active/v0-1-1-persistent-graph-authority-plan.md
+++ b/docs/coding-agent/plans/active/v0-1-1-persistent-graph-authority-plan.md
@@ -563,6 +563,7 @@
 - Risks:
   - Oxigraph persistence requires a dependency feature decision and may affect build behavior.
   - Oxigraph service mode requires HTTP snapshot/write behavior to remain graph-authoritative and may need live smoke validation against the official container before closeout.
+  - Current Oxigraph service reads snapshot all named graphs into a local Oxigraph store before applying bounded selectors. This preserves RDF-backed authority for the phase, but targeted remote SPARQL reads should replace it before service mode is treated as large-dataset production-ready.
   - RDF/Oxigraph-to-domain hydration is the main architectural risk.
   - Reconciliation diagnostic access is now implemented but still requires Cargo/test validation after the native RocksDB build blocker is resolved.
   - Live Qdrant smoke tests require Docker and `QDRANT_CONNECTION_STRING`.

--- a/docs/design/database/graph_schema_design.md
+++ b/docs/design/database/graph_schema_design.md
@@ -21,7 +21,9 @@ Those questions are graph questions. The schema therefore prioritizes stable ide
 
 ## Backend Boundary
 
-Embedded in-memory Oxigraph is the default graph authority. Persistent Oxigraph storage configuration is v0.1.1 future work.
+Oxigraph service mode is the default graph authority for application construction. It is configured with `OXIGRAPH_CONNECTION_STRING` as an HTTP endpoint, for example `http://localhost:7878`, and can be started with `docker compose -f docker-compose.oxigraph.yml up -d`.
+
+Embedded filesystem persistence remains available by setting `GRAPH_STORE_MODE=persistent` and using `OXIGRAPH_CONNECTION_STRING` as a local path, for example `./data/oxigraph`. In-memory Oxigraph remains available for deterministic tests and explicit fixture runs by setting `GRAPH_STORE_MODE=in_memory`.
 
 The public domain model does not expose Oxigraph types. Domain objects are mapped into RDF at the infrastructure edge. This keeps the public API stable if the backing graph implementation changes later.
 
@@ -215,17 +217,17 @@ bound traversal by depth, fanout, object type, relation type, and lifecycle
 
 The graph is not optimized for unconstrained exploration. Character Memory retrieval should be bounded because user and assistant entities can become hubs. The schema supports expansion, but the retrieval layer controls fanout and limits.
 
-## Why Not Store Everything As Triples Only
+## Durable Hydration
 
-The embedded Oxigraph adapter also keeps canonical domain objects in memory for contract reads while materializing RDF triples. That is an implementation boundary, not a rejection of RDF.
+Canonical objects and links are hydrated from RDF/Oxigraph state. The persistent graph authority must not depend on a persisted sidecar object store or on Qdrant payloads to reconstruct domain memory after restart.
 
-It keeps the graph authority simple and deterministic:
+The hydration boundary keeps these rules explicit:
 
-- domain objects can round-trip without lossy RDF reconstruction
-- tests can validate graph behavior without committing to full SPARQL object hydration yet
-- RDF triples still exist for relationship mapping and future query expansion
+- RDF named graphs are the durable source for graph-authoritative object and link fields
+- Qdrant payloads can help find candidates, but cannot fill missing graph truth
+- multi-value RDF fields are normalized deterministically when hydrated
 
-Persistent graph storage can later move more responsibility into SPARQL-backed queries without changing the public object model. That persistent authority work remains scoped to v0.1.1-era follow-up, not the v0.1 in-memory boundary.
+This means a reopened graph store can answer object queries, link queries, provenance lookup, lifecycle filtering, supersession checks, and bounded expansion without process-local sidecar state.
 
 ## Cross-Store Contract
 
@@ -238,12 +240,22 @@ Oxigraph verifies existence, relationships, provenance, lifecycle, and context
 
 This is why the vector payload intentionally duplicates some graph-derived hints. Duplication is acceptable for speed as long as retrieval treats those hints as non-authoritative.
 
+Internal reconciliation diagnostics can report cross-store drift:
+
+- vector point exists but graph object is missing
+- graph object exists but vector point is missing
+- vector payload `graph_uri` does not match the canonical graph URI
+- vector lifecycle/currentness hints disagree with graph authority
+- vector payload schema version is unsupported
+- graph object is missing required provenance
+
+The initial boundary is report-only. Diagnostics do not change normal retrieval behavior and are not exposed through the public facade.
+
 ## Future Revisit Points
 
 Revisit this design when:
 
-- v0.1.1 persistent Oxigraph storage becomes configurable
-- SPARQL query helpers replace more in-memory object-side reads
+- public/admin reconciliation operations need a stable facade
 - belief/claim tracking adds richer factual rigor semantics
 - some relation types become important enough to deserve specialized objects
 - graph migrations need compatibility across stored schema versions

--- a/docs/design/database/schema_cheat_sheet.md
+++ b/docs/design/database/schema_cheat_sheet.md
@@ -13,6 +13,13 @@ This is the compact schema reference. The companion design notes explain why the
 | Oxigraph | Graph authority | Memory objects, typed links, provenance, lifecycle, currentness, expansion context | Semantic nearest-neighbor ranking |
 | Raw store / caller storage | Source material | Raw transcript or source content behind `raw_ref` | Canonical memory state |
 
+## Graph Store Configuration
+
+| Setting | Default | Notes |
+|---|---|---|
+| `GRAPH_STORE_MODE` | `service` | Use `persistent` for embedded filesystem persistence or `in_memory` for tests/fixtures. |
+| `OXIGRAPH_CONNECTION_STRING` | `http://localhost:7878` in `.env.example` | HTTP endpoint in service mode; filesystem path only in embedded persistent mode. |
+
 ## Cross-Store Join Keys
 
 | Field | Stored In | Purpose |
@@ -191,3 +198,7 @@ Qdrant narrows candidates.
 Oxigraph verifies graph truth.
 The final context pack follows Oxigraph state.
 ```
+
+## Reconciliation Diagnostics
+
+Internal diagnostics can report vector-only records, graph-only records, graph URI mismatch, stale lifecycle/currentness hints, unsupported vector schema versions, and graph records with missing required provenance. The initial boundary is report-only; diagnostics do not repair stores or expose a public facade API.

--- a/docs/design/database/schema_cheat_sheet.md
+++ b/docs/design/database/schema_cheat_sheet.md
@@ -13,13 +13,6 @@ This is the compact schema reference. The companion design notes explain why the
 | Oxigraph | Graph authority | Memory objects, typed links, provenance, lifecycle, currentness, expansion context | Semantic nearest-neighbor ranking |
 | Raw store / caller storage | Source material | Raw transcript or source content behind `raw_ref` | Canonical memory state |
 
-## Graph Store Configuration
-
-| Setting | Default | Notes |
-|---|---|---|
-| `GRAPH_STORE_MODE` | `service` | Use `persistent` for embedded filesystem persistence or `in_memory` for tests/fixtures. |
-| `OXIGRAPH_CONNECTION_STRING` | `http://localhost:7878` in `.env.example` | HTTP endpoint in service mode; filesystem path only in embedded persistent mode. |
-
 ## Cross-Store Join Keys
 
 | Field | Stored In | Purpose |

--- a/docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md
+++ b/docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md
@@ -139,6 +139,21 @@ In-memory mode remains useful for deterministic unit tests and local fast fixtur
 
 Persistent mode is the default recommendation for applications that expect memory to survive process restart.
 
+Implemented default service configuration:
+
+```text
+GRAPH_STORE_MODE=service
+OXIGRAPH_CONNECTION_STRING=http://localhost:7878
+```
+
+Start the local service with:
+
+```text
+docker compose -f docker-compose.oxigraph.yml up -d
+```
+
+`GRAPH_STORE_MODE=persistent` is the explicit embedded filesystem-backed mode, where `OXIGRAPH_CONNECTION_STRING` is a local path such as `./data/oxigraph`. `GRAPH_STORE_MODE=in_memory` is the explicit test/fixture override.
+
 ---
 
 # 5. Required behavior
@@ -189,6 +204,8 @@ graph object has missing required provenance
 ```
 
 Initial reconciliation may report rather than fully repair all cases.
+
+This phase keeps reconciliation internal/admin-facing. It does not expose diagnostics through the public `CharacterMemory` facade.
 
 Minimum behavior:
 

--- a/docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md
+++ b/docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md
@@ -120,24 +120,25 @@ documentation for persistent graph setup
 
 # 4. Configuration direction
 
-The graph authority should support at least two modes:
+The graph authority should support three modes:
 
 ```rust
-GraphStoreMode::InMemory
+GraphStoreMode::Service { endpoint: Url }
 GraphStoreMode::Persistent { path: PathBuf }
+GraphStoreMode::InMemory
 ```
 
 or equivalent settings:
 
 ```toml
 [graph]
-mode = "persistent"
-path = "./data/oxigraph"
+mode = "service"
+endpoint = "http://localhost:7878"
 ```
 
 In-memory mode remains useful for deterministic unit tests and local fast fixtures.
 
-Persistent mode is the default recommendation for applications that expect memory to survive process restart.
+Service mode is the default recommendation for applications that expect memory to survive process restart. Embedded filesystem persistence remains available for explicit local or isolated deployments.
 
 Implemented default service configuration:
 

--- a/docs/roadmap/development_roadmap.md
+++ b/docs/roadmap/development_roadmap.md
@@ -133,7 +133,7 @@ Set up the project so v0.1 can remain lean but future versions do not require br
 Core model package
 Storage interfaces
 Default Qdrant candidate-recall adapter
-Default embedded Oxigraph graph-authority adapter
+Default Oxigraph graph-authority adapter
 Raw store interface
 Schema/versioning utilities
 Stable ID/IRI utilities
@@ -295,7 +295,7 @@ This phase closes the gap where Qdrant candidates may survive restart while the 
 ## Goals
 
 ```text
-support persistent Oxigraph storage configuration
+support Docker-backed Oxigraph service configuration and embedded persistent storage configuration
 preserve graph-authoritative state across process restarts
 keep in-memory graph mode available for deterministic tests
 validate restart-safe retrieval
@@ -303,6 +303,8 @@ detect Qdrant/Oxigraph drift
 prevent vector-only candidates from becoming behavior-influencing memory
 document persistence configuration and operational expectations
 ```
+
+Oxigraph service mode is the application default. Embedded persistent graph mode is explicit through `GRAPH_STORE_MODE=persistent`; in-memory graph mode is reserved for tests and explicit fixture runs through `GRAPH_STORE_MODE=in_memory`.
 
 ## Non-goals
 
@@ -321,7 +323,7 @@ distributed transactions across Qdrant and Oxigraph
 
 ```text
 configurable Oxigraph graph store mode
-persistent Oxigraph graph authority implementation
+service-backed and embedded persistent Oxigraph graph authority implementation
 restart-safe graph authority tests
 retrieval behavior tests after graph restart
 Qdrant/Oxigraph reconciliation diagnostics

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,4 +1,4 @@
 mod app_settings;
 
 pub(crate) use crate::internal::config::settings::EmbeddingProviderSettings;
-pub use app_settings::Settings;
+pub use app_settings::{GraphStoreMode, Settings};

--- a/src/config/settings/app_settings.rs
+++ b/src/config/settings/app_settings.rs
@@ -2,6 +2,7 @@ use config::Config;
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use std::env;
+use std::path::{Path, PathBuf};
 
 use crate::errors::CustomError;
 use crate::internal::models::vector::EmbeddingModel;
@@ -12,6 +13,30 @@ pub struct Settings {
     oxigraph_connection_string: SecretString,
     openai_api_key: SecretString,
     embedding_model: SecretString,
+    #[serde(default)]
+    graph_store_mode: GraphStoreMode,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphStoreMode {
+    #[default]
+    Service,
+    Persistent,
+    InMemory,
+}
+
+impl GraphStoreMode {
+    fn parse(value: &str) -> Result<Self, CustomError> {
+        match value {
+            "service" => Ok(Self::Service),
+            "persistent" => Ok(Self::Persistent),
+            "in_memory" => Ok(Self::InMemory),
+            other => Err(CustomError::ConfigParseError(format!(
+                "GRAPH_STORE_MODE must be service, persistent, or in_memory, got {other}"
+            ))),
+        }
+    }
 }
 
 impl Settings {
@@ -75,12 +100,16 @@ impl Settings {
             .map_err(|e| CustomError::ConfigParseError(format!("OPENAI_API_KEY: {e}")))?;
         let embedding_model = env::var("EMBEDDING_MODEL")
             .map_err(|e| CustomError::ConfigParseError(format!("EMBEDDING_MODEL: {e}")))?;
+        let graph_store_mode = env::var("GRAPH_STORE_MODE")
+            .map(|value| GraphStoreMode::parse(&value))
+            .unwrap_or(Ok(GraphStoreMode::Service))?;
 
         Ok(Self {
             qdrant_connection_string: SecretString::new(qdrant_connection_string.into()),
             oxigraph_connection_string: SecretString::new(oxigraph_connection_string.into()),
             openai_api_key: SecretString::new(openai_api_key.into()),
             embedding_model: SecretString::new(embedding_model.into()),
+            graph_store_mode,
         })
     }
 
@@ -88,9 +117,42 @@ impl Settings {
         self.qdrant_connection_string.expose_secret()
     }
 
-    #[allow(dead_code)] // Remove once production Oxigraph configuration consumes this setting.
     pub fn get_oxigraph_connection(&self) -> &str {
         self.oxigraph_connection_string.expose_secret()
+    }
+
+    pub fn get_graph_store_mode(&self) -> GraphStoreMode {
+        self.graph_store_mode
+    }
+
+    pub fn get_oxigraph_path(&self) -> Result<PathBuf, CustomError> {
+        let configured_path = self.get_oxigraph_connection();
+        if configured_path.contains("://") {
+            return Err(CustomError::ConfigParseError(
+                "OXIGRAPH_CONNECTION_STRING must be a filesystem path for embedded persistent graph mode"
+                    .to_owned(),
+            ));
+        }
+
+        let path = Path::new(configured_path);
+        if path.as_os_str().is_empty() {
+            return Err(CustomError::ConfigParseError(
+                "OXIGRAPH_CONNECTION_STRING must be a filesystem path for persistent graph mode"
+                    .to_owned(),
+            ));
+        }
+        Ok(path.to_path_buf())
+    }
+
+    pub fn get_oxigraph_endpoint(&self) -> Result<String, CustomError> {
+        let endpoint = self.get_oxigraph_connection().trim().trim_end_matches('/');
+        if !(endpoint.starts_with("http://") || endpoint.starts_with("https://")) {
+            return Err(CustomError::ConfigParseError(
+                "OXIGRAPH_CONNECTION_STRING must be an HTTP(S) endpoint for service graph mode"
+                    .to_owned(),
+            ));
+        }
+        Ok(endpoint.to_owned())
     }
 
     pub fn get_openai_api_key(&self) -> &str {
@@ -119,6 +181,7 @@ impl Settings {
             oxigraph_connection_string,
             openai_api_key,
             embedding_model,
+            graph_store_mode: GraphStoreMode::InMemory,
         }
     }
 }
@@ -148,6 +211,53 @@ mod tests {
         let settings = result.unwrap();
         assert_eq!(settings.get_qdrant_connection(), "external_qdrant");
         assert_eq!(settings.get_oxigraph_connection(), "external_oxigraph");
+        assert_eq!(settings.get_graph_store_mode(), GraphStoreMode::Service);
+    }
+
+    #[test]
+    fn test_settings_new_accepts_in_memory_graph_override() {
+        let external_config = Config::builder()
+            .set_override("qdrant_connection_string", "external_qdrant")
+            .unwrap()
+            .set_override("oxigraph_connection_string", "external_oxigraph")
+            .unwrap()
+            .set_override("openai_api_key", "external_openai")
+            .unwrap()
+            .set_override("embedding_model", "TextEmbedding3Small")
+            .unwrap()
+            .set_override("graph_store_mode", "in_memory")
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let settings = Settings::new(external_config).unwrap();
+
+        assert_eq!(settings.get_graph_store_mode(), GraphStoreMode::InMemory);
+    }
+
+    #[test]
+    fn test_settings_new_accepts_embedded_persistent_graph_override() {
+        let external_config = Config::builder()
+            .set_override("qdrant_connection_string", "external_qdrant")
+            .unwrap()
+            .set_override("oxigraph_connection_string", "./data/oxigraph")
+            .unwrap()
+            .set_override("openai_api_key", "external_openai")
+            .unwrap()
+            .set_override("embedding_model", "TextEmbedding3Small")
+            .unwrap()
+            .set_override("graph_store_mode", "persistent")
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let settings = Settings::new(external_config).unwrap();
+
+        assert_eq!(settings.get_graph_store_mode(), GraphStoreMode::Persistent);
+        assert_eq!(
+            settings.get_oxigraph_path().unwrap(),
+            PathBuf::from("./data/oxigraph")
+        );
     }
 
     #[test]

--- a/src/internal/infrastructures/external_services/qdrant_vector_candidate_store.rs
+++ b/src/internal/infrastructures/external_services/qdrant_vector_candidate_store.rs
@@ -502,14 +502,19 @@ fn retrieved_point_to_diagnostic_record(
         CustomError::DatabaseError(format!("Invalid Qdrant object_id payload UUID: {error}"))
     })?;
     let object_type = parse_object_type(payload_string(&point.payload, OBJECT_TYPE_FIELD)?)?;
-    let surface = parse_vector_surface(payload_string(&point.payload, SURFACE_FIELD)?)?;
+    let surface = optional_payload_string(&point.payload, SURFACE_FIELD)
+        .map(parse_vector_surface)
+        .transpose()?
+        .unwrap_or(VectorSurface::Summary);
 
     Ok(VectorCandidateDiagnosticRecord {
         object_id,
         object_type,
-        graph_uri: payload_string(&point.payload, GRAPH_URI_FIELD)?,
+        graph_uri: optional_payload_string(&point.payload, GRAPH_URI_FIELD)
+            .unwrap_or_else(|| "<missing graph_uri>".to_owned()),
         surface,
-        schema_version: payload_string(&point.payload, SCHEMA_VERSION_FIELD)?,
+        schema_version: optional_payload_string(&point.payload, SCHEMA_VERSION_FIELD)
+            .unwrap_or_else(|| "<missing schema_version>".to_owned()),
         retention_state: optional_payload_string(&point.payload, RETENTION_STATE_FIELD)
             .map(parse_retention_state)
             .transpose()?,
@@ -790,6 +795,29 @@ mod tests {
         assert_eq!(matched.object_type, ObjectType::DerivedMemory);
         assert_eq!(matched.surface, VectorSurface::DerivedText);
         assert_eq!(matched.score, 0.75);
+    }
+
+    #[test]
+    fn diagnostic_mapping_reports_missing_legacy_payload_fields_without_aborting() {
+        let object_id = Uuid::new_v4();
+        let point = RetrievedPoint {
+            payload: HashMap::from([
+                (
+                    OBJECT_ID_FIELD.to_owned(),
+                    string_value(&object_id.to_string()),
+                ),
+                (OBJECT_TYPE_FIELD.to_owned(), string_value("derived_memory")),
+            ]),
+            ..Default::default()
+        };
+
+        let diagnostic = retrieved_point_to_diagnostic_record(point).expect("diagnostic maps");
+
+        assert_eq!(diagnostic.object_id, object_id);
+        assert_eq!(diagnostic.object_type, ObjectType::DerivedMemory);
+        assert_eq!(diagnostic.surface, VectorSurface::Summary);
+        assert_eq!(diagnostic.graph_uri, "<missing graph_uri>");
+        assert_eq!(diagnostic.schema_version, "<missing schema_version>");
     }
 
     #[test]

--- a/src/internal/infrastructures/external_services/qdrant_vector_candidate_store.rs
+++ b/src/internal/infrastructures/external_services/qdrant_vector_candidate_store.rs
@@ -10,25 +10,26 @@ use chrono::{DateTime, Utc};
 use qdrant_client::qdrant::{
     points_selector::PointsSelectorOneOf, value::Kind, vectors_config, Condition,
     CreateCollectionBuilder, CreateFieldIndexCollectionBuilder, DatetimeRange, DeletePointsBuilder,
-    Distance, Filter, PointStruct, ScoredPoint, SearchPointsBuilder, Timestamp,
-    UpsertPointsBuilder, VectorParams, VectorsConfig,
+    Distance, Filter, PointId, PointStruct, RetrievedPoint, ScoredPoint, ScrollPointsBuilder,
+    SearchPointsBuilder, Timestamp, UpsertPointsBuilder, VectorParams, VectorsConfig,
 };
 use qdrant_client::{config::QdrantConfig, Qdrant};
 
 use crate::api::types::{MemoryId, ObjectType};
 use crate::errors::CustomError;
 use crate::internal::models::vector::{
-    VectorCandidateFilters, VectorCandidateMatch, VectorCandidateSearch, VectorRecordEmbedding,
-    VectorSurface, VectorTimeField, VectorTimeRangeFilter,
+    VectorCandidateDiagnosticRecord, VectorCandidateFilters, VectorCandidateMatch,
+    VectorCandidateSearch, VectorRecordEmbedding, VectorSurface, VectorTimeField,
+    VectorTimeRangeFilter,
 };
 use crate::internal::repositories::VectorCandidateStore;
 
 use super::qdrant_payload::{
     qdrant_payload_index_fields, qdrant_payload_map, CREATED_AT_FIELD, ENDED_AT_FIELD,
-    ENTITY_IDS_FIELD, EPISODE_IDS_FIELD, IS_CURRENT_FIELD, IS_SUPERSEDED_FIELD,
+    ENTITY_IDS_FIELD, EPISODE_IDS_FIELD, GRAPH_URI_FIELD, IS_CURRENT_FIELD, IS_SUPERSEDED_FIELD,
     LAST_TOUCHED_AT_FIELD, OBJECT_ID_FIELD, OBJECT_TYPE_FIELD, OBSERVED_AT_FIELD,
-    PARTICIPANT_ENTITY_IDS_FIELD, RETENTION_STATE_FIELD, SPEAKER_ENTITY_ID_FIELD, STARTED_AT_FIELD,
-    SURFACE_FIELD, THREAD_IDS_FIELD, UPDATED_AT_FIELD,
+    PARTICIPANT_ENTITY_IDS_FIELD, RETENTION_STATE_FIELD, SCHEMA_VERSION_FIELD,
+    SPEAKER_ENTITY_ID_FIELD, STARTED_AT_FIELD, SURFACE_FIELD, THREAD_IDS_FIELD, UPDATED_AT_FIELD,
 };
 
 const QDRANT_CANDIDATE_TIMEOUT_SECS: u64 = 30;
@@ -211,6 +212,41 @@ impl VectorCandidateStore for QdrantVectorCandidateStore {
             .into_iter()
             .map(scored_point_to_match)
             .collect()
+    }
+
+    async fn list_candidate_diagnostics(
+        &self,
+    ) -> Result<Vec<VectorCandidateDiagnosticRecord>, CustomError> {
+        let mut records = Vec::new();
+        let mut offset: Option<PointId> = None;
+
+        loop {
+            let mut builder = ScrollPointsBuilder::new(&self.collection_name)
+                .limit(256)
+                .with_payload(true)
+                .with_vectors(false)
+                .timeout(QDRANT_CANDIDATE_TIMEOUT_SECS);
+            if let Some(next_offset) = offset {
+                builder = builder.offset(next_offset);
+            }
+
+            let response = self.client.scroll(builder).await?;
+            records.extend(
+                response
+                    .result
+                    .into_iter()
+                    .map(retrieved_point_to_diagnostic_record)
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
+
+            offset = response.next_page_offset;
+            if offset.is_none() {
+                break;
+            }
+        }
+
+        records.sort_by_key(|record| (record.object_id, object_type_rank(record.object_type)));
+        Ok(records)
     }
 
     async fn delete_candidates(&self, object_ids: &[MemoryId]) -> Result<(), CustomError> {
@@ -458,6 +494,30 @@ fn scored_point_to_match(point: ScoredPoint) -> Result<VectorCandidateMatch, Cus
     ))
 }
 
+fn retrieved_point_to_diagnostic_record(
+    point: RetrievedPoint,
+) -> Result<VectorCandidateDiagnosticRecord, CustomError> {
+    let object_id = payload_string(&point.payload, OBJECT_ID_FIELD)?;
+    let object_id = uuid::Uuid::parse_str(&object_id).map_err(|error| {
+        CustomError::DatabaseError(format!("Invalid Qdrant object_id payload UUID: {error}"))
+    })?;
+    let object_type = parse_object_type(payload_string(&point.payload, OBJECT_TYPE_FIELD)?)?;
+    let surface = parse_vector_surface(payload_string(&point.payload, SURFACE_FIELD)?)?;
+
+    Ok(VectorCandidateDiagnosticRecord {
+        object_id,
+        object_type,
+        graph_uri: payload_string(&point.payload, GRAPH_URI_FIELD)?,
+        surface,
+        schema_version: payload_string(&point.payload, SCHEMA_VERSION_FIELD)?,
+        retention_state: optional_payload_string(&point.payload, RETENTION_STATE_FIELD)
+            .map(parse_retention_state)
+            .transpose()?,
+        is_current: optional_payload_bool(&point.payload, IS_CURRENT_FIELD)?,
+        is_superseded: optional_payload_bool(&point.payload, IS_SUPERSEDED_FIELD)?,
+    })
+}
+
 fn qdrant_point_id(record: &crate::internal::models::vector::VectorRecord) -> uuid::Uuid {
     let mut first = 0xcbf29ce484222325_u64;
     let mut second = 0x9e3779b97f4a7c15_u64;
@@ -495,6 +555,29 @@ fn payload_string(
     }
 }
 
+fn optional_payload_string(
+    payload: &HashMap<String, qdrant_client::qdrant::Value>,
+    field: &str,
+) -> Option<String> {
+    match payload.get(field).and_then(|value| value.kind.as_ref()) {
+        Some(Kind::StringValue(value)) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn optional_payload_bool(
+    payload: &HashMap<String, qdrant_client::qdrant::Value>,
+    field: &str,
+) -> Result<Option<bool>, CustomError> {
+    match payload.get(field).and_then(|value| value.kind.as_ref()) {
+        Some(Kind::BoolValue(value)) => Ok(Some(*value)),
+        None => Ok(None),
+        _ => Err(CustomError::DatabaseError(format!(
+            "Invalid boolean field in Qdrant payload: {field}"
+        ))),
+    }
+}
+
 fn object_type_name(object_type: ObjectType) -> &'static str {
     match object_type {
         ObjectType::Episode => "episode",
@@ -503,6 +586,17 @@ fn object_type_name(object_type: ObjectType) -> &'static str {
         ObjectType::MemoryThread => "memory_thread",
         ObjectType::DerivedMemory => "derived_memory",
         ObjectType::MemoryLink => "memory_link",
+    }
+}
+
+fn object_type_rank(object_type: ObjectType) -> u8 {
+    match object_type {
+        ObjectType::Episode => 0,
+        ObjectType::Observation => 1,
+        ObjectType::Entity => 2,
+        ObjectType::MemoryThread => 3,
+        ObjectType::DerivedMemory => 4,
+        ObjectType::MemoryLink => 5,
     }
 }
 
@@ -546,6 +640,18 @@ fn parse_object_type(value: String) -> Result<ObjectType, CustomError> {
         "memory_link" => Ok(ObjectType::MemoryLink),
         _ => Err(CustomError::DatabaseError(format!(
             "Unknown Qdrant object_type payload value: {value}"
+        ))),
+    }
+}
+
+fn parse_retention_state(value: String) -> Result<crate::api::types::RetentionState, CustomError> {
+    match value.as_str() {
+        "active" => Ok(crate::api::types::RetentionState::Active),
+        "suppressed" => Ok(crate::api::types::RetentionState::Suppressed),
+        "archived" => Ok(crate::api::types::RetentionState::Archived),
+        "deleted" => Ok(crate::api::types::RetentionState::Deleted),
+        _ => Err(CustomError::DatabaseError(format!(
+            "Unknown Qdrant retention_state payload value: {value}"
         ))),
     }
 }

--- a/src/internal/infrastructures/graph.rs
+++ b/src/internal/infrastructures/graph.rs
@@ -3,4 +3,6 @@ mod rdf_mapping;
 mod sparql_selectors;
 mod vocabulary;
 
-pub(crate) use oxigraph_authority_store::OxigraphGraphAuthorityStore;
+pub(crate) use oxigraph_authority_store::{
+    OxigraphGraphAuthorityStore, OxigraphHttpGraphAuthorityStore,
+};

--- a/src/internal/infrastructures/graph/oxigraph_authority_store.rs
+++ b/src/internal/infrastructures/graph/oxigraph_authority_store.rs
@@ -2973,6 +2973,15 @@ mod tests {
             Ok(candidates)
         }
 
+        async fn list_candidate_diagnostics(
+            &self,
+        ) -> Result<
+            Vec<crate::internal::models::vector::VectorCandidateDiagnosticRecord>,
+            CustomError,
+        > {
+            Ok(Vec::new())
+        }
+
         async fn delete_candidates(&self, _object_ids: &[MemoryId]) -> Result<(), CustomError> {
             Ok(())
         }

--- a/src/internal/infrastructures/graph/oxigraph_authority_store.rs
+++ b/src/internal/infrastructures/graph/oxigraph_authority_store.rs
@@ -1,15 +1,22 @@
-// Embedded Oxigraph graph authority. Canonical domain objects are retained
-// for contract reads while RDF triples are materialized into Oxigraph.
+// Oxigraph graph authority. Canonical domain objects and links are written to
+// RDF and hydrated from Oxigraph.
 #![allow(dead_code)]
 
 use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
 use std::sync::{Mutex, MutexGuard};
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use oxigraph::model::{GraphName, Literal, NamedNode, NamedOrBlankNode, Quad, Term};
 use oxigraph::store::Store;
+use serde::{de::DeserializeOwned, Deserialize};
 
-use crate::api::types::{graph_uri, DerivedMemory, MemoryId, MemoryLink, MemoryObject, ObjectType};
+use crate::api::types::{
+    graph_uri, DerivedMemory, Entity, Episode, MemoryId, MemoryLink, MemoryObject, MemoryThread,
+    ObjectType, Observation,
+};
 use crate::errors::CustomError;
 use crate::internal::repositories::{
     bounded_expansion, derived_memories_by_provenance, derived_memories_by_thread,
@@ -22,9 +29,12 @@ use super::sparql_selectors::SparqlGraphSelectors;
 
 pub(crate) struct OxigraphGraphAuthorityStore {
     store: Store,
-    objects: Mutex<HashMap<(MemoryId, ObjectType), MemoryObject>>,
-    links: Mutex<HashMap<MemoryId, MemoryLink>>,
     inserted_quads: Mutex<HashMap<String, Vec<Quad>>>,
+}
+
+pub(crate) struct OxigraphHttpGraphAuthorityStore {
+    endpoint: String,
+    client: reqwest::Client,
 }
 
 impl OxigraphGraphAuthorityStore {
@@ -32,8 +42,26 @@ impl OxigraphGraphAuthorityStore {
         let store = Store::new().map_err(oxigraph_error)?;
         Ok(Self {
             store,
-            objects: Mutex::new(HashMap::new()),
-            links: Mutex::new(HashMap::new()),
+            inserted_quads: Mutex::new(HashMap::new()),
+        })
+    }
+
+    pub(crate) fn new_persistent(path: impl AsRef<Path>) -> Result<Self, CustomError> {
+        let path = path.as_ref();
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent).map_err(|error| {
+                CustomError::DatabaseError(format!(
+                    "Failed to create Oxigraph graph store parent directory {}: {error}",
+                    parent.display()
+                ))
+            })?;
+        }
+        let store = Store::open(path).map_err(oxigraph_error)?;
+        Ok(Self {
+            store,
             inserted_quads: Mutex::new(HashMap::new()),
         })
     }
@@ -61,6 +89,10 @@ impl OxigraphGraphAuthorityStore {
         for (owner_graph_uri, _) in &replacements {
             if let Some(previous_quads) = inserted_quads.get(owner_graph_uri) {
                 for quad in previous_quads {
+                    transaction.remove(quad.as_ref());
+                }
+            } else {
+                for quad in self.quads_in_graph(owner_graph_uri)? {
                     transaction.remove(quad.as_ref());
                 }
             }
@@ -91,6 +123,18 @@ impl OxigraphGraphAuthorityStore {
             self.store.remove(quad).map_err(oxigraph_error)?;
         }
         Ok(())
+    }
+
+    fn quads_in_graph(&self, owner_graph_uri: &str) -> Result<Vec<Quad>, CustomError> {
+        let graph_name = GraphName::NamedNode(NamedNode::new(owner_graph_uri)?);
+        self.store
+            .iter()
+            .filter_map(|quad| match quad {
+                Ok(quad) if quad.graph_name == graph_name => Some(Ok(quad)),
+                Ok(_) => None,
+                Err(error) => Some(Err(oxigraph_error(error))),
+            })
+            .collect()
     }
 
     #[cfg(test)]
@@ -161,6 +205,168 @@ impl OxigraphGraphAuthorityStore {
     }
 }
 
+impl OxigraphHttpGraphAuthorityStore {
+    pub(crate) fn new(endpoint: impl AsRef<str>) -> Result<Self, CustomError> {
+        let endpoint = endpoint.as_ref().trim().trim_end_matches('/');
+        if !(endpoint.starts_with("http://") || endpoint.starts_with("https://")) {
+            return Err(CustomError::ConfigParseError(
+                "Oxigraph service endpoint must start with http:// or https://".to_owned(),
+            ));
+        }
+        Ok(Self {
+            endpoint: endpoint.to_owned(),
+            client: reqwest::Client::new(),
+        })
+    }
+
+    async fn replace_triples_batch(
+        &self,
+        replacements: Vec<(String, Vec<Quad>)>,
+    ) -> Result<(), CustomError> {
+        if replacements.is_empty() {
+            return Ok(());
+        }
+
+        let mut update = String::new();
+        for (owner_graph_uri, _) in &replacements {
+            update.push_str("DELETE { GRAPH <");
+            update.push_str(owner_graph_uri);
+            update.push_str("> { ?s ?p ?o } } WHERE { GRAPH <");
+            update.push_str(owner_graph_uri);
+            update.push_str("> { ?s ?p ?o } };\n");
+        }
+        update.push_str("INSERT DATA {\n");
+        for (_, quads) in &replacements {
+            for quad in quads {
+                update.push_str(&sparql_quad(quad)?);
+                update.push('\n');
+            }
+        }
+        update.push_str("}\n");
+
+        self.post_update(update).await
+    }
+
+    async fn post_update(&self, update: String) -> Result<(), CustomError> {
+        let response = self
+            .client
+            .post(format!("{}/update", self.endpoint))
+            .header("content-type", "application/sparql-update")
+            .body(update)
+            .send()
+            .await
+            .map_err(oxigraph_http_error)?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            Err(CustomError::DatabaseError(format!(
+                "Oxigraph update failed with {status}: {body}"
+            )))
+        }
+    }
+
+    #[cfg(test)]
+    async fn delete_named_graphs(&self, graph_uris: &[String]) -> Result<(), CustomError> {
+        if graph_uris.is_empty() {
+            return Ok(());
+        }
+
+        let mut update = String::new();
+        for graph_uri in graph_uris {
+            update.push_str("DROP SILENT GRAPH <");
+            update.push_str(graph_uri);
+            update.push_str(">;\n");
+        }
+        self.post_update(update).await
+    }
+
+    #[cfg(test)]
+    async fn named_graph_quad_count(&self, graph_uris: &[String]) -> Result<usize, CustomError> {
+        if graph_uris.is_empty() {
+            return Ok(0);
+        }
+
+        let mut query = String::from("SELECT (COUNT(*) AS ?count) WHERE { VALUES ?g {");
+        for graph_uri in graph_uris {
+            query.push_str(" <");
+            query.push_str(graph_uri);
+            query.push('>');
+        }
+        query.push_str(" } GRAPH ?g { ?s ?p ?o } }");
+
+        let response = self
+            .client
+            .post(format!("{}/query", self.endpoint))
+            .header("accept", "application/sparql-results+json")
+            .header("content-type", "application/sparql-query")
+            .body(query)
+            .send()
+            .await
+            .map_err(oxigraph_http_error)?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(CustomError::DatabaseError(format!(
+                "Oxigraph query failed with {status}: {body}"
+            )));
+        }
+
+        let result = response
+            .json::<SparqlSelectResponse>()
+            .await
+            .map_err(oxigraph_http_error)?;
+        let count = result
+            .results
+            .bindings
+            .first()
+            .and_then(|binding| binding.get("count"))
+            .ok_or_else(|| {
+                CustomError::DatabaseError(
+                    "Oxigraph SPARQL count result is missing count binding".to_owned(),
+                )
+            })?;
+        count.value.parse().map_err(|error| {
+            CustomError::DatabaseError(format!("Invalid Oxigraph SPARQL count literal: {error}"))
+        })
+    }
+
+    async fn snapshot_store(&self) -> Result<Store, CustomError> {
+        let response = self
+            .client
+            .post(format!("{}/query", self.endpoint))
+            .header("accept", "application/sparql-results+json")
+            .header("content-type", "application/sparql-query")
+            .body("SELECT ?g ?s ?p ?o WHERE { GRAPH ?g { ?s ?p ?o } }".to_owned())
+            .send()
+            .await
+            .map_err(oxigraph_http_error)?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(CustomError::DatabaseError(format!(
+                "Oxigraph query failed with {status}: {body}"
+            )));
+        }
+
+        let result = response
+            .json::<SparqlSelectResponse>()
+            .await
+            .map_err(oxigraph_http_error)?;
+        let store = Store::new().map_err(oxigraph_error)?;
+        for binding in result.results.bindings {
+            store
+                .insert(&quad_from_sparql_binding(&binding)?)
+                .map_err(oxigraph_error)?;
+        }
+        Ok(store)
+    }
+}
+
 fn quads_for_triples(
     owner_graph_uri: &str,
     triples: &[RdfTriple],
@@ -169,6 +375,117 @@ fn quads_for_triples(
         .iter()
         .map(|triple| quad_for_triple(owner_graph_uri, triple))
         .collect()
+}
+
+fn sparql_quad(quad: &Quad) -> Result<String, CustomError> {
+    let GraphName::NamedNode(graph_name) = &quad.graph_name else {
+        return Err(CustomError::DatabaseError(
+            "Oxigraph service writes require named graphs".to_owned(),
+        ));
+    };
+    let NamedOrBlankNode::NamedNode(subject) = &quad.subject else {
+        return Err(CustomError::DatabaseError(
+            "Oxigraph service writes require named-node subjects".to_owned(),
+        ));
+    };
+
+    Ok(format!(
+        "GRAPH <{}> {{ <{}> <{}> {} . }}",
+        graph_name.as_str(),
+        subject.as_str(),
+        quad.predicate.as_str(),
+        sparql_term(&quad.object)?
+    ))
+}
+
+fn sparql_term(term: &Term) -> Result<String, CustomError> {
+    match term {
+        Term::NamedNode(value) => Ok(format!("<{}>", value.as_str())),
+        Term::Literal(value) => Ok(format!("\"{}\"", sparql_escape_literal(value.value()))),
+        Term::BlankNode(_) => Err(CustomError::DatabaseError(
+            "Oxigraph service writes do not support blank-node objects".to_owned(),
+        )),
+    }
+}
+
+fn sparql_escape_literal(value: &str) -> String {
+    let mut escaped = String::new();
+    for character in value.chars() {
+        match character {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            _ => escaped.push(character),
+        }
+    }
+    escaped
+}
+
+#[derive(Debug, Deserialize)]
+struct SparqlSelectResponse {
+    results: SparqlResults,
+}
+
+#[derive(Debug, Deserialize)]
+struct SparqlResults {
+    bindings: Vec<HashMap<String, SparqlBinding>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SparqlBinding {
+    #[serde(rename = "type")]
+    kind: String,
+    value: String,
+}
+
+fn quad_from_sparql_binding(binding: &HashMap<String, SparqlBinding>) -> Result<Quad, CustomError> {
+    let graph = named_node_binding(binding, "g")?;
+    let subject = named_node_binding(binding, "s")?;
+    let predicate = named_node_binding(binding, "p")?;
+    let object = term_binding(binding, "o")?;
+
+    Ok(Quad::new(
+        NamedOrBlankNode::NamedNode(subject),
+        predicate,
+        object,
+        GraphName::NamedNode(graph),
+    ))
+}
+
+fn named_node_binding(
+    binding: &HashMap<String, SparqlBinding>,
+    name: &'static str,
+) -> Result<NamedNode, CustomError> {
+    let value = binding.get(name).ok_or_else(|| {
+        CustomError::DatabaseError(format!("Oxigraph SPARQL result is missing binding {name}"))
+    })?;
+    if value.kind != "uri" {
+        return Err(CustomError::DatabaseError(format!(
+            "Oxigraph SPARQL binding {name} must be a uri, got {}",
+            value.kind
+        )));
+    }
+    NamedNode::new(value.value.as_str()).map_err(CustomError::from)
+}
+
+fn term_binding(
+    binding: &HashMap<String, SparqlBinding>,
+    name: &'static str,
+) -> Result<Term, CustomError> {
+    let value = binding.get(name).ok_or_else(|| {
+        CustomError::DatabaseError(format!("Oxigraph SPARQL result is missing binding {name}"))
+    })?;
+    match value.kind.as_str() {
+        "uri" => Ok(Term::NamedNode(NamedNode::new(value.value.as_str())?)),
+        "literal" | "typed-literal" => Ok(Term::Literal(Literal::new_simple_literal(
+            value.value.as_str(),
+        ))),
+        other => Err(CustomError::DatabaseError(format!(
+            "Oxigraph SPARQL binding {name} has unsupported term type {other}"
+        ))),
+    }
 }
 
 #[async_trait]
@@ -189,10 +506,6 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
 
         self.replace_triples_batch(replacements)?;
 
-        let mut stored = lock(&self.objects)?;
-        for object in objects {
-            stored.insert(object_identity(object), object.clone());
-        }
         Ok(())
     }
 
@@ -210,10 +523,6 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
 
         self.replace_triples_batch(replacements)?;
 
-        let mut stored = lock(&self.links)?;
-        for link in links {
-            stored.insert(link.id, link.clone());
-        }
         Ok(())
     }
 
@@ -247,15 +556,6 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
 
         self.replace_triples_batch(replacements)?;
 
-        let mut stored_objects = lock(&self.objects)?;
-        for object in objects {
-            stored_objects.insert(object_identity(object), object.clone());
-        }
-        let mut stored_links = lock(&self.links)?;
-        for link in links {
-            stored_links.insert(link.id, link.clone());
-        }
-
         Ok(())
     }
 
@@ -264,8 +564,7 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
         query: &GraphObjectQuery,
     ) -> Result<Vec<MemoryObject>, CustomError> {
         let selected_refs = SparqlGraphSelectors::new(&self.store).select_objects(query)?;
-        let objects = lock(&self.objects)?;
-        Ok(hydrate_objects_by_refs(&selected_refs, &objects))
+        hydrate_objects_by_refs_from_store(&self.store, &selected_refs)
     }
 
     async fn query_derived_memories_by_provenance(
@@ -279,14 +578,21 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
             .into_iter()
             .collect::<HashSet<_>>();
 
-        let objects = lock(&self.objects)?.clone();
-        let links = lock(&self.links)?.clone();
+        let objects = hydrate_objects_by_refs_from_store(
+            &self.store,
+            &selected_ids
+                .iter()
+                .copied()
+                .map(|id| GraphObjectRef::new(id, ObjectType::DerivedMemory))
+                .collect::<Vec<_>>(),
+        )?;
+        let links = hydrate_all_links_from_store(&self.store)?;
         Ok(derived_memories_by_provenance(
             query,
-            objects
-                .into_values()
-                .filter(|object| matches!(object, MemoryObject::DerivedMemory(memory) if selected_ids.contains(&memory.id))),
-            links.into_values(),
+            objects.into_iter().filter(
+                |object| matches!(object, MemoryObject::DerivedMemory(memory) if selected_ids.contains(&memory.id)),
+            ),
+            links,
         ))
     }
 
@@ -301,14 +607,21 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
             .into_iter()
             .collect::<HashSet<_>>();
 
-        let objects = lock(&self.objects)?.clone();
-        let links = lock(&self.links)?.clone();
+        let objects = hydrate_objects_by_refs_from_store(
+            &self.store,
+            &selected_ids
+                .iter()
+                .copied()
+                .map(|id| GraphObjectRef::new(id, ObjectType::DerivedMemory))
+                .collect::<Vec<_>>(),
+        )?;
+        let links = hydrate_all_links_from_store(&self.store)?;
         Ok(derived_memories_by_thread(
             query,
-            objects
-                .into_values()
-                .filter(|object| matches!(object, MemoryObject::DerivedMemory(memory) if selected_ids.contains(&memory.id))),
-            links.into_values(),
+            objects.into_iter().filter(
+                |object| matches!(object, MemoryObject::DerivedMemory(memory) if selected_ids.contains(&memory.id)),
+            ),
+            links,
         ))
     }
 
@@ -327,22 +640,588 @@ impl GraphAuthorityStore for OxigraphGraphAuthorityStore {
         }
 
         let visibility = bounded_graph_visible_refs(&selectors, root_ref, query)?;
-        let objects = {
-            let objects = lock(&self.objects)?;
-            hydrate_objects_by_ref_set(&visibility.object_refs, &objects)
-        };
-        let links = {
-            let links = lock(&self.links)?;
-            hydrate_links_by_id_sets(
-                &visibility.traversal_link_ids,
-                &visibility.lifecycle_link_ids,
-                &visibility.object_refs,
-                &links,
-            )
-        };
+        let objects = hydrate_objects_by_refs_from_store(
+            &self.store,
+            &visibility.object_refs.iter().copied().collect::<Vec<_>>(),
+        )?;
+        let links = hydrate_links_by_id_sets_from_store(
+            &self.store,
+            &visibility.traversal_link_ids,
+            &visibility.lifecycle_link_ids,
+            &visibility.object_refs,
+        )?;
 
         bounded_expansion(query, objects, links)
     }
+
+    async fn list_diagnostic_objects(&self) -> Result<Vec<MemoryObject>, CustomError> {
+        let object_types = [
+            ObjectType::Episode,
+            ObjectType::Observation,
+            ObjectType::Entity,
+            ObjectType::MemoryThread,
+            ObjectType::DerivedMemory,
+        ];
+        let object_refs = SparqlGraphSelectors::new(&self.store)
+            .select_objects(&GraphObjectQuery::by_types(object_types.to_vec(), None))?;
+        hydrate_objects_by_refs_from_store(&self.store, &object_refs)
+    }
+
+    async fn list_diagnostic_links(&self) -> Result<Vec<MemoryLink>, CustomError> {
+        hydrate_all_links_from_store(&self.store)
+    }
+}
+
+#[async_trait]
+impl GraphAuthorityStore for OxigraphHttpGraphAuthorityStore {
+    async fn upsert_objects(&self, objects: &[MemoryObject]) -> Result<(), CustomError> {
+        let mut replacements = Vec::new();
+        for object in objects {
+            object
+                .validate()
+                .map_err(|error| CustomError::MemoryValidation(error.to_string()))?;
+            let (object_id, object_type) = object_identity(object);
+            let owner_graph_uri = graph_uri(object_type, object_id);
+            replacements.push((
+                owner_graph_uri.clone(),
+                quads_for_triples(&owner_graph_uri, &rdf_triples_for_object(object)?)?,
+            ));
+        }
+
+        self.replace_triples_batch(replacements).await
+    }
+
+    async fn upsert_links(&self, links: &[MemoryLink]) -> Result<(), CustomError> {
+        let mut replacements = Vec::new();
+        for link in links {
+            link.validate()
+                .map_err(|error| CustomError::MemoryValidation(error.to_string()))?;
+            let owner_graph_uri = graph_uri(ObjectType::MemoryLink, link.id);
+            replacements.push((
+                owner_graph_uri.clone(),
+                quads_for_triples(&owner_graph_uri, &rdf_triples_for_link(link)?)?,
+            ));
+        }
+
+        self.replace_triples_batch(replacements).await
+    }
+
+    async fn upsert_objects_and_links(
+        &self,
+        objects: &[MemoryObject],
+        links: &[MemoryLink],
+    ) -> Result<(), CustomError> {
+        let mut replacements = Vec::new();
+        for object in objects {
+            object
+                .validate()
+                .map_err(|error| CustomError::MemoryValidation(error.to_string()))?;
+            let (object_id, object_type) = object_identity(object);
+            let owner_graph_uri = graph_uri(object_type, object_id);
+            replacements.push((
+                owner_graph_uri.clone(),
+                quads_for_triples(&owner_graph_uri, &rdf_triples_for_object(object)?)?,
+            ));
+        }
+
+        for link in links {
+            link.validate()
+                .map_err(|error| CustomError::MemoryValidation(error.to_string()))?;
+            let owner_graph_uri = graph_uri(ObjectType::MemoryLink, link.id);
+            replacements.push((
+                owner_graph_uri.clone(),
+                quads_for_triples(&owner_graph_uri, &rdf_triples_for_link(link)?)?,
+            ));
+        }
+
+        self.replace_triples_batch(replacements).await
+    }
+
+    async fn query_objects(
+        &self,
+        query: &GraphObjectQuery,
+    ) -> Result<Vec<MemoryObject>, CustomError> {
+        let store = self.snapshot_store().await?;
+        let selected_refs = SparqlGraphSelectors::new(&store).select_objects(query)?;
+        hydrate_objects_by_refs_from_store(&store, &selected_refs)
+    }
+
+    async fn query_derived_memories_by_provenance(
+        &self,
+        query: &GraphDerivedMemoryProvenanceQuery,
+    ) -> Result<Vec<DerivedMemory>, CustomError> {
+        let store = self.snapshot_store().await?;
+        let mut selector_query = query.clone();
+        selector_query.limit = None;
+        let selected_ids = SparqlGraphSelectors::new(&store)
+            .select_derived_memories_by_provenance(&selector_query)?
+            .into_iter()
+            .collect::<HashSet<_>>();
+
+        let objects = hydrate_objects_by_refs_from_store(
+            &store,
+            &selected_ids
+                .iter()
+                .copied()
+                .map(|id| GraphObjectRef::new(id, ObjectType::DerivedMemory))
+                .collect::<Vec<_>>(),
+        )?;
+        let links = hydrate_all_links_from_store(&store)?;
+        Ok(derived_memories_by_provenance(
+            query,
+            objects.into_iter().filter(
+                |object| matches!(object, MemoryObject::DerivedMemory(memory) if selected_ids.contains(&memory.id)),
+            ),
+            links,
+        ))
+    }
+
+    async fn query_derived_memories_by_thread(
+        &self,
+        query: &GraphDerivedMemoryThreadQuery,
+    ) -> Result<Vec<DerivedMemory>, CustomError> {
+        let store = self.snapshot_store().await?;
+        let mut selector_query = query.clone();
+        selector_query.limit = None;
+        let selected_ids = SparqlGraphSelectors::new(&store)
+            .select_derived_memories_by_thread(&selector_query)?
+            .into_iter()
+            .collect::<HashSet<_>>();
+
+        let objects = hydrate_objects_by_refs_from_store(
+            &store,
+            &selected_ids
+                .iter()
+                .copied()
+                .map(|id| GraphObjectRef::new(id, ObjectType::DerivedMemory))
+                .collect::<Vec<_>>(),
+        )?;
+        let links = hydrate_all_links_from_store(&store)?;
+        Ok(derived_memories_by_thread(
+            query,
+            objects.into_iter().filter(
+                |object| matches!(object, MemoryObject::DerivedMemory(memory) if selected_ids.contains(&memory.id)),
+            ),
+            links,
+        ))
+    }
+
+    async fn expand_bounded(
+        &self,
+        query: &GraphExpansionQuery,
+    ) -> Result<GraphExpansion, CustomError> {
+        let store = self.snapshot_store().await?;
+        let selectors = SparqlGraphSelectors::new(&store);
+        let root_ref = GraphObjectRef::new(query.root_id, query.root_type);
+        let root_refs = selectors.select_objects(&GraphObjectQuery::by_refs(vec![root_ref]))?;
+        if root_refs.is_empty() {
+            return Err(CustomError::GraphExpansionRootNotFound {
+                object_type: query.root_type,
+                object_id: query.root_id,
+            });
+        }
+
+        let visibility = bounded_graph_visible_refs(&selectors, root_ref, query)?;
+        let objects = hydrate_objects_by_refs_from_store(
+            &store,
+            &visibility.object_refs.iter().copied().collect::<Vec<_>>(),
+        )?;
+        let links = hydrate_links_by_id_sets_from_store(
+            &store,
+            &visibility.traversal_link_ids,
+            &visibility.lifecycle_link_ids,
+            &visibility.object_refs,
+        )?;
+
+        bounded_expansion(query, objects, links)
+    }
+
+    async fn list_diagnostic_objects(&self) -> Result<Vec<MemoryObject>, CustomError> {
+        let store = self.snapshot_store().await?;
+        let object_types = [
+            ObjectType::Episode,
+            ObjectType::Observation,
+            ObjectType::Entity,
+            ObjectType::MemoryThread,
+            ObjectType::DerivedMemory,
+        ];
+        let object_refs = SparqlGraphSelectors::new(&store)
+            .select_objects(&GraphObjectQuery::by_types(object_types.to_vec(), None))?;
+        hydrate_objects_by_refs_from_store(&store, &object_refs)
+    }
+
+    async fn list_diagnostic_links(&self) -> Result<Vec<MemoryLink>, CustomError> {
+        let store = self.snapshot_store().await?;
+        hydrate_all_links_from_store(&store)
+    }
+}
+
+#[derive(Debug, Default)]
+struct RdfSubjectValues {
+    literals: HashMap<String, Vec<String>>,
+    resources: HashMap<String, Vec<String>>,
+}
+
+impl RdfSubjectValues {
+    fn push_literal(&mut self, predicate: String, value: String) {
+        self.literals.entry(predicate).or_default().push(value);
+    }
+
+    fn push_resource(&mut self, predicate: String, value: String) {
+        self.resources.entry(predicate).or_default().push(value);
+    }
+
+    fn literal(&self, subject: &str, predicate: &'static str) -> Result<String, CustomError> {
+        self.literals
+            .get(predicate)
+            .and_then(|values| values.first())
+            .cloned()
+            .ok_or_else(|| missing_rdf_value(subject, predicate))
+    }
+
+    fn optional_literal(&self, predicate: &'static str) -> Option<String> {
+        self.literals
+            .get(predicate)
+            .and_then(|values| values.first())
+            .cloned()
+    }
+
+    fn literal_values(&self, predicate: &'static str) -> Vec<String> {
+        self.literals.get(predicate).cloned().unwrap_or_default()
+    }
+
+    fn resource(&self, subject: &str, predicate: &'static str) -> Result<String, CustomError> {
+        self.resources
+            .get(predicate)
+            .and_then(|values| values.first())
+            .cloned()
+            .ok_or_else(|| missing_rdf_value(subject, predicate))
+    }
+
+    fn resource_values(&self, predicate: &'static str) -> Vec<String> {
+        self.resources.get(predicate).cloned().unwrap_or_default()
+    }
+}
+
+fn hydrate_objects_by_refs_from_store(
+    store: &Store,
+    refs: &[GraphObjectRef],
+) -> Result<Vec<MemoryObject>, CustomError> {
+    let subjects = rdf_subject_values(store)?;
+    let mut objects = Vec::new();
+    for object_ref in refs {
+        if object_ref.object_type == ObjectType::MemoryLink {
+            continue;
+        }
+        let subject = graph_uri(object_ref.object_type, object_ref.object_id);
+        if let Some(values) = subjects.get(&subject) {
+            objects.push(memory_object_from_rdf(
+                &subject,
+                values,
+                object_ref.object_type,
+            )?);
+        }
+    }
+    sort_objects(&mut objects);
+    Ok(objects)
+}
+
+fn hydrate_all_links_from_store(store: &Store) -> Result<Vec<MemoryLink>, CustomError> {
+    let subjects = rdf_subject_values(store)?;
+    let mut links = subjects
+        .iter()
+        .filter_map(|(subject, values)| {
+            let object_type = values
+                .optional_literal(super::vocabulary::OBJECT_TYPE)
+                .and_then(|value| enum_value_from_literal::<ObjectType>(&value).ok());
+            match object_type {
+                Some(ObjectType::MemoryLink) => Some(memory_link_from_rdf(subject, values)),
+                _ => None,
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    links.sort_by_key(|link| link.id);
+    Ok(links)
+}
+
+fn hydrate_links_by_id_sets_from_store(
+    store: &Store,
+    graph_link_ids: &HashSet<MemoryId>,
+    lifecycle_link_ids: &HashSet<MemoryId>,
+    graph_ref_set: &HashSet<GraphObjectRef>,
+) -> Result<Vec<MemoryLink>, CustomError> {
+    let links = hydrate_all_links_from_store(store)?;
+    Ok(links
+        .into_iter()
+        .filter(|link| graph_link_ids.contains(&link.id) || lifecycle_link_ids.contains(&link.id))
+        .filter(|link| {
+            let endpoints_in_graph = graph_ref_set
+                .contains(&GraphObjectRef::new(link.from_id, link.from_type))
+                && graph_ref_set.contains(&GraphObjectRef::new(link.to_id, link.to_type));
+            (graph_link_ids.contains(&link.id) && endpoints_in_graph)
+                || lifecycle_link_ids.contains(&link.id)
+        })
+        .collect())
+}
+
+fn rdf_subject_values(store: &Store) -> Result<HashMap<String, RdfSubjectValues>, CustomError> {
+    let mut subjects = HashMap::<String, RdfSubjectValues>::new();
+    for quad in store.iter() {
+        let quad = quad.map_err(oxigraph_error)?;
+        if !matches!(quad.graph_name, GraphName::NamedNode(_)) {
+            continue;
+        }
+        let NamedOrBlankNode::NamedNode(subject) = quad.subject else {
+            continue;
+        };
+        let values = subjects.entry(subject.as_str().to_owned()).or_default();
+        match quad.object {
+            Term::NamedNode(value) => values.push_resource(
+                quad.predicate.as_str().to_owned(),
+                value.as_str().to_owned(),
+            ),
+            Term::Literal(value) => {
+                values.push_literal(quad.predicate.as_str().to_owned(), value.value().to_owned())
+            }
+            Term::BlankNode(_) => {}
+        }
+    }
+    Ok(subjects)
+}
+
+fn memory_object_from_rdf(
+    subject: &str,
+    values: &RdfSubjectValues,
+    object_type: ObjectType,
+) -> Result<MemoryObject, CustomError> {
+    match object_type {
+        ObjectType::Episode => Ok(MemoryObject::Episode(Episode {
+            id: memory_id_literal(subject, values, super::vocabulary::OBJECT_ID)?,
+            object_type,
+            modality: enum_literal(subject, values, super::vocabulary::MODALITY)?,
+            source_conversation_id: values
+                .optional_literal(super::vocabulary::SOURCE_CONVERSATION_ID),
+            started_at: optional_timestamp_literal(values, super::vocabulary::STARTED_AT)?,
+            ended_at: optional_timestamp_literal(values, super::vocabulary::ENDED_AT)?,
+            participant_entity_ids: memory_ids_from_resources(
+                values.resource_values(super::vocabulary::PARTICIPANT_ENTITY),
+            )?,
+            summary: values.literal(subject, super::vocabulary::SUMMARY)?,
+            raw_ref: values.optional_literal(super::vocabulary::RAW_REF),
+            salience_score: f32_literal(subject, values, super::vocabulary::SALIENCE_SCORE)?,
+            retention_state: enum_literal(subject, values, super::vocabulary::RETENTION_STATE)?,
+            created_at: timestamp_literal(subject, values, super::vocabulary::CREATED_AT)?,
+            schema_version: values.literal(subject, super::vocabulary::SCHEMA_VERSION)?,
+        })),
+        ObjectType::Observation => Ok(MemoryObject::Observation(Observation {
+            id: memory_id_literal(subject, values, super::vocabulary::OBJECT_ID)?,
+            object_type,
+            episode_id: memory_id_from_resource(
+                &values.resource(subject, super::vocabulary::EPISODE)?,
+            )?,
+            speaker_entity_id: values
+                .resource_values(super::vocabulary::SPEAKER_ENTITY)
+                .first()
+                .map(|value| memory_id_from_resource(value))
+                .transpose()?,
+            observed_at: optional_timestamp_literal(values, super::vocabulary::OBSERVED_AT)?,
+            modality: enum_literal(subject, values, super::vocabulary::MODALITY)?,
+            text: values.literal(subject, super::vocabulary::TEXT)?,
+            raw_ref: values.optional_literal(super::vocabulary::RAW_REF),
+            salience_score: f32_literal(subject, values, super::vocabulary::SALIENCE_SCORE)?,
+            retention_state: enum_literal(subject, values, super::vocabulary::RETENTION_STATE)?,
+            created_at: timestamp_literal(subject, values, super::vocabulary::CREATED_AT)?,
+            schema_version: values.literal(subject, super::vocabulary::SCHEMA_VERSION)?,
+        })),
+        ObjectType::Entity => Ok(MemoryObject::Entity(Entity {
+            id: memory_id_literal(subject, values, super::vocabulary::OBJECT_ID)?,
+            object_type,
+            entity_type: enum_literal(subject, values, super::vocabulary::ENTITY_TYPE)?,
+            name: values.literal(subject, super::vocabulary::NAME)?,
+            aliases: values.literal_values(super::vocabulary::ALIAS),
+            canonical_key: values.optional_literal(super::vocabulary::CANONICAL_KEY),
+            summary: values.optional_literal(super::vocabulary::SUMMARY),
+            created_at: timestamp_literal(subject, values, super::vocabulary::CREATED_AT)?,
+            updated_at: timestamp_literal(subject, values, super::vocabulary::UPDATED_AT)?,
+            schema_version: values.literal(subject, super::vocabulary::SCHEMA_VERSION)?,
+        })),
+        ObjectType::MemoryThread => Ok(MemoryObject::MemoryThread(MemoryThread {
+            id: memory_id_literal(subject, values, super::vocabulary::OBJECT_ID)?,
+            object_type,
+            title: values.literal(subject, super::vocabulary::TITLE)?,
+            summary: values.literal(subject, super::vocabulary::SUMMARY)?,
+            status: enum_literal(subject, values, super::vocabulary::THREAD_STATUS)?,
+            last_touched_at: timestamp_literal(
+                subject,
+                values,
+                super::vocabulary::LAST_TOUCHED_AT,
+            )?,
+            salience_score: f32_literal(subject, values, super::vocabulary::SALIENCE_SCORE)?,
+            canonical_key: values.optional_literal(super::vocabulary::CANONICAL_KEY),
+            created_at: timestamp_literal(subject, values, super::vocabulary::CREATED_AT)?,
+            updated_at: timestamp_literal(subject, values, super::vocabulary::UPDATED_AT)?,
+            schema_version: values.literal(subject, super::vocabulary::SCHEMA_VERSION)?,
+        })),
+        ObjectType::DerivedMemory => Ok(MemoryObject::DerivedMemory(DerivedMemory {
+            id: memory_id_literal(subject, values, super::vocabulary::OBJECT_ID)?,
+            object_type,
+            derived_type: enum_literal(subject, values, super::vocabulary::DERIVED_TYPE)?,
+            text: values.literal(subject, super::vocabulary::TEXT)?,
+            derived_from_episode_ids: memory_ids_from_resources(
+                values.resource_values(super::vocabulary::DERIVED_FROM_EPISODE),
+            )?,
+            derived_from_observation_ids: memory_ids_from_resources(
+                values.resource_values(super::vocabulary::DERIVED_FROM_OBSERVATION),
+            )?,
+            thread_ids: memory_ids_from_resources(
+                values.resource_values(super::vocabulary::PART_OF_THREAD),
+            )?,
+            entity_ids: memory_ids_from_resources(
+                values.resource_values(super::vocabulary::ABOUT_ENTITY),
+            )?,
+            confidence: f32_literal(subject, values, super::vocabulary::CONFIDENCE)?,
+            salience_score: f32_literal(subject, values, super::vocabulary::SALIENCE_SCORE)?,
+            stability: enum_literal(subject, values, super::vocabulary::STABILITY)?,
+            is_current: bool_literal(subject, values, super::vocabulary::IS_CURRENT)?,
+            supersedes: memory_ids_from_resources(
+                values.resource_values(super::vocabulary::SUPERSEDES),
+            )?,
+            retention_state: enum_literal(subject, values, super::vocabulary::RETENTION_STATE)?,
+            created_at: timestamp_literal(subject, values, super::vocabulary::CREATED_AT)?,
+            updated_at: timestamp_literal(subject, values, super::vocabulary::UPDATED_AT)?,
+            schema_version: values.literal(subject, super::vocabulary::SCHEMA_VERSION)?,
+        })),
+        ObjectType::MemoryLink => Ok(MemoryObject::MemoryLink(memory_link_from_rdf(
+            subject, values,
+        )?)),
+    }
+}
+
+fn memory_link_from_rdf(
+    subject: &str,
+    values: &RdfSubjectValues,
+) -> Result<MemoryLink, CustomError> {
+    Ok(MemoryLink {
+        id: memory_id_literal(subject, values, super::vocabulary::OBJECT_ID)?,
+        object_type: ObjectType::MemoryLink,
+        from_id: memory_id_from_resource(&values.resource(subject, super::vocabulary::FROM)?)?,
+        from_type: enum_literal(subject, values, super::vocabulary::FROM_TYPE)?,
+        to_id: memory_id_from_resource(&values.resource(subject, super::vocabulary::TO)?)?,
+        to_type: enum_literal(subject, values, super::vocabulary::TO_TYPE)?,
+        relation: enum_literal(subject, values, super::vocabulary::RELATION)?,
+        confidence: f32_literal(subject, values, super::vocabulary::CONFIDENCE)?,
+        rationale: values.optional_literal(super::vocabulary::RATIONALE),
+        created_at: timestamp_literal(subject, values, super::vocabulary::CREATED_AT)?,
+        schema_version: values.literal(subject, super::vocabulary::SCHEMA_VERSION)?,
+    })
+}
+
+fn memory_id_literal(
+    subject: &str,
+    values: &RdfSubjectValues,
+    predicate: &'static str,
+) -> Result<MemoryId, CustomError> {
+    values
+        .literal(subject, predicate)?
+        .parse()
+        .map_err(|error| rdf_parse_error(subject, predicate, error))
+}
+
+fn memory_id_from_resource(value: &str) -> Result<MemoryId, CustomError> {
+    value
+        .rsplit(':')
+        .next()
+        .ok_or_else(|| CustomError::DatabaseError(format!("Invalid graph URI resource: {value}")))?
+        .parse()
+        .map_err(|error| CustomError::DatabaseError(format!("Invalid graph URI MemoryId: {error}")))
+}
+
+fn memory_ids_from_resources(values: Vec<String>) -> Result<Vec<MemoryId>, CustomError> {
+    let mut ids = values
+        .iter()
+        .map(|value| memory_id_from_resource(value))
+        .collect::<Result<Vec<_>, _>>()?;
+    ids.sort();
+    Ok(ids)
+}
+
+fn enum_literal<T: DeserializeOwned>(
+    subject: &str,
+    values: &RdfSubjectValues,
+    predicate: &'static str,
+) -> Result<T, CustomError> {
+    enum_value_from_literal(&values.literal(subject, predicate)?)
+        .map_err(|error| rdf_parse_error(subject, predicate, error))
+}
+
+fn enum_value_from_literal<T: DeserializeOwned>(value: &str) -> Result<T, serde_json::Error> {
+    serde_json::from_value(serde_json::Value::String(value.to_owned()))
+}
+
+fn f32_literal(
+    subject: &str,
+    values: &RdfSubjectValues,
+    predicate: &'static str,
+) -> Result<f32, CustomError> {
+    values
+        .literal(subject, predicate)?
+        .parse()
+        .map_err(|error| rdf_parse_error(subject, predicate, error))
+}
+
+fn bool_literal(
+    subject: &str,
+    values: &RdfSubjectValues,
+    predicate: &'static str,
+) -> Result<bool, CustomError> {
+    values
+        .literal(subject, predicate)?
+        .parse()
+        .map_err(|error| rdf_parse_error(subject, predicate, error))
+}
+
+fn timestamp_literal(
+    subject: &str,
+    values: &RdfSubjectValues,
+    predicate: &'static str,
+) -> Result<DateTime<Utc>, CustomError> {
+    parse_timestamp(subject, predicate, &values.literal(subject, predicate)?)
+}
+
+fn optional_timestamp_literal(
+    values: &RdfSubjectValues,
+    predicate: &'static str,
+) -> Result<Option<DateTime<Utc>>, CustomError> {
+    values
+        .optional_literal(predicate)
+        .map(|value| parse_timestamp("<optional>", predicate, &value))
+        .transpose()
+}
+
+fn parse_timestamp(
+    subject: &str,
+    predicate: &'static str,
+    value: &str,
+) -> Result<DateTime<Utc>, CustomError> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|value| value.with_timezone(&Utc))
+        .map_err(|error| rdf_parse_error(subject, predicate, error))
+}
+
+fn missing_rdf_value(subject: &str, predicate: &'static str) -> CustomError {
+    CustomError::DatabaseError(format!(
+        "Oxigraph RDF object {subject} is missing required predicate {predicate}"
+    ))
+}
+
+fn rdf_parse_error(
+    subject: &str,
+    predicate: &'static str,
+    error: impl std::fmt::Display,
+) -> CustomError {
+    CustomError::DatabaseError(format!(
+        "Oxigraph RDF object {subject} has invalid predicate {predicate}: {error}"
+    ))
 }
 
 #[derive(Debug, Default)]
@@ -398,63 +1277,9 @@ fn bounded_graph_visible_refs(
     })
 }
 
-fn hydrate_objects_by_ref_set(
-    refs: &HashSet<GraphObjectRef>,
-    objects: &HashMap<(MemoryId, ObjectType), MemoryObject>,
-) -> Vec<MemoryObject> {
-    refs.iter()
-        .filter_map(|object_ref| {
-            objects
-                .get(&(object_ref.object_id, object_ref.object_type))
-                .cloned()
-        })
-        .collect()
-}
-
-fn hydrate_links_by_id_sets(
-    graph_link_ids: &HashSet<MemoryId>,
-    lifecycle_link_ids: &HashSet<MemoryId>,
-    graph_ref_set: &HashSet<GraphObjectRef>,
-    links: &HashMap<MemoryId, MemoryLink>,
-) -> Vec<MemoryLink> {
-    graph_link_ids
-        .union(lifecycle_link_ids)
-        .filter_map(|link_id| links.get(link_id))
-        .filter(|link| {
-            let endpoints_in_graph = graph_ref_set
-                .contains(&GraphObjectRef::new(link.from_id, link.from_type))
-                && graph_ref_set.contains(&GraphObjectRef::new(link.to_id, link.to_type));
-            (graph_link_ids.contains(&link.id) && endpoints_in_graph)
-                || lifecycle_link_ids.contains(&link.id)
-        })
-        .cloned()
-        .collect()
-}
-
 fn graph_object_ref(object: &MemoryObject) -> GraphObjectRef {
     let (object_id, object_type) = object_identity(object);
     GraphObjectRef::new(object_id, object_type)
-}
-
-fn hydrate_objects_by_refs(
-    refs: &[GraphObjectRef],
-    objects: &HashMap<(MemoryId, ObjectType), MemoryObject>,
-) -> Vec<MemoryObject> {
-    refs.iter()
-        .filter_map(|object_ref| {
-            match objects.get(&(object_ref.object_id, object_ref.object_type)) {
-                Some(object) => Some(object.clone()),
-                None if object_ref.object_type == ObjectType::MemoryLink => None,
-                None => {
-                    debug_assert!(
-                        false,
-                        "SPARQL selected {object_ref:?} but canonical object cache could not hydrate it"
-                    );
-                    None
-                }
-            }
-        })
-        .collect()
 }
 
 fn quad_for_triple(owner_graph_uri: &str, triple: &RdfTriple) -> Result<Quad, CustomError> {
@@ -482,6 +1307,10 @@ fn lock<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, CustomError> {
 
 fn oxigraph_error(error: impl std::fmt::Display) -> CustomError {
     CustomError::DatabaseError(format!("Oxigraph graph store error: {error}"))
+}
+
+fn oxigraph_http_error(error: impl std::fmt::Display) -> CustomError {
+    CustomError::DatabaseError(format!("Oxigraph service error: {error}"))
 }
 
 fn object_identity(object: &MemoryObject) -> (MemoryId, ObjectType) {
@@ -543,6 +1372,29 @@ mod tests {
         GraphObjectRef,
     };
     use crate::internal::repositories::{MemoryEmbedder, RetrievePipeline, VectorCandidateStore};
+    use std::path::{Path, PathBuf};
+
+    struct TempGraphDir {
+        path: PathBuf,
+    }
+
+    impl TempGraphDir {
+        fn new() -> Self {
+            Self {
+                path: std::env::temp_dir().join(format!("cmem-oxigraph-{}", MemoryId::new_v4())),
+            }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempGraphDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
 
     #[tokio::test]
     async fn oxigraph_store_upserts_and_queries_canonical_objects() {
@@ -653,7 +1505,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn oxigraph_queries_select_from_rdf_before_cache_hydration() {
+    async fn oxigraph_queries_hydrate_from_rdf() {
         let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
         let fixtures = representative_fixtures();
         let episode_graph = graph_uri(ObjectType::Episode, fixtures.episode.id);
@@ -729,7 +1581,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn oxigraph_upsert_objects_and_links_replaces_rdf_and_caches_atomically() {
+    async fn oxigraph_upsert_objects_and_links_replaces_rdf_atomically() {
         let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
         let fixtures = representative_fixtures();
         let mut updated_memory = fixtures.derived_reflection.clone();
@@ -997,22 +1849,11 @@ mod tests {
         let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
         let fixtures = representative_fixtures();
         let graph_visible_link = fixtures.hub_links[1].clone();
-        let mut stale_cache_only_link = graph_visible_link.clone();
-        stale_cache_only_link.id = MemoryId::from_u128(0x550e_8400_e29b_41d4_a716_4466_5500_0001);
-        stale_cache_only_link.to_id = fixtures.episode.id;
-        stale_cache_only_link.to_type = ObjectType::Episode;
-        stale_cache_only_link.relation = RelationType::About;
-        stale_cache_only_link.rationale =
-            Some("Cache-only stale link should not consume fanout.".to_owned());
-
         store.upsert_objects(&fixtures.objects()).await.unwrap();
         store
             .upsert_links(std::slice::from_ref(&graph_visible_link))
             .await
             .unwrap();
-        lock(&store.links)
-            .unwrap()
-            .insert(stale_cache_only_link.id, stale_cache_only_link.clone());
 
         let expansion = store
             .expand_bounded(
@@ -1023,7 +1864,6 @@ mod tests {
             .unwrap();
 
         assert_eq!(expansion.links, vec![graph_visible_link.clone()]);
-        assert!(!expansion.links.contains(&stale_cache_only_link));
         assert!(expansion
             .objects
             .contains(&MemoryObject::Entity(fixtures.hub_entity.clone())));
@@ -1664,6 +2504,198 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires local test Oxigraph: docker compose -f docker-compose.oxigraph.test.yml up -d and OXIGRAPH_TEST_CONNECTION_STRING"]
+    async fn oxigraph_http_service_live_smoke_upserts_queries_and_filters(
+    ) -> Result<(), CustomError> {
+        let endpoint = std::env::var("OXIGRAPH_TEST_CONNECTION_STRING")
+            .unwrap_or_else(|_| "http://localhost:7879".to_owned());
+        let store = OxigraphHttpGraphAuthorityStore::new(endpoint)?;
+        let fixtures = representative_fixtures();
+        let smoke_graph_uris = fixtures
+            .objects()
+            .into_iter()
+            .map(|object| {
+                let (id, object_type) = object_identity(&object);
+                graph_uri(object_type, id)
+            })
+            .chain(
+                fixtures
+                    .links()
+                    .into_iter()
+                    .map(|link| graph_uri(ObjectType::MemoryLink, link.id)),
+            )
+            .collect::<Vec<_>>();
+
+        let test_result: Result<(), CustomError> = async {
+            store.upsert_objects(&fixtures.objects()).await?;
+            store.upsert_links(&fixtures.links()).await?;
+
+            let queried = store
+                .query_objects(&GraphObjectQuery::by_refs(vec![
+                    GraphObjectRef::new(fixtures.episode.id, ObjectType::Episode),
+                    GraphObjectRef::new(fixtures.derived_reflection.id, ObjectType::DerivedMemory),
+                ]))
+                .await?;
+            if !queried.contains(&MemoryObject::Episode(fixtures.episode.clone())) {
+                return Err(CustomError::DatabaseError(
+                    "Oxigraph smoke did not return the stored episode".to_owned(),
+                ));
+            }
+            if !queried.contains(&MemoryObject::DerivedMemory(
+                fixtures.derived_reflection.clone(),
+            )) {
+                return Err(CustomError::DatabaseError(
+                    "Oxigraph smoke did not return the stored derived memory".to_owned(),
+                ));
+            }
+
+            let vector = FixedVectorStore::new(vec![
+                VectorCandidateMatch::new(
+                    fixtures.derived_reflection.id,
+                    ObjectType::DerivedMemory,
+                    VectorSurface::Summary,
+                    0.99,
+                ),
+                VectorCandidateMatch::new(
+                    fixtures.suppressed_seed.id,
+                    ObjectType::DerivedMemory,
+                    VectorSurface::Summary,
+                    0.98,
+                ),
+            ]);
+            let embedder = FixedEmbedder::new(vec![1.0, 0.0]);
+            let pipeline = RetrievePipeline::new(&store, &vector, &embedder);
+
+            let outcome = pipeline
+                .retrieve(RetrievalContext::new("service graph authority"))
+                .await?;
+            if !outcome
+                .pack
+                .derived_memories
+                .iter()
+                .any(|included| included.memory.id == fixtures.derived_reflection.id)
+            {
+                return Err(CustomError::DatabaseError(
+                    "Oxigraph smoke retrieval did not include the current derived memory"
+                        .to_owned(),
+                ));
+            }
+            if outcome
+                .pack
+                .derived_memories
+                .iter()
+                .chain(outcome.pack.preferences.iter())
+                .any(|included| included.memory.id == fixtures.suppressed_seed.id)
+            {
+                return Err(CustomError::DatabaseError(
+                    "Oxigraph smoke retrieval included a suppressed derived memory".to_owned(),
+                ));
+            }
+            Ok(())
+        }
+        .await;
+
+        let cleanup_result = store.delete_named_graphs(&smoke_graph_uris).await;
+        let remaining_result = store.named_graph_quad_count(&smoke_graph_uris).await;
+        cleanup_result?;
+        let remaining = remaining_result?;
+        if remaining != 0 {
+            return Err(CustomError::DatabaseError(format!(
+                "Oxigraph smoke cleanup left {remaining} quads in smoke graphs"
+            )));
+        }
+        test_result
+    }
+
+    #[tokio::test]
+    async fn persistent_oxigraph_reopens_and_hydrates_objects_links_and_lifecycle_from_rdf() {
+        let graph_dir = TempGraphDir::new();
+        let fixtures = representative_fixtures();
+        let mut archived_thread = fixtures.soft_thread.clone();
+        archived_thread.status = ThreadStatus::Archived;
+
+        {
+            let store = OxigraphGraphAuthorityStore::new_persistent(graph_dir.path()).unwrap();
+            store
+                .upsert_objects(&[
+                    MemoryObject::Episode(fixtures.episode.clone()),
+                    MemoryObject::Observation(fixtures.salient_observation.clone()),
+                    MemoryObject::Entity(fixtures.user_entity.clone()),
+                    MemoryObject::MemoryThread(archived_thread.clone()),
+                    MemoryObject::DerivedMemory(fixtures.correction.clone()),
+                    MemoryObject::DerivedMemory(fixtures.suppressed_seed.clone()),
+                ])
+                .await
+                .unwrap();
+            store.upsert_links(&fixtures.links()).await.unwrap();
+        }
+
+        {
+            let reopened = OxigraphGraphAuthorityStore::new_persistent(graph_dir.path()).unwrap();
+            let queried = reopened
+                .query_objects(&GraphObjectQuery::by_refs(vec![
+                    GraphObjectRef::new(fixtures.episode.id, ObjectType::Episode),
+                    GraphObjectRef::new(fixtures.salient_observation.id, ObjectType::Observation),
+                    GraphObjectRef::new(fixtures.user_entity.id, ObjectType::Entity),
+                    GraphObjectRef::new(archived_thread.id, ObjectType::MemoryThread),
+                    GraphObjectRef::new(fixtures.correction.id, ObjectType::DerivedMemory),
+                    GraphObjectRef::new(fixtures.suppressed_seed.id, ObjectType::DerivedMemory),
+                ]))
+                .await
+                .unwrap();
+
+            assert!(queried.contains(&MemoryObject::Episode(fixtures.episode.clone())));
+            assert!(queried.contains(&MemoryObject::Observation(
+                fixtures.salient_observation.clone()
+            )));
+            assert!(queried.contains(&MemoryObject::Entity(fixtures.user_entity.clone())));
+            assert!(queried.contains(&MemoryObject::MemoryThread(archived_thread.clone())));
+            assert!(queried.contains(&MemoryObject::DerivedMemory(fixtures.correction.clone())));
+            assert!(queried.contains(&MemoryObject::DerivedMemory(
+                fixtures.suppressed_seed.clone()
+            )));
+
+            let by_provenance = reopened
+                .query_derived_memories_by_provenance(
+                    &GraphDerivedMemoryProvenanceQuery::by_sources(
+                        vec![fixtures.episode.id],
+                        vec![fixtures.salient_observation.id],
+                    ),
+                )
+                .await
+                .unwrap();
+            assert!(by_provenance
+                .iter()
+                .any(|memory| memory.id == fixtures.correction.id));
+            assert!(!by_provenance
+                .iter()
+                .any(|memory| memory.id == fixtures.suppressed_seed.id));
+
+            let default_expansion = reopened
+                .expand_bounded(&GraphExpansionQuery::new(
+                    fixtures.correction.id,
+                    ObjectType::DerivedMemory,
+                    1,
+                    5,
+                ))
+                .await
+                .unwrap();
+            assert!(default_expansion
+                .objects
+                .contains(&MemoryObject::DerivedMemory(fixtures.correction.clone())));
+            assert!(!default_expansion
+                .objects
+                .contains(&MemoryObject::DerivedMemory(
+                    fixtures.suppressed_seed.clone()
+                )));
+            assert!(default_expansion.filtered_nodes.iter().any(|filtered| {
+                filtered.object_ref
+                    == GraphObjectRef::new(fixtures.suppressed_seed.id, ObjectType::DerivedMemory)
+            }));
+        }
+    }
+
+    #[tokio::test]
     async fn retrieve_pipeline_expands_fixed_vector_candidate_with_embedded_oxigraph() {
         let store = OxigraphGraphAuthorityStore::new_in_memory().unwrap();
         let fixtures = representative_fixtures();
@@ -1751,6 +2783,70 @@ mod tests {
             assignment.object.id == fixtures.derived_reflection.id
                 && assignment.section == ContextPackSection::DerivedMemories
         }));
+    }
+
+    #[tokio::test]
+    async fn retrieve_pipeline_after_persistent_reopen_uses_graph_authority_filters() {
+        let graph_dir = TempGraphDir::new();
+        let fixtures = representative_fixtures();
+        let missing_vector_only_id = MemoryId::new_v4();
+
+        {
+            let store = OxigraphGraphAuthorityStore::new_persistent(graph_dir.path()).unwrap();
+            store.upsert_objects(&fixtures.objects()).await.unwrap();
+            store.upsert_links(&fixtures.links()).await.unwrap();
+        }
+
+        {
+            let reopened = OxigraphGraphAuthorityStore::new_persistent(graph_dir.path()).unwrap();
+            let vector = FixedVectorStore::new(vec![
+                VectorCandidateMatch::new(
+                    fixtures.derived_reflection.id,
+                    ObjectType::DerivedMemory,
+                    VectorSurface::Summary,
+                    0.99,
+                ),
+                VectorCandidateMatch::new(
+                    fixtures.suppressed_seed.id,
+                    ObjectType::DerivedMemory,
+                    VectorSurface::Summary,
+                    0.98,
+                ),
+                VectorCandidateMatch::new(
+                    missing_vector_only_id,
+                    ObjectType::DerivedMemory,
+                    VectorSurface::Summary,
+                    0.97,
+                ),
+            ]);
+            let embedder = FixedEmbedder::new(vec![1.0, 0.0]);
+            let pipeline = RetrievePipeline::new(&reopened, &vector, &embedder);
+
+            let outcome = pipeline
+                .retrieve(RetrievalContext::new("restart graph authority").with_trace())
+                .await
+                .unwrap();
+            let retrieved_ids = outcome
+                .pack
+                .derived_memories
+                .iter()
+                .chain(outcome.pack.preferences.iter())
+                .map(|included| included.memory.id)
+                .collect::<HashSet<_>>();
+
+            assert!(retrieved_ids.contains(&fixtures.derived_reflection.id));
+            assert!(!retrieved_ids.contains(&fixtures.suppressed_seed.id));
+            assert!(!retrieved_ids.contains(&missing_vector_only_id));
+            let trace = outcome.trace.as_ref().unwrap();
+            assert!(trace.vector_candidates.iter().any(|candidate| {
+                candidate.object.id == missing_vector_only_id
+                    && candidate.object.object_type == ObjectType::DerivedMemory
+            }));
+            assert!(trace.lifecycle_filter_decisions.iter().any(|decision| {
+                decision.object.id == fixtures.suppressed_seed.id
+                    && decision.action == LifecycleFilterAction::Omitted
+            }));
+        }
     }
 
     #[tokio::test]

--- a/src/internal/infrastructures/graph/oxigraph_authority_store.rs
+++ b/src/internal/infrastructures/graph/oxigraph_authority_store.rs
@@ -335,6 +335,9 @@ impl OxigraphHttpGraphAuthorityStore {
     }
 
     async fn snapshot_store(&self) -> Result<Store, CustomError> {
+        // Initial service-mode bridge: keep RDF hydration shared with embedded
+        // Oxigraph by snapshotting named graphs locally. Replace with targeted
+        // remote SPARQL before using service mode for large graph datasets.
         let response = self
             .client
             .post(format!("{}/query", self.endpoint))
@@ -2509,6 +2512,7 @@ mod tests {
     ) -> Result<(), CustomError> {
         let endpoint = std::env::var("OXIGRAPH_TEST_CONNECTION_STRING")
             .unwrap_or_else(|_| "http://localhost:7879".to_owned());
+        ensure_live_smoke_test_endpoint(&endpoint)?;
         let store = OxigraphHttpGraphAuthorityStore::new(endpoint)?;
         let fixtures = representative_fixtures();
         let smoke_graph_uris = fixtures
@@ -2605,6 +2609,35 @@ mod tests {
             )));
         }
         test_result
+    }
+
+    fn ensure_live_smoke_test_endpoint(endpoint: &str) -> Result<(), CustomError> {
+        let parsed = reqwest::Url::parse(endpoint).map_err(|error| {
+            CustomError::ConfigParseError(format!(
+                "OXIGRAPH_TEST_CONNECTION_STRING must be a valid test endpoint URL: {error}"
+            ))
+        })?;
+        let host = parsed.host_str().unwrap_or_default();
+        let is_local_test_endpoint = parsed.scheme() == "http"
+            && matches!(host, "localhost" | "127.0.0.1" | "::1")
+            && parsed.port_or_known_default() == Some(7879);
+        if is_local_test_endpoint {
+            return Ok(());
+        }
+
+        Err(CustomError::ConfigParseError(
+            "Refusing live Oxigraph smoke cleanup outside the local test endpoint http://localhost:7879"
+            .to_owned(),
+        ))
+    }
+
+    #[test]
+    fn live_smoke_endpoint_guard_allows_only_local_test_service() {
+        assert!(ensure_live_smoke_test_endpoint("http://localhost:7879").is_ok());
+        assert!(ensure_live_smoke_test_endpoint("http://127.0.0.1:7879").is_ok());
+        assert!(ensure_live_smoke_test_endpoint("http://localhost:7878").is_err());
+        assert!(ensure_live_smoke_test_endpoint("https://localhost:7879").is_err());
+        assert!(ensure_live_smoke_test_endpoint("http://example.com:7879").is_err());
     }
 
     #[tokio::test]

--- a/src/internal/infrastructures/graph/sparql_selectors.rs
+++ b/src/internal/infrastructures/graph/sparql_selectors.rs
@@ -1,5 +1,5 @@
 // Internal SPARQL selectors for the embedded Oxigraph authority. These helpers
-// return backend-neutral IDs/refs; canonical object hydration stays in the cache.
+// return backend-neutral IDs/refs; canonical object hydration reads RDF state.
 #![allow(dead_code)]
 
 use std::collections::HashSet;

--- a/src/internal/models/vector.rs
+++ b/src/internal/models/vector.rs
@@ -19,5 +19,6 @@ pub(crate) use embedding_surface::{
 };
 #[allow(unused_imports)]
 pub(crate) use record::{
-    VectorPayloadHints, VectorRecord, VectorRecordEmbedding, VectorRelationshipHints,
+    VectorCandidateDiagnosticRecord, VectorPayloadHints, VectorRecord, VectorRecordEmbedding,
+    VectorRelationshipHints,
 };

--- a/src/internal/models/vector/record.rs
+++ b/src/internal/models/vector/record.rs
@@ -17,6 +17,36 @@ pub(crate) struct VectorRecordEmbedding<'a> {
     pub(crate) embedding: &'a [f32],
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct VectorCandidateDiagnosticRecord {
+    pub(crate) object_id: MemoryId,
+    pub(crate) object_type: ObjectType,
+    pub(crate) graph_uri: String,
+    pub(crate) surface: VectorSurface,
+    pub(crate) schema_version: String,
+    pub(crate) retention_state: Option<RetentionState>,
+    pub(crate) is_current: Option<bool>,
+    pub(crate) is_superseded: Option<bool>,
+}
+
+impl VectorCandidateDiagnosticRecord {
+    pub(crate) fn from_vector_record(record: &VectorRecord) -> Self {
+        Self {
+            object_id: record.object_id,
+            object_type: record.object_type,
+            graph_uri: record.graph_uri.clone(),
+            surface: record.surface,
+            schema_version: record.schema_version.clone(),
+            retention_state: record.retention_state,
+            is_current: record.is_current,
+            is_superseded: record
+                .payload_hints
+                .is_superseded
+                .or_else(|| record.is_current.map(|value| !value)),
+        }
+    }
+}
+
 impl<'a> VectorRecordEmbedding<'a> {
     pub(crate) fn new(record: &'a VectorRecord, embedding: &'a [f32]) -> Self {
         Self { record, embedding }

--- a/src/internal/repositories.rs
+++ b/src/internal/repositories.rs
@@ -3,6 +3,7 @@ mod embedder;
 mod graph_authority_store;
 mod link_pipeline;
 mod raw_reference_resolver;
+mod reconciliation;
 mod remember_pipeline;
 mod retrieve_pipeline;
 #[cfg(test)]
@@ -36,6 +37,14 @@ pub(crate) use link_pipeline::LinkPipeline;
 // Raw-reference contracts remain internal until production raw storage lands.
 #[allow(unused_imports)]
 pub(crate) use raw_reference_resolver::{RawReference, RawReferenceResolver};
+
+// Internal/admin reconciliation diagnostics. These remain out of the public
+// CharacterMemory facade until a governance surface is planned.
+#[allow(unused_imports)]
+pub(crate) use reconciliation::{
+    reconcile_graph_vector_stores, ReconciliationDiagnostic, ReconciliationDriftKind,
+    ReconciliationReport,
+};
 
 // Remember pipeline surface; outcome types are converted at the public
 // facade boundary.

--- a/src/internal/repositories/correction_forget_pipeline.rs
+++ b/src/internal/repositories/correction_forget_pipeline.rs
@@ -2311,6 +2311,14 @@ mod tests {
         ) -> Result<GraphExpansion, CustomError> {
             Ok(GraphExpansion::new(Vec::new(), Vec::new()))
         }
+
+        async fn list_diagnostic_objects(&self) -> Result<Vec<MemoryObject>, CustomError> {
+            Ok(lock(&self.objects).clone())
+        }
+
+        async fn list_diagnostic_links(&self) -> Result<Vec<MemoryLink>, CustomError> {
+            Ok(lock(&self.links).clone())
+        }
     }
 
     #[derive(Debug, Default)]
@@ -2349,6 +2357,15 @@ mod tests {
             &self,
             _query: &VectorCandidateSearch,
         ) -> Result<Vec<VectorCandidateMatch>, CustomError> {
+            Ok(Vec::new())
+        }
+
+        async fn list_candidate_diagnostics(
+            &self,
+        ) -> Result<
+            Vec<crate::internal::models::vector::VectorCandidateDiagnosticRecord>,
+            CustomError,
+        > {
             Ok(Vec::new())
         }
 
@@ -2418,6 +2435,15 @@ mod tests {
             query: &VectorCandidateSearch,
         ) -> Result<Vec<VectorCandidateMatch>, CustomError> {
             self.inner.search_candidates(query).await
+        }
+
+        async fn list_candidate_diagnostics(
+            &self,
+        ) -> Result<
+            Vec<crate::internal::models::vector::VectorCandidateDiagnosticRecord>,
+            CustomError,
+        > {
+            self.inner.list_candidate_diagnostics().await
         }
 
         async fn delete_candidates(&self, _object_ids: &[MemoryId]) -> Result<(), CustomError> {

--- a/src/internal/repositories/graph_authority_store.rs
+++ b/src/internal/repositories/graph_authority_store.rs
@@ -1,6 +1,6 @@
 // Graph authority contract and provider-neutral expansion helpers.
-// Oxigraph is the default in-process authority; tests also use deterministic
-// fake stores.
+// Oxigraph service mode is the application default; embedded and fake stores
+// keep tests and explicit fixture runs deterministic.
 #![allow(dead_code)]
 
 use async_trait::async_trait;

--- a/src/internal/repositories/graph_authority_store.rs
+++ b/src/internal/repositories/graph_authority_store.rs
@@ -998,23 +998,9 @@ pub(crate) trait GraphAuthorityStore: Send + Sync {
         query: &GraphExpansionQuery,
     ) -> Result<GraphExpansion, CustomError>;
 
-    async fn list_diagnostic_objects(&self) -> Result<Vec<MemoryObject>, CustomError> {
-        self.query_objects(&GraphObjectQuery::by_types(
-            vec![
-                ObjectType::Episode,
-                ObjectType::Observation,
-                ObjectType::Entity,
-                ObjectType::MemoryThread,
-                ObjectType::DerivedMemory,
-            ],
-            None,
-        ))
-        .await
-    }
+    async fn list_diagnostic_objects(&self) -> Result<Vec<MemoryObject>, CustomError>;
 
-    async fn list_diagnostic_links(&self) -> Result<Vec<MemoryLink>, CustomError> {
-        Ok(Vec::new())
-    }
+    async fn list_diagnostic_links(&self) -> Result<Vec<MemoryLink>, CustomError>;
 }
 
 #[async_trait]

--- a/src/internal/repositories/graph_authority_store.rs
+++ b/src/internal/repositories/graph_authority_store.rs
@@ -997,6 +997,24 @@ pub(crate) trait GraphAuthorityStore: Send + Sync {
         &self,
         query: &GraphExpansionQuery,
     ) -> Result<GraphExpansion, CustomError>;
+
+    async fn list_diagnostic_objects(&self) -> Result<Vec<MemoryObject>, CustomError> {
+        self.query_objects(&GraphObjectQuery::by_types(
+            vec![
+                ObjectType::Episode,
+                ObjectType::Observation,
+                ObjectType::Entity,
+                ObjectType::MemoryThread,
+                ObjectType::DerivedMemory,
+            ],
+            None,
+        ))
+        .await
+    }
+
+    async fn list_diagnostic_links(&self) -> Result<Vec<MemoryLink>, CustomError> {
+        Ok(Vec::new())
+    }
 }
 
 #[async_trait]
@@ -1043,6 +1061,14 @@ impl<T: GraphAuthorityStore + ?Sized> GraphAuthorityStore for Box<T> {
         query: &GraphExpansionQuery,
     ) -> Result<GraphExpansion, CustomError> {
         (**self).expand_bounded(query).await
+    }
+
+    async fn list_diagnostic_objects(&self) -> Result<Vec<MemoryObject>, CustomError> {
+        (**self).list_diagnostic_objects().await
+    }
+
+    async fn list_diagnostic_links(&self) -> Result<Vec<MemoryLink>, CustomError> {
+        (**self).list_diagnostic_links().await
     }
 }
 

--- a/src/internal/repositories/reconciliation.rs
+++ b/src/internal/repositories/reconciliation.rs
@@ -79,16 +79,6 @@ fn reconcile_records(
 
     for record in &vector_records {
         let object_ref = GraphObjectRef::new(record.object_id, record.object_type);
-        let Some(graph_object) = graph_by_ref.get(&object_ref) else {
-            push_diagnostic(
-                &mut diagnostics,
-                object_ref,
-                ReconciliationDriftKind::VectorOnlyCandidate,
-                "vector candidate has no matching graph object",
-            );
-            continue;
-        };
-
         let expected_graph_uri = graph_uri(record.object_type, record.object_id);
         if record.graph_uri != expected_graph_uri {
             push_diagnostic(
@@ -113,6 +103,16 @@ fn reconcile_records(
                 ),
             );
         }
+
+        let Some(graph_object) = graph_by_ref.get(&object_ref) else {
+            push_diagnostic(
+                &mut diagnostics,
+                object_ref,
+                ReconciliationDriftKind::VectorOnlyCandidate,
+                "vector candidate has no matching graph object",
+            );
+            continue;
+        };
 
         push_lifecycle_diagnostics(
             &mut diagnostics,
@@ -401,7 +401,7 @@ mod tests {
                     id(999),
                     ObjectType::Entity,
                     graph_uri(ObjectType::Entity, id(999)),
-                    DEFAULT_SCHEMA_VERSION,
+                    "<missing schema_version>",
                     None,
                     None,
                     None,
@@ -442,6 +442,10 @@ mod tests {
         assert!(report.diagnostics.iter().any(|diagnostic| {
             diagnostic.kind == ReconciliationDriftKind::MissingProvenance
                 && diagnostic.object_ref.object_id == missing_provenance.id
+        }));
+        assert!(report.diagnostics.iter().any(|diagnostic| {
+            diagnostic.kind == ReconciliationDriftKind::UnsupportedVectorSchema
+                && diagnostic.object_ref.object_id == id(999)
         }));
     }
 

--- a/src/internal/repositories/reconciliation.rs
+++ b/src/internal/repositories/reconciliation.rs
@@ -1,0 +1,516 @@
+#![allow(dead_code)]
+
+use std::collections::{HashMap, HashSet};
+
+use crate::api::types::{
+    graph_uri, MemoryId, MemoryObject, ObjectType, RelationType, RetentionState,
+    CURRENT_SCHEMA_VERSION,
+};
+use crate::errors::CustomError;
+use crate::internal::models::vector::VectorCandidateDiagnosticRecord;
+
+use super::{GraphAuthorityStore, GraphObjectRef, VectorCandidateStore};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReconciliationReport {
+    pub(crate) diagnostics: Vec<ReconciliationDiagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReconciliationDiagnostic {
+    pub(crate) object_ref: GraphObjectRef,
+    pub(crate) kind: ReconciliationDriftKind,
+    pub(crate) detail: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReconciliationDriftKind {
+    VectorOnlyCandidate,
+    GraphOnlyObject,
+    GraphUriMismatch,
+    StaleLifecycleHint,
+    StaleCurrentnessHint,
+    UnsupportedVectorSchema,
+    MissingProvenance,
+}
+
+pub(crate) async fn reconcile_graph_vector_stores<G, V>(
+    graph_store: &G,
+    vector_store: &V,
+) -> Result<ReconciliationReport, CustomError>
+where
+    G: GraphAuthorityStore + ?Sized,
+    V: VectorCandidateStore + ?Sized,
+{
+    let graph_objects = graph_store.list_diagnostic_objects().await?;
+    let graph_links = graph_store.list_diagnostic_links().await?;
+    let vector_records = vector_store.list_candidate_diagnostics().await?;
+
+    Ok(reconcile_records(
+        graph_objects,
+        graph_links,
+        vector_records,
+    ))
+}
+
+fn reconcile_records(
+    graph_objects: Vec<MemoryObject>,
+    graph_links: Vec<crate::api::types::MemoryLink>,
+    vector_records: Vec<VectorCandidateDiagnosticRecord>,
+) -> ReconciliationReport {
+    let graph_by_ref = graph_objects
+        .iter()
+        .map(|object| (graph_object_ref(object), object))
+        .collect::<HashMap<_, _>>();
+    let vector_refs = vector_records
+        .iter()
+        .map(|record| GraphObjectRef::new(record.object_id, record.object_type))
+        .collect::<HashSet<_>>();
+    let superseded = graph_links
+        .iter()
+        .filter(|link| {
+            link.relation == RelationType::Supersedes
+                && link.from_type == ObjectType::DerivedMemory
+                && link.to_type == ObjectType::DerivedMemory
+        })
+        .map(|link| link.to_id)
+        .collect::<HashSet<_>>();
+    let mut diagnostics = Vec::new();
+
+    for record in &vector_records {
+        let object_ref = GraphObjectRef::new(record.object_id, record.object_type);
+        let Some(graph_object) = graph_by_ref.get(&object_ref) else {
+            push_diagnostic(
+                &mut diagnostics,
+                object_ref,
+                ReconciliationDriftKind::VectorOnlyCandidate,
+                "vector candidate has no matching graph object",
+            );
+            continue;
+        };
+
+        let expected_graph_uri = graph_uri(record.object_type, record.object_id);
+        if record.graph_uri != expected_graph_uri {
+            push_diagnostic(
+                &mut diagnostics,
+                object_ref,
+                ReconciliationDriftKind::GraphUriMismatch,
+                format!(
+                    "vector graph_uri '{}' does not match canonical '{}'",
+                    record.graph_uri, expected_graph_uri
+                ),
+            );
+        }
+
+        if record.schema_version != CURRENT_SCHEMA_VERSION {
+            push_diagnostic(
+                &mut diagnostics,
+                object_ref,
+                ReconciliationDriftKind::UnsupportedVectorSchema,
+                format!(
+                    "vector schema_version '{}' is not supported",
+                    record.schema_version
+                ),
+            );
+        }
+
+        push_lifecycle_diagnostics(
+            &mut diagnostics,
+            object_ref,
+            record,
+            graph_object,
+            &superseded,
+        );
+    }
+
+    for object in &graph_objects {
+        let object_ref = graph_object_ref(object);
+        if object_ref.object_type != ObjectType::MemoryLink && !vector_refs.contains(&object_ref) {
+            push_diagnostic(
+                &mut diagnostics,
+                object_ref,
+                ReconciliationDriftKind::GraphOnlyObject,
+                "graph object has no matching vector candidate",
+            );
+        }
+        if missing_required_provenance(object, &graph_links) {
+            push_diagnostic(
+                &mut diagnostics,
+                object_ref,
+                ReconciliationDriftKind::MissingProvenance,
+                "derived memory has no source episode or observation provenance",
+            );
+        }
+    }
+
+    diagnostics.sort_by_key(|diagnostic| {
+        (
+            diagnostic.object_ref.object_id,
+            object_type_rank(diagnostic.object_ref.object_type),
+            drift_kind_rank(diagnostic.kind),
+        )
+    });
+    ReconciliationReport { diagnostics }
+}
+
+fn push_lifecycle_diagnostics(
+    diagnostics: &mut Vec<ReconciliationDiagnostic>,
+    object_ref: GraphObjectRef,
+    record: &VectorCandidateDiagnosticRecord,
+    graph_object: &MemoryObject,
+    superseded: &HashSet<MemoryId>,
+) {
+    if let Some(graph_retention) = graph_retention_state(graph_object) {
+        if record
+            .retention_state
+            .is_some_and(|vector_retention| vector_retention != graph_retention)
+        {
+            push_diagnostic(
+                diagnostics,
+                object_ref,
+                ReconciliationDriftKind::StaleLifecycleHint,
+                format!(
+                    "vector retention hint does not match graph retention state {:?}",
+                    graph_retention
+                ),
+            );
+        }
+    }
+
+    if let Some(graph_is_current) = graph_is_current(graph_object) {
+        if record
+            .is_current
+            .is_some_and(|vector_is_current| vector_is_current != graph_is_current)
+        {
+            push_diagnostic(
+                diagnostics,
+                object_ref,
+                ReconciliationDriftKind::StaleCurrentnessHint,
+                format!(
+                    "vector currentness hint does not match graph is_current={graph_is_current}"
+                ),
+            );
+        }
+
+        let graph_is_superseded = superseded.contains(&object_ref.object_id);
+        if record
+            .is_superseded
+            .is_some_and(|vector_is_superseded| vector_is_superseded != graph_is_superseded)
+        {
+            push_diagnostic(
+                diagnostics,
+                object_ref,
+                ReconciliationDriftKind::StaleCurrentnessHint,
+                format!(
+                    "vector supersession hint does not match graph superseded={graph_is_superseded}"
+                ),
+            );
+        }
+    }
+}
+
+fn missing_required_provenance(
+    object: &MemoryObject,
+    links: &[crate::api::types::MemoryLink],
+) -> bool {
+    let MemoryObject::DerivedMemory(memory) = object else {
+        return false;
+    };
+    if !memory.derived_from_episode_ids.is_empty()
+        || !memory.derived_from_observation_ids.is_empty()
+    {
+        return false;
+    }
+    !links.iter().any(|link| {
+        link.relation == RelationType::DerivedFrom
+            && ((link.from_id == memory.id
+                && link.from_type == ObjectType::DerivedMemory
+                && matches!(link.to_type, ObjectType::Episode | ObjectType::Observation))
+                || (link.to_id == memory.id
+                    && link.to_type == ObjectType::DerivedMemory
+                    && matches!(
+                        link.from_type,
+                        ObjectType::Episode | ObjectType::Observation
+                    )))
+    })
+}
+
+fn push_diagnostic(
+    diagnostics: &mut Vec<ReconciliationDiagnostic>,
+    object_ref: GraphObjectRef,
+    kind: ReconciliationDriftKind,
+    detail: impl Into<String>,
+) {
+    diagnostics.push(ReconciliationDiagnostic {
+        object_ref,
+        kind,
+        detail: detail.into(),
+    });
+}
+
+fn graph_object_ref(object: &MemoryObject) -> GraphObjectRef {
+    let (object_id, object_type) = match object {
+        MemoryObject::Episode(object) => (object.id, object.object_type),
+        MemoryObject::Observation(object) => (object.id, object.object_type),
+        MemoryObject::Entity(object) => (object.id, object.object_type),
+        MemoryObject::MemoryThread(object) => (object.id, object.object_type),
+        MemoryObject::DerivedMemory(object) => (object.id, object.object_type),
+        MemoryObject::MemoryLink(object) => (object.id, object.object_type),
+    };
+    GraphObjectRef::new(object_id, object_type)
+}
+
+fn graph_retention_state(object: &MemoryObject) -> Option<RetentionState> {
+    match object {
+        MemoryObject::Episode(object) => Some(object.retention_state),
+        MemoryObject::Observation(object) => Some(object.retention_state),
+        MemoryObject::DerivedMemory(object) => Some(object.retention_state),
+        MemoryObject::Entity(_) | MemoryObject::MemoryThread(_) | MemoryObject::MemoryLink(_) => {
+            None
+        }
+    }
+}
+
+fn graph_is_current(object: &MemoryObject) -> Option<bool> {
+    match object {
+        MemoryObject::DerivedMemory(object) => Some(object.is_current),
+        _ => None,
+    }
+}
+
+fn object_type_rank(object_type: ObjectType) -> u8 {
+    match object_type {
+        ObjectType::Episode => 0,
+        ObjectType::Observation => 1,
+        ObjectType::Entity => 2,
+        ObjectType::MemoryThread => 3,
+        ObjectType::DerivedMemory => 4,
+        ObjectType::MemoryLink => 5,
+    }
+}
+
+fn drift_kind_rank(kind: ReconciliationDriftKind) -> u8 {
+    match kind {
+        ReconciliationDriftKind::VectorOnlyCandidate => 0,
+        ReconciliationDriftKind::GraphOnlyObject => 1,
+        ReconciliationDriftKind::GraphUriMismatch => 2,
+        ReconciliationDriftKind::StaleLifecycleHint => 3,
+        ReconciliationDriftKind::StaleCurrentnessHint => 4,
+        ReconciliationDriftKind::UnsupportedVectorSchema => 5,
+        ReconciliationDriftKind::MissingProvenance => 6,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::{
+        DerivedMemory, DerivedType, MemoryObject, MemoryThread, Stability, ThreadStatus,
+        DEFAULT_SCHEMA_VERSION,
+    };
+    use crate::internal::models::vector::{VectorCandidateDiagnosticRecord, VectorSurface};
+    use crate::internal::repositories::test_support::{
+        representative_fixtures, FakeGraphAuthorityStore, FakeVectorCandidateStore,
+    };
+    use crate::internal::repositories::GraphAuthorityStore;
+    use chrono::{DateTime, Utc};
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn reconciliation_reports_cross_store_drift_classes() {
+        let fixtures = representative_fixtures();
+        let graph = FakeGraphAuthorityStore::new();
+        let mut suppressed_observation = fixtures.salient_observation.clone();
+        suppressed_observation.retention_state = RetentionState::Suppressed;
+        let mut non_current_memory = fixtures.user_preference.clone();
+        non_current_memory.is_current = false;
+        let mut superseded_memory = fixtures.derived_reflection.clone();
+        superseded_memory.id = id(501);
+        let mut replacement_memory = fixtures.correction.clone();
+        replacement_memory.id = id(502);
+        let mut missing_provenance = invalid_derived_memory(id(503));
+        missing_provenance.text = "Corrupt derived memory without provenance.".to_owned();
+        let graph_only_thread = graph_only_thread(id(504));
+        let supersedes_link = crate::api::types::MemoryLink {
+            id: id(601),
+            object_type: ObjectType::MemoryLink,
+            from_id: replacement_memory.id,
+            from_type: ObjectType::DerivedMemory,
+            to_id: superseded_memory.id,
+            to_type: ObjectType::DerivedMemory,
+            relation: RelationType::Supersedes,
+            confidence: 0.9,
+            rationale: Some("replacement".to_owned()),
+            created_at: timestamp("2026-04-28T12:00:00Z"),
+            schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+        };
+        graph
+            .upsert_objects(&[
+                MemoryObject::Episode(fixtures.episode.clone()),
+                MemoryObject::Observation(suppressed_observation.clone()),
+                MemoryObject::DerivedMemory(non_current_memory.clone()),
+                MemoryObject::DerivedMemory(superseded_memory.clone()),
+                MemoryObject::DerivedMemory(replacement_memory.clone()),
+                MemoryObject::DerivedMemory(missing_provenance.clone()),
+                MemoryObject::MemoryThread(graph_only_thread),
+            ])
+            .await
+            .unwrap();
+        graph.upsert_links(&[supersedes_link]).await.unwrap();
+
+        let vector = FakeVectorCandidateStore::new();
+        vector
+            .upsert_diagnostic_records(&[
+                diagnostic(
+                    fixtures.episode.id,
+                    ObjectType::Episode,
+                    "urn:cmem:episode:wrong",
+                    DEFAULT_SCHEMA_VERSION,
+                    Some(RetentionState::Active),
+                    None,
+                    None,
+                ),
+                diagnostic(
+                    suppressed_observation.id,
+                    ObjectType::Observation,
+                    graph_uri(ObjectType::Observation, suppressed_observation.id),
+                    DEFAULT_SCHEMA_VERSION,
+                    Some(RetentionState::Active),
+                    None,
+                    None,
+                ),
+                diagnostic(
+                    non_current_memory.id,
+                    ObjectType::DerivedMemory,
+                    graph_uri(ObjectType::DerivedMemory, non_current_memory.id),
+                    DEFAULT_SCHEMA_VERSION,
+                    Some(RetentionState::Active),
+                    Some(true),
+                    Some(false),
+                ),
+                diagnostic(
+                    superseded_memory.id,
+                    ObjectType::DerivedMemory,
+                    graph_uri(ObjectType::DerivedMemory, superseded_memory.id),
+                    DEFAULT_SCHEMA_VERSION,
+                    Some(RetentionState::Active),
+                    Some(true),
+                    Some(false),
+                ),
+                diagnostic(
+                    id(999),
+                    ObjectType::Entity,
+                    graph_uri(ObjectType::Entity, id(999)),
+                    DEFAULT_SCHEMA_VERSION,
+                    None,
+                    None,
+                    None,
+                ),
+                diagnostic(
+                    replacement_memory.id,
+                    ObjectType::DerivedMemory,
+                    graph_uri(ObjectType::DerivedMemory, replacement_memory.id),
+                    "future_schema",
+                    Some(RetentionState::Active),
+                    Some(true),
+                    Some(false),
+                ),
+            ])
+            .await
+            .unwrap();
+
+        let report = reconcile_graph_vector_stores(&graph, &vector)
+            .await
+            .unwrap();
+        let kinds = report
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.kind)
+            .collect::<Vec<_>>();
+
+        for expected in [
+            ReconciliationDriftKind::VectorOnlyCandidate,
+            ReconciliationDriftKind::GraphOnlyObject,
+            ReconciliationDriftKind::GraphUriMismatch,
+            ReconciliationDriftKind::StaleLifecycleHint,
+            ReconciliationDriftKind::StaleCurrentnessHint,
+            ReconciliationDriftKind::UnsupportedVectorSchema,
+            ReconciliationDriftKind::MissingProvenance,
+        ] {
+            assert!(kinds.contains(&expected), "missing {expected:?}");
+        }
+        assert!(report.diagnostics.iter().any(|diagnostic| {
+            diagnostic.kind == ReconciliationDriftKind::MissingProvenance
+                && diagnostic.object_ref.object_id == missing_provenance.id
+        }));
+    }
+
+    fn diagnostic(
+        object_id: MemoryId,
+        object_type: ObjectType,
+        graph_uri: impl Into<String>,
+        schema_version: impl Into<String>,
+        retention_state: Option<RetentionState>,
+        is_current: Option<bool>,
+        is_superseded: Option<bool>,
+    ) -> VectorCandidateDiagnosticRecord {
+        VectorCandidateDiagnosticRecord {
+            object_id,
+            object_type,
+            graph_uri: graph_uri.into(),
+            surface: VectorSurface::Summary,
+            schema_version: schema_version.into(),
+            retention_state,
+            is_current,
+            is_superseded,
+        }
+    }
+
+    fn invalid_derived_memory(id: MemoryId) -> DerivedMemory {
+        DerivedMemory {
+            id,
+            object_type: ObjectType::DerivedMemory,
+            derived_type: DerivedType::Reflection,
+            text: "Invalid memory".to_owned(),
+            derived_from_episode_ids: Vec::new(),
+            derived_from_observation_ids: Vec::new(),
+            thread_ids: Vec::new(),
+            entity_ids: Vec::new(),
+            confidence: 0.8,
+            salience_score: 0.7,
+            stability: Stability::Medium,
+            is_current: true,
+            supersedes: Vec::new(),
+            retention_state: RetentionState::Active,
+            created_at: timestamp("2026-04-28T12:00:00Z"),
+            updated_at: timestamp("2026-04-28T12:00:00Z"),
+            schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+        }
+    }
+
+    fn graph_only_thread(id: MemoryId) -> MemoryThread {
+        MemoryThread {
+            id,
+            object_type: ObjectType::MemoryThread,
+            title: "Graph only thread".to_owned(),
+            summary: "Thread missing vector candidate.".to_owned(),
+            status: ThreadStatus::Active,
+            last_touched_at: timestamp("2026-04-28T12:00:00Z"),
+            salience_score: 0.5,
+            canonical_key: Some("thread:graph-only".to_owned()),
+            created_at: timestamp("2026-04-28T12:00:00Z"),
+            updated_at: timestamp("2026-04-28T12:00:00Z"),
+            schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+        }
+    }
+
+    fn id(value: u128) -> MemoryId {
+        Uuid::from_u128(0x550e_8400_e29b_41d4_a716_4466_7000_0000 + value)
+    }
+
+    fn timestamp(value: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(value)
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+}

--- a/src/internal/repositories/remember_pipeline.rs
+++ b/src/internal/repositories/remember_pipeline.rs
@@ -674,6 +674,14 @@ mod tests {
         ) -> Result<GraphExpansion, CustomError> {
             Ok(GraphExpansion::new(Vec::new(), Vec::new()))
         }
+
+        async fn list_diagnostic_objects(&self) -> Result<Vec<MemoryObject>, CustomError> {
+            Ok(Vec::new())
+        }
+
+        async fn list_diagnostic_links(&self) -> Result<Vec<MemoryLink>, CustomError> {
+            Ok(Vec::new())
+        }
     }
 
     #[derive(Debug, Default)]
@@ -715,6 +723,15 @@ mod tests {
             &self,
             _query: &VectorCandidateSearch,
         ) -> Result<Vec<VectorCandidateMatch>, CustomError> {
+            Ok(Vec::new())
+        }
+
+        async fn list_candidate_diagnostics(
+            &self,
+        ) -> Result<
+            Vec<crate::internal::models::vector::VectorCandidateDiagnosticRecord>,
+            CustomError,
+        > {
             Ok(Vec::new())
         }
 

--- a/src/internal/repositories/retrieve_pipeline.rs
+++ b/src/internal/repositories/retrieve_pipeline.rs
@@ -1762,6 +1762,15 @@ mod tests {
             Ok(candidates)
         }
 
+        async fn list_candidate_diagnostics(
+            &self,
+        ) -> Result<
+            Vec<crate::internal::models::vector::VectorCandidateDiagnosticRecord>,
+            CustomError,
+        > {
+            Ok(Vec::new())
+        }
+
         async fn delete_candidates(&self, _object_ids: &[MemoryId]) -> Result<(), CustomError> {
             Ok(())
         }
@@ -1827,6 +1836,16 @@ mod tests {
             _query: &GraphExpansionQuery,
         ) -> Result<GraphExpansion, CustomError> {
             Err(CustomError::MemoryValidation(self.message.clone()))
+        }
+
+        async fn list_diagnostic_objects(&self) -> Result<Vec<MemoryObject>, CustomError> {
+            Ok(Vec::new())
+        }
+
+        async fn list_diagnostic_links(
+            &self,
+        ) -> Result<Vec<crate::api::types::MemoryLink>, CustomError> {
+            Ok(Vec::new())
         }
     }
 

--- a/src/internal/repositories/test_support.rs
+++ b/src/internal/repositories/test_support.rs
@@ -18,9 +18,9 @@ use crate::api::types::{
 };
 use crate::errors::CustomError;
 use crate::internal::models::vector::{
-    EmbeddingInput, VectorCandidateFilters, VectorCandidateMatch, VectorCandidateRecord,
-    VectorCandidateSearch, VectorRecordEmbedding, VectorSurface, VectorTimeField,
-    VectorTimeRangeFilter,
+    EmbeddingInput, VectorCandidateDiagnosticRecord, VectorCandidateFilters, VectorCandidateMatch,
+    VectorCandidateRecord, VectorCandidateSearch, VectorRecordEmbedding, VectorSurface,
+    VectorTimeField, VectorTimeRangeFilter,
 };
 use crate::internal::repositories::{
     bounded_expansion, derived_memories_by_provenance, derived_memories_by_thread,
@@ -32,6 +32,7 @@ use crate::internal::repositories::{
 #[derive(Debug, Default)]
 pub(crate) struct FakeVectorCandidateStore {
     records: Mutex<Vec<VectorCandidateRecord>>,
+    diagnostics: Mutex<Vec<VectorCandidateDiagnosticRecord>>,
 }
 
 impl FakeVectorCandidateStore {
@@ -43,11 +44,39 @@ impl FakeVectorCandidateStore {
         &self,
         candidates: &[VectorCandidateRecord],
     ) -> Result<(), CustomError> {
-        self.replace_candidates(candidates)
+        self.replace_candidates(candidates)?;
+        let diagnostics = candidates
+            .iter()
+            .map(default_diagnostic_record)
+            .collect::<Vec<_>>();
+        self.replace_diagnostic_records(&diagnostics)
+    }
+
+    pub(crate) async fn upsert_diagnostic_records(
+        &self,
+        records: &[VectorCandidateDiagnosticRecord],
+    ) -> Result<(), CustomError> {
+        self.replace_diagnostic_records(records)
     }
 
     fn replace_candidates(&self, candidates: &[VectorCandidateRecord]) -> Result<(), CustomError> {
         let mut records = lock(&self.records)?;
+
+        for candidate in candidates {
+            records.retain(|record| {
+                record.object_id != candidate.object_id || record.surface != candidate.surface
+            });
+            records.push(candidate.clone());
+        }
+
+        Ok(())
+    }
+
+    fn replace_diagnostic_records(
+        &self,
+        candidates: &[VectorCandidateDiagnosticRecord],
+    ) -> Result<(), CustomError> {
+        let mut records = lock(&self.diagnostics)?;
 
         for candidate in candidates {
             records.retain(|record| {
@@ -70,7 +99,12 @@ impl VectorCandidateStore for FakeVectorCandidateStore {
             .iter()
             .map(|record| record.to_candidate_record())
             .collect::<Vec<_>>();
-        self.replace_candidates(&candidates)
+        self.replace_candidates(&candidates)?;
+        let diagnostics = records
+            .iter()
+            .map(|record| VectorCandidateDiagnosticRecord::from_vector_record(record.record))
+            .collect::<Vec<_>>();
+        self.replace_diagnostic_records(&diagnostics)
     }
 
     async fn search_candidates(
@@ -112,7 +146,32 @@ impl VectorCandidateStore for FakeVectorCandidateStore {
     async fn delete_candidates(&self, object_ids: &[MemoryId]) -> Result<(), CustomError> {
         let delete_ids: HashSet<_> = object_ids.iter().copied().collect();
         lock(&self.records)?.retain(|record| !delete_ids.contains(&record.object_id));
+        lock(&self.diagnostics)?.retain(|record| !delete_ids.contains(&record.object_id));
         Ok(())
+    }
+
+    async fn list_candidate_diagnostics(
+        &self,
+    ) -> Result<Vec<VectorCandidateDiagnosticRecord>, CustomError> {
+        let mut records = lock(&self.diagnostics)?.clone();
+        records.sort_by_key(|record| (record.object_id, object_type_rank(record.object_type)));
+        Ok(records)
+    }
+}
+
+fn default_diagnostic_record(record: &VectorCandidateRecord) -> VectorCandidateDiagnosticRecord {
+    VectorCandidateDiagnosticRecord {
+        object_id: record.object_id,
+        object_type: record.object_type,
+        graph_uri: crate::api::types::graph_uri(record.object_type, record.object_id),
+        surface: record.surface,
+        schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+        retention_state: record.retention_state,
+        is_current: record.is_current,
+        is_superseded: record
+            .payload_hints
+            .is_superseded
+            .or_else(|| record.is_current.map(|value| !value)),
     }
 }
 
@@ -298,6 +357,18 @@ impl GraphAuthorityStore for FakeGraphAuthorityStore {
         let objects = lock(&self.objects)?.clone();
         let links = lock(&self.links)?.clone();
         bounded_expansion(query, objects, links)
+    }
+
+    async fn list_diagnostic_objects(&self) -> Result<Vec<MemoryObject>, CustomError> {
+        let mut objects = lock(&self.objects)?.clone();
+        sort_objects(&mut objects);
+        Ok(objects)
+    }
+
+    async fn list_diagnostic_links(&self) -> Result<Vec<MemoryLink>, CustomError> {
+        let mut links = lock(&self.links)?.clone();
+        links.sort_by_key(|link| link.id);
+        Ok(links)
     }
 }
 

--- a/src/internal/repositories/vector_candidate_store.rs
+++ b/src/internal/repositories/vector_candidate_store.rs
@@ -7,7 +7,8 @@ use async_trait::async_trait;
 use crate::api::types::MemoryId;
 use crate::errors::CustomError;
 use crate::internal::models::vector::{
-    VectorCandidateMatch, VectorCandidateSearch, VectorRecordEmbedding,
+    VectorCandidateDiagnosticRecord, VectorCandidateMatch, VectorCandidateSearch,
+    VectorRecordEmbedding,
 };
 
 #[async_trait]
@@ -21,6 +22,12 @@ pub(crate) trait VectorCandidateStore: Send + Sync {
         &self,
         query: &VectorCandidateSearch,
     ) -> Result<Vec<VectorCandidateMatch>, CustomError>;
+
+    async fn list_candidate_diagnostics(
+        &self,
+    ) -> Result<Vec<VectorCandidateDiagnosticRecord>, CustomError> {
+        Ok(Vec::new())
+    }
 
     async fn delete_candidates(&self, object_ids: &[MemoryId]) -> Result<(), CustomError>;
 }
@@ -39,6 +46,12 @@ impl<T: VectorCandidateStore + ?Sized> VectorCandidateStore for Box<T> {
         query: &VectorCandidateSearch,
     ) -> Result<Vec<VectorCandidateMatch>, CustomError> {
         (**self).search_candidates(query).await
+    }
+
+    async fn list_candidate_diagnostics(
+        &self,
+    ) -> Result<Vec<VectorCandidateDiagnosticRecord>, CustomError> {
+        (**self).list_candidate_diagnostics().await
     }
 
     async fn delete_candidates(&self, object_ids: &[MemoryId]) -> Result<(), CustomError> {

--- a/src/internal/repositories/vector_candidate_store.rs
+++ b/src/internal/repositories/vector_candidate_store.rs
@@ -25,9 +25,7 @@ pub(crate) trait VectorCandidateStore: Send + Sync {
 
     async fn list_candidate_diagnostics(
         &self,
-    ) -> Result<Vec<VectorCandidateDiagnosticRecord>, CustomError> {
-        Ok(Vec::new())
-    }
+    ) -> Result<Vec<VectorCandidateDiagnosticRecord>, CustomError>;
 
     async fn delete_candidates(&self, object_ids: &[MemoryId]) -> Result<(), CustomError>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,13 @@ mod internal;
 
 use async_trait::async_trait;
 
-use crate::config::settings::EmbeddingProviderSettings;
+use crate::config::settings::{EmbeddingProviderSettings, GraphStoreMode as ConfigGraphStoreMode};
 use crate::internal::infrastructures::external_services::{
     OpenAIEmbeddingProvider, QdrantVectorCandidateStore,
 };
-use crate::internal::infrastructures::graph::OxigraphGraphAuthorityStore;
+use crate::internal::infrastructures::graph::{
+    OxigraphGraphAuthorityStore, OxigraphHttpGraphAuthorityStore,
+};
 use crate::internal::models::vector::EmbeddingInput;
 use crate::internal::repositories::{
     CorrectionForgetPipeline, GraphAuthorityStore, LinkPipeline, MemoryEmbedder, RememberPipeline,
@@ -40,7 +42,7 @@ pub use crate::api::types::{
     ThreadStatus, VectorCandidateTrace, VectorIndexingFailure, VectorMaintenanceFailure,
     CURRENT_SCHEMA_VERSION, DEFAULT_SCHEMA_VERSION, EPISODIC_MEMORY_SCHEMA_VERSION,
 };
-pub use crate::config::settings::Settings;
+pub use crate::config::settings::{GraphStoreMode, Settings};
 pub use crate::errors::CustomError;
 
 // Re-export for integration tests
@@ -167,8 +169,20 @@ impl CharacterMemory {
             expected_vector_size as u64,
         )?;
         vector_store.init_collection().await?;
+        let graph_store = match settings.get_graph_store_mode() {
+            ConfigGraphStoreMode::Service => Box::new(OxigraphHttpGraphAuthorityStore::new(
+                settings.get_oxigraph_endpoint()?,
+            )?) as Box<dyn GraphAuthorityStore>,
+            ConfigGraphStoreMode::Persistent => Box::new(
+                OxigraphGraphAuthorityStore::new_persistent(settings.get_oxigraph_path()?)?,
+            ),
+            ConfigGraphStoreMode::InMemory => {
+                Box::new(OxigraphGraphAuthorityStore::new_in_memory()?)
+            }
+        };
+
         Ok(Self::from_parts(
-            Box::new(OxigraphGraphAuthorityStore::new_in_memory()?),
+            graph_store,
             Box::new(vector_store),
             Box::new(EmbeddingProviderMemoryEmbedder::new(embed_provider)),
         ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -922,6 +922,15 @@ mod tests {
             Ok(candidates)
         }
 
+        async fn list_candidate_diagnostics(
+            &self,
+        ) -> Result<
+            Vec<crate::internal::models::vector::VectorCandidateDiagnosticRecord>,
+            CustomError,
+        > {
+            Ok(Vec::new())
+        }
+
         async fn delete_candidates(&self, _object_ids: &[MemoryId]) -> Result<(), CustomError> {
             Ok(())
         }

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -12,7 +12,7 @@ static INIT: Once = Once::new();
 // Initialize environment once for all tests
 pub fn initialize() {
     INIT.call_once(|| {
-        // Any global setup can go here
+        std::env::set_var("GRAPH_STORE_MODE", "in_memory");
     });
 }
 


### PR DESCRIPTION
## Summary
- make Oxigraph HTTP service mode the default graph authority while keeping embedded persistent and in-memory modes explicit
- add Docker Compose configs for separate production/default and live-test Oxigraph services, both on Oxigraph `0.5.8`
- hydrate canonical graph objects/links from RDF, add restart-safe retrieval coverage, and add internal Qdrant/Oxigraph reconciliation diagnostics
- harden reconciliation diagnostics so legacy or incomplete Qdrant payloads produce drift records instead of aborting the run
- require diagnostic store methods explicitly so future adapters cannot silently hide reconciliation data
- guard live Oxigraph smoke cleanup to the dedicated local test endpoint and keep per-test cleanup expectations documented
- document the accepted service snapshot bridge debt and add a follow-up plan to replace it with targeted remote SPARQL reads

## Review Finding Status
- Findings 2, 3, 4, 5, and 6 are fixed in code/docs.
- Findings 7, 8, and 9 are fixed in `docs/coding-agent/plans/active/service-remote-sparql-graph-authority-plan.md`.
- Finding 1 is intentionally tracked as follow-up work in the committed remote-SPARQL plan rather than being implemented in this PR.

## Validation
- cargo fmt --check
- git diff --check
- cargo check
- cargo test internal::infrastructures::graph::oxigraph_authority_store --lib
- cargo test --lib
- cargo clippy --all-targets -- -D warnings
- docker compose -f docker-compose.oxigraph.test.yml config
- docker compose -f docker-compose.oxigraph.test.yml up -d
- OXIGRAPH_TEST_CONNECTION_STRING=http://localhost:7879 cargo test --lib oxigraph_http_service_live_smoke_upserts_queries_and_filters -- --ignored
- verified test Oxigraph service returned 0 quads after smoke cleanup
- pre-commit hooks on final commits: trailing whitespace, EOF, large-file check, TODO warning check, Rust format

## Notes
- live Qdrant smoke remains ignored/prerequisite-gated
- production/default Oxigraph service and live-test Oxigraph service use separate containers, ports, and volumes
- local `gh auth status` reports an invalid CLI token, so PR metadata was updated through the GitHub connector