### PR TITLE
⚡ Batch OpenAI embedding requests

### DIFF
--- a/docs/coding-agent/plans/active/openai-embedding-batching-plan.md
+++ b/docs/coding-agent/plans/active/openai-embedding-batching-plan.md
@@ -58,6 +58,7 @@
 - A2: The first implementation should fail the whole batch on API or parse failure, matching the current all-or-nothing bulk trait behavior.
 - A3: Provider-specific batching should stay inside the OpenAI adapter so tests and alternative embedding providers remain unchanged.
 - A4: Live benchmark speedup should be measured after the core provider change lands, not inside this implementation plan.
+- A5: Token estimation and token-limit preflight guards are intentionally deferred. Supporting future embedding model configurations beyond the OpenAI adapter will affect the right abstraction, so this plan should not add OpenAI-specific token counting yet.
 
 ## Tasks
 
@@ -72,6 +73,7 @@
 - acceptance:
   - Plan decision log records the batch size and retry boundary.
   - Plan decision log records empty batch and empty text behavior.
+  - Plan decision log records that token estimation and token-limit preflight guards are intentionally deferred.
   - Plan decision log records response ordering expectations.
   - No public trait or model default changes are introduced by this decision.
 - validation:
@@ -91,6 +93,7 @@
   - `bulk_generate_embeddings` sends array inputs to the embeddings endpoint.
   - Empty batch returns an empty vector without an HTTP request.
   - Blank text entries return a clear embedding generation error before the HTTP request.
+  - The implementation may split only by documented input-array count limits; it must not add token estimation or token-limit preflight guards in this scope.
   - Response parsing validates embedding count and vector dimensions.
   - Returned embeddings preserve input order.
 - validation:
@@ -191,6 +194,12 @@ Interpretation:
   - Plan delta (what changed): Created a dedicated implementation scope for provider batching.
   - Tradeoffs considered: Keep batching provider-local rather than changing public traits or eval configs.
   - User approval: yes; user requested branches and committed plans for ready work scopes.
+
+- 2026-05-04 00:00 Decision:
+  - Trigger / new insight: OpenAI documents request-level token limits, but future-proof token handling across embedding provider/model configurations needs a broader abstraction than this provider-local batching fix.
+  - Plan delta (what changed): Token estimation and token-limit preflight guards are explicitly deferred; the implementation should rely on API errors for token-limit failures in this scope.
+  - Tradeoffs considered: Avoid adding OpenAI-specific token counting now, while still permitting splitting by documented input-array count limits if needed.
+  - User approval: yes; user requested this decision be recorded where it is not easily missed.
 
 ## Notes
 - Risks:

--- a/docs/coding-agent/plans/active/openai-embedding-batching-plan.md
+++ b/docs/coding-agent/plans/active/openai-embedding-batching-plan.md
@@ -1,0 +1,203 @@
+# Plan: OpenAI Embedding Batching
+
+- status: draft
+- generated: 2026-05-04
+- last_updated: 2026-05-04
+- work_type: code
+
+## Goal
+- Replace serial OpenAI embedding calls in the provider bulk path with true batched embeddings API requests while preserving the existing public embedding provider trait and memory write semantics.
+
+## Definition of Done
+- `OpenAIEmbeddingProvider::bulk_generate_embeddings` sends batches of input texts to the embeddings API instead of awaiting one request per text.
+- Returned embeddings are validated for count, order, and vector dimensionality before indexing.
+- Empty batch and empty text behavior is explicit and covered by tests.
+- Remember/correction indexing paths continue to use the existing `MemoryEmbedder::embed_batch` flow without public API changes.
+- Required Rust checks and focused provider/pipeline tests pass or have explicit recorded waivers.
+
+## Scope / Non-goals
+- Scope:
+  - `src/internal/infrastructures/external_services/openai_embedding_provider.rs`
+  - adjacent unit tests in the same module
+  - `src/internal/repositories/remember_pipeline.rs` tests only if integration coverage needs adjustment
+  - `src/internal/repositories/correction_forget_pipeline.rs` tests only if replacement indexing coverage needs adjustment
+- Non-goals:
+  - Changing the public `EmbeddingProvider` trait.
+  - Changing embedding model defaults.
+  - Introducing a new embedding vendor or local embedding backend.
+  - Running live OpenAI benchmark jobs as part of ordinary validation.
+  - Tuning retrieval budgets or eval configs.
+
+## Context (workspace)
+- Related files/areas:
+  - `src/api/embedding.rs`
+  - `src/internal/infrastructures/external_services/openai_embedding_provider.rs`
+  - `src/internal/repositories/remember_pipeline.rs`
+  - `src/internal/repositories/correction_forget_pipeline.rs`
+  - `src/lib.rs`
+- Existing patterns or references:
+  - The repository already batches vector records at the remember pipeline boundary.
+  - `MemoryEmbedder::embed_batch` already delegates to the provider bulk method.
+  - The current OpenAI provider bulk method loops through `generate_embedding` and awaits one HTTP call per text.
+  - The roadmap keeps OpenAI as a default adapter, not a philosophical dependency.
+- Repo reference docs consulted:
+  - `docs/coding-agent/rules/index.md`
+  - `docs/coding-agent/rules/common.md`
+  - `docs/coding-agent/rules/orchestrator.md`
+  - `docs/coding-agent/lessons.md`
+  - `docs/decisions/implementation/ADR-I-0002-natural-language-embedding-surfaces.md`
+  - `docs/roadmap/development_roadmap.md`
+
+## Open Questions (max 3)
+- Q1: Should batch size be a fixed internal constant for the first implementation, or become a configurable provider setting later?
+- Q2: Should HTTP response parsing preserve provider response order directly, or sort by response `index` before returning embeddings?
+- Q3: Should a failed item fail the whole batch, or should partial retry behavior be planned separately after the baseline batching fix?
+
+## Assumptions
+- A1: The OpenAI embeddings endpoint accepts an array of input strings and returns one embedding per input.
+- A2: The first implementation should fail the whole batch on API or parse failure, matching the current all-or-nothing bulk trait behavior.
+- A3: Provider-specific batching should stay inside the OpenAI adapter so tests and alternative embedding providers remain unchanged.
+- A4: Live benchmark speedup should be measured after the core provider change lands, not inside this implementation plan.
+
+## Tasks
+
+### Task_1: Define Batch Request Semantics
+- type: design
+- owns:
+  - `docs/coding-agent/plans/active/openai-embedding-batching-plan.md`
+  - `src/internal/infrastructures/external_services/openai_embedding_provider.rs`
+- depends_on: []
+- description: |
+  Finalize the internal batching policy before implementation: empty input handling, per-item validation, response order handling, dimensionality checks, and whether the initial implementation uses a fixed internal batch size.
+- acceptance:
+  - Plan decision log records the batch size and retry boundary.
+  - Plan decision log records empty batch and empty text behavior.
+  - Plan decision log records response ordering expectations.
+  - No public trait or model default changes are introduced by this decision.
+- validation:
+  - kind: review
+    required: true
+    owner: orchestrator
+    detail: "Decision log updated with batching semantics and tradeoffs"
+
+### Task_2: Implement OpenAI Bulk Request Path
+- type: impl
+- owns:
+  - `src/internal/infrastructures/external_services/openai_embedding_provider.rs`
+- depends_on: [Task_1]
+- description: |
+  Replace the serial loop in `bulk_generate_embeddings` with batched OpenAI embeddings requests. Reuse the existing client, model, API key, error type, and vector-size expectations.
+- acceptance:
+  - `bulk_generate_embeddings` sends array inputs to the embeddings endpoint.
+  - Empty batch returns an empty vector without an HTTP request.
+  - Blank text entries return a clear embedding generation error before the HTTP request.
+  - Response parsing validates embedding count and vector dimensions.
+  - Returned embeddings preserve input order.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test openai_embedding_provider --lib"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test internal::repositories::remember_pipeline --lib"
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Review provider error handling, response parsing, and trait compatibility"
+
+### Task_3: Add Focused Provider Coverage
+- type: test
+- owns:
+  - `src/internal/infrastructures/external_services/openai_embedding_provider.rs`
+- depends_on: [Task_2]
+- description: |
+  Add or refine service-free tests around request construction and response parsing. Prefer in-module test seams over adding new HTTP mocking dependencies unless the plan is explicitly updated.
+- acceptance:
+  - Tests cover empty batch behavior.
+  - Tests cover blank text rejection in a batch.
+  - Tests cover parsing multiple embeddings from one response.
+  - Tests cover response count mismatch or invalid embedding shape.
+  - Tests do not require a real OpenAI API key.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test openai_embedding_provider --lib"
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Review test seam for minimality and no live-network dependency"
+
+### Task_4: Closeout Validation
+- type: review
+- owns: []
+- depends_on: [Task_2, Task_3]
+- description: |
+  Run repository-required checks and review the final change against write-path performance intent and provider abstraction boundaries.
+- acceptance:
+  - Required validation evidence is complete or explicitly waived.
+  - Reviewer confirms the implementation removes serial per-text OpenAI calls in the bulk path.
+  - Reviewer confirms no retrieval-budget or benchmark-result semantics changed.
+- validation:
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo fmt --check"
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo check"
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo test --no-run"
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Full diff review against this plan"
+
+## Task Waves (explicit parallel dispatch sets)
+
+Interpretation:
+- Tasks listed in the same wave are intended to be dispatched in parallel by default when `owns` are disjoint and dependencies are met.
+- Waves are executed sequentially.
+
+- Wave 1 (parallel): [Task_1]
+- Wave 2 (parallel): [Task_2]
+- Wave 3 (parallel): [Task_3]
+- Wave 4 (parallel): [Task_4]
+
+## E2E / Visual Validation Spec
+
+- Not applicable. This plan does not touch UI or browser-facing flows.
+
+## Rollback / Safety
+- Revert the provider implementation to the previous serial loop if batched requests produce incompatible API behavior.
+- Keep the `EmbeddingProvider` trait unchanged so callers and test providers are insulated from rollback.
+
+## Progress Log (append-only)
+
+- 2026-05-04 00:00 Plan drafted on `feature-2026-05-04-openai-embedding-batching`.
+  - Summary: Created execution plan for true OpenAI embedding batching.
+  - Validation evidence: Planning artifact only; implementation validation pending.
+  - Notes: Budget sweep and retrieval default tuning are out of scope.
+
+## Decision Log (append-only; re-plans and major discoveries)
+
+- 2026-05-04 00:00 Decision:
+  - Trigger / new insight: LongMemEval live ingestion showed the provider bulk path is serial.
+  - Plan delta (what changed): Created a dedicated implementation scope for provider batching.
+  - Tradeoffs considered: Keep batching provider-local rather than changing public traits or eval configs.
+  - User approval: yes; user requested branches and committed plans for ready work scopes.
+
+## Notes
+- Risks:
+  - OpenAI response parsing must preserve input-to-embedding correspondence.
+  - Request-size limits may require internal chunking.
+- Edge cases:
+  - Empty batches.
+  - Blank text entries.
+  - Mismatched response counts.
+  - Embedding dimensions that do not match the configured model.

--- a/docs/coding-agent/plans/active/openai-embedding-batching-plan.md
+++ b/docs/coding-agent/plans/active/openai-embedding-batching-plan.md
@@ -1,6 +1,6 @@
 # Plan: OpenAI Embedding Batching
 
-- status: draft
+- status: in_progress
 - generated: 2026-05-04
 - last_updated: 2026-05-04
 - work_type: code
@@ -49,9 +49,15 @@
   - `docs/roadmap/development_roadmap.md`
 
 ## Open Questions (max 3)
-- Q1: Should batch size be a fixed internal constant for the first implementation, or become a configurable provider setting later?
-- Q2: Should HTTP response parsing preserve provider response order directly, or sort by response `index` before returning embeddings?
-- Q3: Should a failed item fail the whole batch, or should partial retry behavior be planned separately after the baseline batching fix?
+- None.
+
+## Resolved Decisions
+- Use one OpenAI embeddings request for the full bulk input when it is within documented input-array count constraints.
+- Split automatically only when the documented input-array count limit is exceeded.
+- Do not add token estimation or token-limit preflight guards in this scope.
+- Restore response order by returned embedding `index`.
+- Fail the whole batch on API, parse, token-limit, or rate-limit errors.
+- Defer adaptive retry/backoff.
 
 ## Assumptions
 - A1: The OpenAI embeddings endpoint accepts an array of input strings and returns one embedding per input.
@@ -181,6 +187,26 @@ Interpretation:
 - Keep the `EmbeddingProvider` trait unchanged so callers and test providers are insulated from rollback.
 
 ## Progress Log (append-only)
+
+- 2026-05-04 00:00 Wave 1 completed: [Task_1]
+  - Summary: Batch request semantics resolved and recorded in the decision log.
+  - Validation evidence: Orchestrator reviewed the plan decision log and resolved open questions.
+  - Notes: No public trait or model-default changes are in scope.
+
+- 2026-05-04 00:00 Wave 2 completed: [Task_2]
+  - Summary: Replaced the serial provider bulk loop with batched array requests, response parsing by index, documented input-count chunking, and provider-local validation.
+  - Validation evidence: `cargo test openai_embedding_provider --lib` passed; `cargo test internal::repositories::remember_pipeline --lib` passed.
+  - Notes: Token-limit preflight and adaptive retry/backoff remain deferred by decision.
+
+- 2026-05-04 00:00 Wave 3 completed: [Task_3]
+  - Summary: Added service-free provider tests for payload shape, blank input validation, index-ordered parsing, count mismatch, dimension mismatch, duplicate index, and nonnumeric values.
+  - Validation evidence: `cargo test openai_embedding_provider --lib` passed.
+  - Notes: Removed reliance on dummy-key live-network tests.
+
+- 2026-05-04 00:00 Review loop completed: [Task_4]
+  - Summary: First reviewer pass found missing request-count coverage for the actual bulk path; implementation added a private transport seam and bulk-method tests. Second reviewer pass reported no findings and approved the branch.
+  - Validation evidence: `cargo fmt --check` passed; `cargo check` passed; `cargo test --no-run` passed; `cargo test openai_embedding_provider --lib` passed; `cargo test internal::repositories::remember_pipeline --lib` passed; `cargo test internal::repositories::correction_forget_pipeline --lib` passed.
+  - Notes: Live OpenAI integration remains out of scope; token-limit preflight remains intentionally deferred.
 
 - 2026-05-04 00:00 Plan drafted on `feature-2026-05-04-openai-embedding-batching`.
   - Summary: Created execution plan for true OpenAI embedding batching.

--- a/docs/coding-agent/plans/active/openai-embedding-batching-plan.md
+++ b/docs/coding-agent/plans/active/openai-embedding-batching-plan.md
@@ -201,6 +201,12 @@ Interpretation:
   - Tradeoffs considered: Avoid adding OpenAI-specific token counting now, while still permitting splitting by documented input-array count limits if needed.
   - User approval: yes; user requested this decision be recorded where it is not easily missed.
 
+- 2026-05-04 00:00 Decision:
+  - Trigger / new insight: Remaining provider batching open questions were resolved before implementation.
+  - Plan delta (what changed): Use one request for the full bulk input when within documented input-array count constraints; split automatically only when the documented input-array count limit is exceeded; restore response order by embedding `index`; fail the whole batch on API, parse, token-limit, or rate-limit errors; defer adaptive retry/backoff.
+  - Tradeoffs considered: Preserve the existing all-or-nothing bulk trait behavior and avoid introducing retry/order complexity before the basic batch path is stable.
+  - User approval: yes; user accepted these recommendations.
+
 ## Notes
 - Risks:
   - OpenAI response parsing must preserve input-to-embedding correspondence.

--- a/src/internal/infrastructures/external_services/openai_embedding_provider.rs
+++ b/src/internal/infrastructures/external_services/openai_embedding_provider.rs
@@ -1,10 +1,14 @@
 use async_trait::async_trait;
-use reqwest::Client;
+use reqwest::{Client, StatusCode};
 use serde_json::json;
+use std::sync::Arc;
 
 use crate::errors::CustomError;
 use crate::internal::config::settings::EmbeddingProviderSettings;
 use crate::EmbeddingProvider;
+
+const OPENAI_EMBEDDING_ENDPOINT: &str = "https://api.openai.com/v1/embeddings";
+const MAX_OPENAI_EMBEDDING_INPUTS: usize = 2048;
 
 /// OpenAI-based implementation of the EmbeddingProvider trait.
 ///
@@ -21,7 +25,7 @@ pub(crate) struct OpenAIEmbeddingProvider {
     api_key: String,
     model: String,
     vector_size: usize,
-    client: Client,
+    transport: Arc<dyn OpenAIEmbeddingTransport>,
 }
 
 impl OpenAIEmbeddingProvider {
@@ -49,8 +53,52 @@ impl OpenAIEmbeddingProvider {
             api_key: settings.api_key,
             model: settings.model.as_str().to_string(),
             vector_size: settings.model.vector_size() as usize,
-            client: Client::new(),
+            transport: Arc::new(ReqwestOpenAIEmbeddingTransport {
+                client: Client::new(),
+            }),
         })
+    }
+}
+
+#[async_trait]
+trait OpenAIEmbeddingTransport: Send + Sync {
+    async fn send_embeddings_request(
+        &self,
+        api_key: &str,
+        payload: serde_json::Value,
+    ) -> Result<OpenAIEmbeddingHttpResponse, CustomError>;
+}
+
+struct OpenAIEmbeddingHttpResponse {
+    status: StatusCode,
+    body: String,
+}
+
+struct ReqwestOpenAIEmbeddingTransport {
+    client: Client,
+}
+
+#[async_trait]
+impl OpenAIEmbeddingTransport for ReqwestOpenAIEmbeddingTransport {
+    async fn send_embeddings_request(
+        &self,
+        api_key: &str,
+        payload: serde_json::Value,
+    ) -> Result<OpenAIEmbeddingHttpResponse, CustomError> {
+        let response = self
+            .client
+            .post(OPENAI_EMBEDDING_ENDPOINT)
+            .bearer_auth(api_key)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| embedding_generation_error(e.to_string()))?;
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| embedding_generation_error(e.to_string()))?;
+        Ok(OpenAIEmbeddingHttpResponse { status, body })
     }
 }
 
@@ -66,65 +114,178 @@ impl EmbeddingProvider for OpenAIEmbeddingProvider {
                 "Input text is empty.".into(),
             ));
         }
-        let payload = json!({
-            "model": &self.model,
-            "input": text,
-        });
-        let response = self
-            .client
-            .post("https://api.openai.com/v1/embeddings")
-            .bearer_auth(&self.api_key)
-            .json(&payload)
-            .send()
-            .await
-            .map_err(|e| CustomError::EmbeddingGenerationError(e.to_string()))?;
-        if !response.status().is_success() {
-            return Err(CustomError::EmbeddingGenerationError(format!(
-                "OpenAI API error: {}",
-                response.status()
+        let mut embeddings = self.request_embedding_batch(&[text]).await?;
+        if embeddings.len() != 1 {
+            return Err(embedding_generation_error(format!(
+                "OpenAI API returned {} embeddings for 1 input",
+                embeddings.len()
             )));
         }
-        let resp_json: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| CustomError::EmbeddingGenerationError(e.to_string()))?;
-        let embedding = resp_json
-            .get("data")
-            .and_then(|data| data.get(0))
-            .and_then(|item| item.get("embedding"))
-            .and_then(|emb| emb.as_array())
-            .ok_or_else(|| {
-                CustomError::EmbeddingGenerationError(
-                    "Failed to parse embedding from API response".into(),
-                )
-            })?;
-        let vec_embedding: Vec<f32> = embedding
-            .iter()
-            .map(|v| v.as_f64().unwrap_or(0.0) as f32)
-            .collect();
-        Ok(vec_embedding)
+        Ok(embeddings.remove(0))
     }
 
     async fn bulk_generate_embeddings<'a>(
         &self,
         texts: &'a [&'a str],
     ) -> Result<Vec<Vec<f32>>, CustomError> {
+        validate_embedding_texts(texts)?;
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let mut embeddings = Vec::with_capacity(texts.len());
-        for &text in texts {
-            let emb = self.generate_embedding(text).await?;
-            embeddings.push(emb);
+        for chunk in texts.chunks(MAX_OPENAI_EMBEDDING_INPUTS) {
+            embeddings.extend(self.request_embedding_batch(chunk).await?);
         }
         Ok(embeddings)
     }
+}
+
+impl OpenAIEmbeddingProvider {
+    async fn request_embedding_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, CustomError> {
+        validate_embedding_texts(texts)?;
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let payload = embedding_payload(&self.model, texts);
+        let response = self
+            .transport
+            .send_embeddings_request(&self.api_key, payload)
+            .await?;
+        if !response.status.is_success() {
+            let status = response.status;
+            let detail = if response.body.trim().is_empty() {
+                status.to_string()
+            } else {
+                format!("{status}: {}", response.body)
+            };
+            return Err(embedding_generation_error(format!(
+                "OpenAI API error: {detail}"
+            )));
+        }
+        let resp_json: serde_json::Value = serde_json::from_str(&response.body)
+            .map_err(|e| embedding_generation_error(e.to_string()))?;
+        parse_embedding_response(resp_json, texts.len(), self.vector_size)
+    }
+}
+
+fn validate_embedding_texts(texts: &[&str]) -> Result<(), CustomError> {
+    if texts.iter().any(|text| text.trim().is_empty()) {
+        return Err(embedding_generation_error("Input text is empty."));
+    }
+    Ok(())
+}
+
+fn embedding_payload(model: &str, texts: &[&str]) -> serde_json::Value {
+    json!({
+        "model": model,
+        "input": texts,
+    })
+}
+
+fn parse_embedding_response(
+    response: serde_json::Value,
+    expected_count: usize,
+    vector_size: usize,
+) -> Result<Vec<Vec<f32>>, CustomError> {
+    let data = response
+        .get("data")
+        .and_then(|data| data.as_array())
+        .ok_or_else(|| {
+            embedding_generation_error("Failed to parse embeddings from API response: missing data")
+        })?;
+    if data.len() != expected_count {
+        return Err(embedding_generation_error(format!(
+            "OpenAI API returned {} embeddings for {} inputs",
+            data.len(),
+            expected_count
+        )));
+    }
+
+    let mut embeddings = vec![None; expected_count];
+    for item in data {
+        let index = item
+            .get("index")
+            .and_then(|index| index.as_u64())
+            .ok_or_else(|| {
+                embedding_generation_error(
+                    "Failed to parse embeddings from API response: missing index",
+                )
+            })? as usize;
+        if index >= expected_count {
+            return Err(embedding_generation_error(format!(
+                "OpenAI API returned embedding index {index} outside expected range 0..{expected_count}"
+            )));
+        }
+        if embeddings[index].is_some() {
+            return Err(embedding_generation_error(format!(
+                "OpenAI API returned duplicate embedding index {index}"
+            )));
+        }
+        let embedding = item
+            .get("embedding")
+            .and_then(|embedding| embedding.as_array())
+            .ok_or_else(|| {
+                embedding_generation_error(
+                    "Failed to parse embeddings from API response: missing embedding",
+                )
+            })?;
+        if embedding.len() != vector_size {
+            return Err(embedding_generation_error(format!(
+                "OpenAI API returned embedding dimension {} but expected {vector_size}",
+                embedding.len()
+            )));
+        }
+        let vec_embedding = embedding
+            .iter()
+            .map(|value| {
+                value.as_f64().map(|value| value as f32).ok_or_else(|| {
+                    embedding_generation_error(
+                        "Failed to parse embeddings from API response: non-numeric embedding value",
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        embeddings[index] = Some(vec_embedding);
+    }
+
+    embeddings
+        .into_iter()
+        .enumerate()
+        .map(|(index, embedding)| {
+            embedding.ok_or_else(|| {
+                embedding_generation_error(format!(
+                    "OpenAI API response is missing embedding index {index}"
+                ))
+            })
+        })
+        .collect()
+}
+
+fn embedding_generation_error(message: impl Into<String>) -> CustomError {
+    CustomError::EmbeddingGenerationError(message.into())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::internal::models::vector::EmbeddingModel;
+    use std::sync::Mutex;
 
     fn create_test_settings(api_key: &str) -> EmbeddingProviderSettings {
         EmbeddingProviderSettings::new(api_key.to_string(), EmbeddingModel::TextEmbedding3Large)
+    }
+
+    fn create_test_provider(
+        transport: Arc<dyn OpenAIEmbeddingTransport>,
+    ) -> OpenAIEmbeddingProvider {
+        OpenAIEmbeddingProvider {
+            api_key: "valid_api_key".to_owned(),
+            model: EmbeddingModel::TextEmbedding3Large.as_str().to_owned(),
+            vector_size: EmbeddingModel::TextEmbedding3Large.vector_size() as usize,
+            transport,
+        }
     }
 
     #[test]
@@ -155,27 +316,207 @@ mod tests {
         assert!(result.is_err(), "Empty text should return an error.");
     }
 
-    #[tokio::test]
-    async fn test_generate_embedding_with_valid_text() {
-        let text = "hello, world";
-        let settings = create_test_settings("valid_api_key");
-        let provider = OpenAIEmbeddingProvider::new(settings).unwrap();
-        let result = provider.generate_embedding(text).await;
-        assert!(
-            result.is_err(),
-            "Valid text with a dummy API key should produce an error during API call."
-        );
+    #[test]
+    fn batch_payload_uses_array_input() {
+        let payload = embedding_payload("text-embedding-3-large", &["first", "second"]);
+
+        assert_eq!(payload["model"], "text-embedding-3-large");
+        assert_eq!(payload["input"][0], "first");
+        assert_eq!(payload["input"][1], "second");
+    }
+
+    #[test]
+    fn validate_embedding_texts_allows_empty_batch() {
+        assert!(validate_embedding_texts(&[]).is_ok());
+    }
+
+    #[test]
+    fn validate_embedding_texts_rejects_blank_entries() {
+        let result = validate_embedding_texts(&["first", "  "]);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_embedding_response_restores_response_order_by_index() {
+        let response = json!({
+            "data": [
+                { "index": 1, "embedding": [0.3, 0.4] },
+                { "index": 0, "embedding": [0.1, 0.2] }
+            ]
+        });
+
+        let embeddings = parse_embedding_response(response, 2, 2).unwrap();
+
+        assert_eq!(embeddings, vec![vec![0.1, 0.2], vec![0.3, 0.4]]);
+    }
+
+    #[test]
+    fn parse_embedding_response_rejects_count_mismatch() {
+        let response = json!({
+            "data": [
+                { "index": 0, "embedding": [0.1, 0.2] }
+            ]
+        });
+
+        let result = parse_embedding_response(response, 2, 2);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_embedding_response_rejects_dimension_mismatch() {
+        let response = json!({
+            "data": [
+                { "index": 0, "embedding": [0.1] }
+            ]
+        });
+
+        let result = parse_embedding_response(response, 1, 2);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_embedding_response_rejects_duplicate_index() {
+        let response = json!({
+            "data": [
+                { "index": 0, "embedding": [0.1, 0.2] },
+                { "index": 0, "embedding": [0.3, 0.4] }
+            ]
+        });
+
+        let result = parse_embedding_response(response, 2, 2);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_embedding_response_rejects_non_numeric_values() {
+        let response = json!({
+            "data": [
+                { "index": 0, "embedding": [0.1, "bad"] }
+            ]
+        });
+
+        let result = parse_embedding_response(response, 1, 2);
+
+        assert!(result.is_err());
     }
 
     #[tokio::test]
-    async fn test_batch_generate_embeddings() {
-        let settings = create_test_settings("valid_api_key");
-        let provider = OpenAIEmbeddingProvider::new(settings).unwrap();
-        let texts = ["first test", "second test"];
-        let result = provider.bulk_generate_embeddings(&texts).await;
-        assert!(
-            result.is_err(),
-            "Batch generation should fail with a dummy API key."
+    async fn bulk_generate_embeddings_sends_one_array_request_for_multiple_inputs() {
+        let transport = Arc::new(RecordingTransport::default());
+        transport.enqueue_success_response(2, 3072);
+        let provider = create_test_provider(transport.clone());
+
+        let result = provider
+            .bulk_generate_embeddings(&["first", "second"])
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 2);
+        let requests = transport.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0]["input"][0], "first");
+        assert_eq!(requests[0]["input"][1], "second");
+    }
+
+    #[tokio::test]
+    async fn bulk_generate_embeddings_splits_by_documented_input_count_limit() {
+        let transport = Arc::new(RecordingTransport::default());
+        transport.enqueue_success_response(MAX_OPENAI_EMBEDDING_INPUTS, 3072);
+        transport.enqueue_success_response(1, 3072);
+        let provider = create_test_provider(transport.clone());
+        let texts = (0..=MAX_OPENAI_EMBEDDING_INPUTS)
+            .map(|index| format!("text {index}"))
+            .collect::<Vec<_>>();
+        let text_refs = texts.iter().map(String::as_str).collect::<Vec<_>>();
+
+        let result = provider.bulk_generate_embeddings(&text_refs).await.unwrap();
+
+        assert_eq!(result.len(), MAX_OPENAI_EMBEDDING_INPUTS + 1);
+        let requests = transport.requests();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[0]["input"].as_array().unwrap().len(),
+            MAX_OPENAI_EMBEDDING_INPUTS
         );
+        assert_eq!(requests[1]["input"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn bulk_generate_embeddings_returns_empty_without_request() {
+        let transport = Arc::new(RecordingTransport::default());
+        let provider = create_test_provider(transport.clone());
+
+        let result = provider.bulk_generate_embeddings(&[]).await.unwrap();
+
+        assert!(result.is_empty());
+        assert!(transport.requests().is_empty());
+    }
+
+    #[tokio::test]
+    async fn bulk_generate_embeddings_rejects_blank_entry_without_request() {
+        let transport = Arc::new(RecordingTransport::default());
+        let provider = create_test_provider(transport.clone());
+
+        let result = provider.bulk_generate_embeddings(&["first", " "]).await;
+
+        assert!(result.is_err());
+        assert!(transport.requests().is_empty());
+    }
+
+    #[derive(Default)]
+    struct RecordingTransport {
+        requests: Mutex<Vec<serde_json::Value>>,
+        responses: Mutex<Vec<OpenAIEmbeddingHttpResponse>>,
+    }
+
+    impl RecordingTransport {
+        fn enqueue_success_response(&self, count: usize, vector_size: usize) {
+            let data = (0..count)
+                .map(|index| {
+                    json!({
+                        "index": index,
+                        "embedding": vec![index as f32; vector_size],
+                    })
+                })
+                .collect::<Vec<_>>();
+            self.responses
+                .lock()
+                .expect("responses mutex poisoned")
+                .push(OpenAIEmbeddingHttpResponse {
+                    status: StatusCode::OK,
+                    body: json!({ "data": data }).to_string(),
+                });
+        }
+
+        fn requests(&self) -> Vec<serde_json::Value> {
+            self.requests
+                .lock()
+                .expect("requests mutex poisoned")
+                .clone()
+        }
+    }
+
+    #[async_trait]
+    impl OpenAIEmbeddingTransport for RecordingTransport {
+        async fn send_embeddings_request(
+            &self,
+            _api_key: &str,
+            payload: serde_json::Value,
+        ) -> Result<OpenAIEmbeddingHttpResponse, CustomError> {
+            self.requests
+                .lock()
+                .expect("requests mutex poisoned")
+                .push(payload);
+            let response = self
+                .responses
+                .lock()
+                .expect("responses mutex poisoned")
+                .remove(0);
+            Ok(response)
+        }
     }
 }


### PR DESCRIPTION
### Motivation and Context

LongMemEval live runs exposed the OpenAI embedding provider bulk path as a major ingestion bottleneck: the library accepted batch embedding inputs, but the OpenAI adapter sent one embeddings request per text.

### Description

- Replaces the serial OpenAI bulk loop with array-input embeddings requests.
- Splits only by OpenAI's documented 2048 input-array count limit.
- Restores response order by returned embedding index and validates count, duplicate/out-of-range index, numeric values, and vector dimensions.
- Adds a private transport seam for deterministic service-free request-count tests.
- Records the plan/review-loop evidence in docs/coding-agent/plans/active/openai-embedding-batching-plan.md.

### Checklist

- [x] Service-free compile check passes
      cargo check
- [x] Service-free test target compilation passes
      cargo test --no-run
- [ ] **Clippy** passes with warnings denied
      cargo clippy --all-targets -- -D warnings
- [x] Rust formatting check passes
      cargo fmt --check
- [ ] Full Qdrant-backed integration tests pass in trusted same-repository CI or with local service configuration
      cargo test --verbose
- [x] Documentation updated where needed
- [x] BREAKING CHANGE? **No**
- [x] I didn’t break anyone

### Additional Notes

Focused validation passed:

- cargo test openai_embedding_provider --lib
- cargo test internal::repositories::remember_pipeline --lib
- cargo test internal::repositories::correction_forget_pipeline --lib

Review loop:

- First reviewer pass found missing request-count coverage for the actual bulk method.
- Added private transport tests for one array request, 2048-count chunking, empty no-request, and blank no-request.
- Second reviewer pass reported no findings and approved the branch.

Token-count estimation and adaptive retry/backoff are intentionally deferred per the plan decision log.