### PR TITLE
✨ Add retrieval stats foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,9 +271,11 @@ dependencies = [
  "oxigraph",
  "qdrant-client",
  "reqwest 0.13.3",
+ "rusqlite",
  "secrecy",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -587,6 +601,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +852,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -818,6 +863,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1277,6 +1331,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,6 +1757,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -2100,6 +2177,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2122,6 +2213,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2590,6 +2694,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2968,6 +3085,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -3467,7 +3590,7 @@ checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ secrecy = { version = "0.10.3", features = ["serde"] }
 qdrant-client = "1.17.0"
 oxigraph = { version = "0.5.7", default-features = false, features = ["rocksdb"] }
 serde_json = "1.0.138"
+rusqlite = { version = "0.32.1", features = ["bundled"] }
 
 # Async Runtime
 tokio = { version = "1.52.1", features = ["full"] }
@@ -30,3 +31,4 @@ chrono = { version = "0.4.44", features = ["serde"] }
 
 [dev-dependencies]
 tonic = "0.12.3"
+tempfile = "3.20.0"

--- a/docs/coding-agent/plans/active/v0-1-2-retrieval-stats-foundation-plan.md
+++ b/docs/coding-agent/plans/active/v0-1-2-retrieval-stats-foundation-plan.md
@@ -1,0 +1,239 @@
+# Plan: v0.1.2 Retrieval Stats Foundation
+
+- status: approved
+- generated: 2026-05-09
+- last_updated: 2026-05-10
+- work_type: code
+
+## Goal
+- Add the derived retrieval statistics foundation required by v0.1.2: a backend-neutral stats contract, deterministic in-memory store, persistent SQLite store, configuration, composition wiring, and write-path updates that keep stats useful without making them memory truth.
+
+## Definition of Done
+- `RetrievalStatsStore` exists as an internal contract for edge-ledger and entity/relation/object counters.
+- In-memory and SQLite stats stores exist; SQLite counters survive restart/reopen.
+- Settings can select stats store mode, path, health fail mode, smoothing, gamma, and relation/object fanout policy defaults.
+- Remember/link/lifecycle write paths update stats after graph-authoritative mutation without changing graph or vector authority.
+- Stats update failures are visible through health/diagnostic state and cause later retrieval policy to have a conservative fallback path.
+- Required Rust validation passes and Reviewer approves the authority boundary.
+
+## Scope / Non-goals
+- Scope:
+  - Internal stats contract and data model.
+  - In-memory and SQLite stats store implementations.
+  - App settings and default construction wiring.
+  - Stats updates from graph write and lifecycle mutation paths.
+  - Unit/restart tests for counter persistence, idempotency, and health states.
+- Non-goals:
+  - Stats-guided retrieval fanout implementation.
+  - Retrieval rationale/trace public DTO expansion.
+  - Durable link co-occurrence admission policy.
+  - Stats rebuild/backfill tooling.
+  - Public admin API or dashboard.
+  - Postgres, Redb, or network stats backends.
+
+## Context (workspace)
+- Related files/areas:
+  - `docs/roadmap/development_roadmap.md`
+  - `docs/design/roadmap-phases/v0_1_2_continuous_entity_selectivity_retrieval_guardrails.md`
+  - `docs/decisions/implementation/ADR-I-0008-retrieval-stats-are-derived-policy-metadata.md`
+  - `docs/decisions/implementation/ADR-I-0009-use-sqlite-as-default-retrieval-stats-store.md`
+  - `src/config/settings/app_settings.rs`
+  - `src/internal/config/settings.rs`
+  - `src/internal/repositories.rs`
+  - `src/internal/repositories/remember_pipeline.rs`
+  - `src/internal/repositories/link_pipeline.rs`
+  - `src/internal/repositories/correction_forget_pipeline.rs`
+  - `src/internal/repositories/test_support.rs`
+  - `src/lib.rs`
+  - `Cargo.toml`
+- Existing patterns or references:
+  - Config parsing is centralized in `Settings`.
+  - Repository contracts live under `src/internal/repositories/`.
+  - Tests prefer deterministic fakes and unit tests near production modules.
+  - Stats must remain derived policy metadata; Oxigraph remains graph truth.
+- Repo reference docs consulted:
+  - `docs/coding-agent/rules/index.md`
+  - `docs/coding-agent/rules/common.md`
+  - `docs/coding-agent/rules/orchestrator.md`
+  - `docs/coding-agent/lessons.md`
+
+## Open Questions (max 3)
+- None.
+
+## Resolved Decisions
+- Use `rusqlite` with bundled SQLite for the default persistent stats implementation.
+- Keep stats update failures internal for this phase through stats health and diagnostics; do not change public remember/link/correct/forget outcome shapes unless a later plan establishes a concrete caller workflow.
+- Missing or unhealthy stats must fall back conservatively: do not expand broadly from stats alone, use minimum fanout for low-selectivity paths, keep existing static graph caps as hard upper bounds, and require stronger support signals before expanding through broad entities.
+
+## Assumptions
+- A1: SQLite is the intended default because ADR-I-0009 is accepted.
+- A2: This plan may add `Cargo.toml`/`Cargo.lock` dependencies for `rusqlite` with bundled SQLite and temp-file testing.
+- A3: Stats update ordering follows the roadmap: graph mutation, vector maintenance, then stats delta.
+- A4: Public `CharacterMemory` facade shape should remain stable unless constructor composition needs a non-breaking internal update.
+
+## Tasks
+
+### Task_1: Define Stats Contract, Config, And Policy Inputs
+- type: impl
+- owns:
+  - `src/internal/repositories.rs`
+  - `src/internal/repositories/retrieval_stats_store.rs`
+  - `src/config/settings/app_settings.rs`
+  - `src/internal/config/settings.rs`
+  - `Cargo.toml`
+  - `Cargo.lock`
+- depends_on: []
+- description: |
+  Add a backend-neutral `RetrievalStatsStore` contract, stats health/fail-mode types, counter/query DTOs, deterministic edge-key expectations, and settings for store selection, path, smoothing, gamma, and relation/object fanout policy inputs.
+- acceptance:
+  - Contract can represent entity/relation/object counters, global counters, edge ledger idempotency, lifecycle/currentness state, and health.
+  - Settings parse retrieval stats mode/path/fail mode and selectivity parameters with stable defaults.
+  - Dependency selection is recorded as `rusqlite` with bundled SQLite unless implementation discovers a blocking validation issue that requires replanning.
+  - Conservative fallback defaults are represented for downstream fanout policy: minimum fanout for weak/low-selectivity paths, existing static graph caps as hard upper bounds, and stronger-support requirement for broad expansion.
+  - No persisted selectivity category type is introduced.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test settings retrieval_stats --no-fail-fast"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo fmt --check"
+
+### Task_2: Implement In-Memory And SQLite Stats Stores
+- type: impl
+- owns:
+  - `src/internal/infrastructures/retrieval_stats/**`
+  - `src/internal/repositories/retrieval_stats_store.rs`
+  - `src/internal/repositories/test_support.rs`
+  - `Cargo.toml`
+  - `Cargo.lock`
+- depends_on: [Task_1]
+- description: |
+  Implement deterministic in-memory and SQLite-backed stats stores with internal tables for edge ledger, entity relation counts, global relation counts, and stats metadata/health.
+- acceptance:
+  - In-memory store is deterministic and suitable for unit tests.
+  - SQLite store creates or migrates its internal schema on open.
+  - Duplicate edge updates are idempotent.
+  - Restart/reopen preserves counters and health metadata.
+  - Corrupt or unavailable stats state is representable without giving stats authority over memory truth.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test retrieval_stats --no-fail-fast"
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo check"
+
+### Task_3: Wire Stats Into Construction And Write Paths
+- type: impl
+- owns:
+  - `src/lib.rs`
+  - `src/internal/repositories/remember_pipeline.rs`
+  - `src/internal/repositories/link_pipeline.rs`
+  - `src/internal/repositories/correction_forget_pipeline.rs`
+  - `src/internal/repositories/test_support.rs`
+- depends_on: [Task_1, Task_2]
+- description: |
+  Add stats store composition and update stats after graph-authoritative writes and vector maintenance for remember, link, correction, forget, suppression, supersession, and currentness changes.
+- acceptance:
+  - Public construction wires a default SQLite stats store when configured for persistent stats.
+  - Tests can inject in-memory/fake stats stores.
+  - Stats updates occur after graph mutation and vector maintenance.
+  - Duplicate retry/write paths do not inflate counters.
+  - Lifecycle/currentness/supersession changes update active/current counters while Oxigraph remains final authority.
+  - Stats update failures are recorded internally as health/diagnostic state and do not alter public remember/link/correct/forget outcome shapes in this phase.
+  - Stats failures do not decide existence, lifecycle, currentness, provenance, or final inclusion.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo test remember_pipeline link_pipeline correction_forget_pipeline retrieval_stats --no-fail-fast"
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Review write ordering and confirm stats remain derived policy metadata only"
+
+### Task_4: Foundation Closeout Review
+- type: review
+- owns: []
+- depends_on: [Task_1, Task_2, Task_3]
+- description: |
+  Validate the stats foundation against v0.1.2 docs and authority invariants before retrieval fanout work begins.
+- acceptance:
+  - All required worker validation evidence is present.
+  - Reviewer approves contract boundaries, config defaults, persistence behavior, and write-path ordering.
+  - No roadmap-version labels are introduced in durable production comments, identifiers, or user-facing errors.
+- validation:
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo fmt --check"
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo check"
+  - kind: command
+    required: true
+    owner: orchestrator
+    detail: "cargo test --no-run"
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Final review of stats foundation implementation"
+
+## Task Waves (explicit parallel dispatch sets)
+
+- Wave 1 (parallel): [Task_1]
+- Wave 2 (parallel): [Task_2]
+- Wave 3 (parallel): [Task_3]
+- Wave 4 (parallel): [Task_4]
+
+## E2E / Visual Validation Spec
+
+- Not applicable. No UI/user-flow changes.
+
+## Rollback / Safety
+- Stats are derived. If the new stats store is unhealthy or absent, retrieval plans must fall back conservatively rather than trusting stats.
+- SQLite schema and dependency changes can be reverted with this feature plan's touched files if the dependency decision changes before implementation.
+
+## Progress Log (append-only)
+
+- 2026-05-09 Draft created:
+  - Summary: Split v0.1.2 into feature plans and drafted the stats foundation plan.
+  - Validation evidence: Researcher mapped v0.1.2 source docs and affected code areas; no implementation dispatched.
+  - Notes: Awaiting user approval and open-question decisions.
+- 2026-05-10 Open questions resolved:
+  - Summary: Recorded approved recommendations for SQLite dependency choice, stats failure surfacing, and conservative fallback defaults.
+  - Validation evidence: Plan-only update; `git diff --check -- docs/coding-agent/plans/active` pending.
+  - Notes: No implementation dispatched.
+- 2026-05-10 Plan approved for execution:
+  - Summary: User requested each plan be committed on its own implementation branch and readied for execution.
+  - Validation evidence: Plan status updated to approved; implementation remains pending.
+  - Notes: No Worker tasks dispatched yet.
+
+## Decision Log (append-only; re-plans and major discoveries)
+
+- 2026-05-09 Decision:
+  - Trigger / new insight: v0.1.2 spans stats persistence, retrieval policy, diagnostics, link admission, and entity-neutral fixtures.
+  - Plan delta (what changed): Split the milestone into a stats foundation plan, retrieval fanout/rationale plan, and link guard/entity-neutral hardening plan.
+  - Tradeoffs considered: A single plan would preserve one milestone artifact but make validation and review too broad.
+  - User approval: no
+- 2026-05-10 Decision:
+  - Trigger / new insight: User approved the recommended answers to all stats foundation open questions.
+  - Plan delta (what changed): Added resolved decisions for `rusqlite` with bundled SQLite, internal-only stats update failure surfacing, and conservative missing/unhealthy stats fallback defaults.
+  - Tradeoffs considered: `rusqlite` keeps the embedded counter workload simple; public outcome changes are deferred until a concrete caller workflow requires them; conservative fallback protects retrieval from treating stale derived stats as authority.
+  - User approval: yes
+
+## Notes
+- Risks:
+  - SQLite dependency choice may affect Windows/native validation.
+  - Stats update failure semantics can leak into public API design if not bounded.
+  - Composition wiring may touch many tests because current construction has graph/vector/embedder only.
+- Edge cases:
+  - Duplicate retries must not increment counters twice.
+  - Lifecycle flips must update active/current counts without changing total history counters incorrectly.
+  - Missing/unhealthy stats must never make retrieval include otherwise invalid graph objects.

--- a/docs/coding-agent/plans/active/v0-1-2-retrieval-stats-foundation-plan.md
+++ b/docs/coding-agent/plans/active/v0-1-2-retrieval-stats-foundation-plan.md
@@ -27,6 +27,7 @@
   - Stats-guided retrieval fanout implementation.
   - Retrieval rationale/trace public DTO expansion.
   - Durable link co-occurrence admission policy.
+  - Weak associative hint storage, associative units, associative memberships, or association support records.
   - Stats rebuild/backfill tooling.
   - Public admin API or dashboard.
   - Postgres, Redb, or network stats backends.
@@ -51,6 +52,7 @@
   - Repository contracts live under `src/internal/repositories/`.
   - Tests prefer deterministic fakes and unit tests near production modules.
   - Stats must remain derived policy metadata; Oxigraph remains graph truth.
+  - Controlled associative recall docs keep weak association evidence graph-internal in future `AssociativeUnit`/`AssociativeMembership`/`AssociationSupport` structures, not in the retrieval stats store.
 - Repo reference docs consulted:
   - `docs/coding-agent/rules/index.md`
   - `docs/coding-agent/rules/common.md`
@@ -91,6 +93,7 @@
   - Dependency selection is recorded as `rusqlite` with bundled SQLite unless implementation discovers a blocking validation issue that requires replanning.
   - Conservative fallback defaults are represented for downstream fanout policy: minimum fanout for weak/low-selectivity paths, existing static graph caps as hard upper bounds, and stronger-support requirement for broad expansion.
   - No persisted selectivity category type is introduced.
+  - Contract does not model weak associative hints, associative units, associative memberships, or association support records.
 - validation:
   - kind: command
     required: true
@@ -214,6 +217,10 @@
   - Summary: User requested each plan be committed on its own implementation branch and readied for execution.
   - Validation evidence: Plan status updated to approved; implementation remains pending.
   - Notes: No Worker tasks dispatched yet.
+- 2026-05-10 Main roadmap refresh reviewed:
+  - Summary: Updated plan boundary after latest main added controlled associative recall docs.
+  - Validation evidence: Plan-only update; branch rebased onto `origin/main`.
+  - Notes: Retrieval stats remain derived counters only and must not become weak associative hint storage.
 
 ## Decision Log (append-only; re-plans and major discoveries)
 
@@ -226,6 +233,11 @@
   - Trigger / new insight: User approved the recommended answers to all stats foundation open questions.
   - Plan delta (what changed): Added resolved decisions for `rusqlite` with bundled SQLite, internal-only stats update failure surfacing, and conservative missing/unhealthy stats fallback defaults.
   - Tradeoffs considered: `rusqlite` keeps the embedded counter workload simple; public outcome changes are deferred until a concrete caller workflow requires them; conservative fallback protects retrieval from treating stale derived stats as authority.
+  - User approval: yes
+- 2026-05-10 Decision:
+  - Trigger / new insight: Latest main adds controlled associative recall docs and ADRs that reserve weak associative evidence for future graph-internal associative structures.
+  - Plan delta (what changed): Added an explicit non-goal and acceptance boundary preventing `RetrievalStatsStore` from becoming a weak associative hint store or associative membership/support store.
+  - Tradeoffs considered: Keeping stats as counters preserves ADR-I-0008's derived-policy boundary and leaves future associative recall under graph authority.
   - User approval: yes
 
 ## Notes

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,4 +1,6 @@
 mod app_settings;
 
 pub(crate) use crate::internal::config::settings::EmbeddingProviderSettings;
-pub use app_settings::{GraphStoreMode, Settings};
+pub use app_settings::{
+    GraphStoreMode, RetrievalStatsHealthFailMode, RetrievalStatsStoreMode, Settings,
+};

--- a/src/config/settings/app_settings.rs
+++ b/src/config/settings/app_settings.rs
@@ -15,6 +15,16 @@ pub struct Settings {
     embedding_model: SecretString,
     #[serde(default)]
     graph_store_mode: GraphStoreMode,
+    #[serde(default)]
+    retrieval_stats_store_mode: RetrievalStatsStoreMode,
+    #[serde(default = "default_retrieval_stats_path")]
+    retrieval_stats_path: PathBuf,
+    #[serde(default)]
+    retrieval_stats_health_fail_mode: RetrievalStatsHealthFailMode,
+    #[serde(default = "default_selectivity_smoothing_alpha")]
+    selectivity_smoothing_alpha: f64,
+    #[serde(default = "default_selectivity_gamma")]
+    selectivity_gamma: f64,
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
@@ -34,6 +44,44 @@ impl GraphStoreMode {
             "in_memory" => Ok(Self::InMemory),
             other => Err(CustomError::ConfigParseError(format!(
                 "GRAPH_STORE_MODE must be service, persistent, or in_memory, got {other}"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RetrievalStatsStoreMode {
+    #[default]
+    Sqlite,
+    InMemory,
+}
+
+impl RetrievalStatsStoreMode {
+    fn parse(value: &str) -> Result<Self, CustomError> {
+        match value {
+            "sqlite" => Ok(Self::Sqlite),
+            "in_memory" => Ok(Self::InMemory),
+            other => Err(CustomError::ConfigParseError(format!(
+                "RETRIEVAL_STATS_STORE_MODE must be sqlite or in_memory, got {other}"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RetrievalStatsHealthFailMode {
+    #[default]
+    Conservative,
+}
+
+impl RetrievalStatsHealthFailMode {
+    fn parse(value: &str) -> Result<Self, CustomError> {
+        match value {
+            "conservative" => Ok(Self::Conservative),
+            other => Err(CustomError::ConfigParseError(format!(
+                "RETRIEVAL_STATS_HEALTH_FAIL_MODE must be conservative, got {other}"
             ))),
         }
     }
@@ -103,6 +151,21 @@ impl Settings {
         let graph_store_mode = env::var("GRAPH_STORE_MODE")
             .map(|value| GraphStoreMode::parse(&value))
             .unwrap_or(Ok(GraphStoreMode::Service))?;
+        let retrieval_stats_store_mode = env::var("RETRIEVAL_STATS_STORE_MODE")
+            .map(|value| RetrievalStatsStoreMode::parse(&value))
+            .unwrap_or(Ok(RetrievalStatsStoreMode::Sqlite))?;
+        let retrieval_stats_path = env::var("RETRIEVAL_STATS_PATH")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| default_retrieval_stats_path());
+        let retrieval_stats_health_fail_mode = env::var("RETRIEVAL_STATS_HEALTH_FAIL_MODE")
+            .map(|value| RetrievalStatsHealthFailMode::parse(&value))
+            .unwrap_or(Ok(RetrievalStatsHealthFailMode::Conservative))?;
+        let selectivity_smoothing_alpha = env::var("SELECTIVITY_SMOOTHING_ALPHA")
+            .map(|value| parse_positive_f64("SELECTIVITY_SMOOTHING_ALPHA", &value))
+            .unwrap_or(Ok(default_selectivity_smoothing_alpha()))?;
+        let selectivity_gamma = env::var("SELECTIVITY_GAMMA")
+            .map(|value| parse_positive_f64("SELECTIVITY_GAMMA", &value))
+            .unwrap_or(Ok(default_selectivity_gamma()))?;
 
         Ok(Self {
             qdrant_connection_string: SecretString::new(qdrant_connection_string.into()),
@@ -110,6 +173,11 @@ impl Settings {
             openai_api_key: SecretString::new(openai_api_key.into()),
             embedding_model: SecretString::new(embedding_model.into()),
             graph_store_mode,
+            retrieval_stats_store_mode,
+            retrieval_stats_path,
+            retrieval_stats_health_fail_mode,
+            selectivity_smoothing_alpha,
+            selectivity_gamma,
         })
     }
 
@@ -123,6 +191,26 @@ impl Settings {
 
     pub fn get_graph_store_mode(&self) -> GraphStoreMode {
         self.graph_store_mode
+    }
+
+    pub fn get_retrieval_stats_store_mode(&self) -> RetrievalStatsStoreMode {
+        self.retrieval_stats_store_mode
+    }
+
+    pub fn get_retrieval_stats_path(&self) -> &Path {
+        &self.retrieval_stats_path
+    }
+
+    pub fn get_retrieval_stats_health_fail_mode(&self) -> RetrievalStatsHealthFailMode {
+        self.retrieval_stats_health_fail_mode
+    }
+
+    pub fn get_selectivity_smoothing_alpha(&self) -> f64 {
+        self.selectivity_smoothing_alpha
+    }
+
+    pub fn get_selectivity_gamma(&self) -> f64 {
+        self.selectivity_gamma
     }
 
     pub fn get_oxigraph_path(&self) -> Result<PathBuf, CustomError> {
@@ -182,8 +270,37 @@ impl Settings {
             openai_api_key,
             embedding_model,
             graph_store_mode: GraphStoreMode::InMemory,
+            retrieval_stats_store_mode: RetrievalStatsStoreMode::InMemory,
+            retrieval_stats_path: default_retrieval_stats_path(),
+            retrieval_stats_health_fail_mode: RetrievalStatsHealthFailMode::Conservative,
+            selectivity_smoothing_alpha: default_selectivity_smoothing_alpha(),
+            selectivity_gamma: default_selectivity_gamma(),
         }
     }
+}
+
+fn default_retrieval_stats_path() -> PathBuf {
+    PathBuf::from("./data/retrieval-stats.sqlite3")
+}
+
+fn default_selectivity_smoothing_alpha() -> f64 {
+    1.0
+}
+
+fn default_selectivity_gamma() -> f64 {
+    1.0
+}
+
+fn parse_positive_f64(name: &str, value: &str) -> Result<f64, CustomError> {
+    let parsed = value.parse::<f64>().map_err(|error| {
+        CustomError::ConfigParseError(format!("{name} must be a finite positive number: {error}"))
+    })?;
+    if !parsed.is_finite() || parsed <= 0.0 {
+        return Err(CustomError::ConfigParseError(format!(
+            "{name} must be a finite positive number, got {value}"
+        )));
+    }
+    Ok(parsed)
 }
 
 #[cfg(test)]
@@ -212,6 +329,20 @@ mod tests {
         assert_eq!(settings.get_qdrant_connection(), "external_qdrant");
         assert_eq!(settings.get_oxigraph_connection(), "external_oxigraph");
         assert_eq!(settings.get_graph_store_mode(), GraphStoreMode::Service);
+        assert_eq!(
+            settings.get_retrieval_stats_store_mode(),
+            RetrievalStatsStoreMode::Sqlite
+        );
+        assert_eq!(
+            settings.get_retrieval_stats_path(),
+            Path::new("./data/retrieval-stats.sqlite3")
+        );
+        assert_eq!(
+            settings.get_retrieval_stats_health_fail_mode(),
+            RetrievalStatsHealthFailMode::Conservative
+        );
+        assert_eq!(settings.get_selectivity_smoothing_alpha(), 1.0);
+        assert_eq!(settings.get_selectivity_gamma(), 1.0);
     }
 
     #[test]
@@ -258,6 +389,44 @@ mod tests {
             settings.get_oxigraph_path().unwrap(),
             PathBuf::from("./data/oxigraph")
         );
+    }
+
+    #[test]
+    fn test_settings_new_accepts_retrieval_stats_overrides() {
+        let external_config = Config::builder()
+            .set_override("qdrant_connection_string", "external_qdrant")
+            .unwrap()
+            .set_override("oxigraph_connection_string", "external_oxigraph")
+            .unwrap()
+            .set_override("openai_api_key", "external_openai")
+            .unwrap()
+            .set_override("embedding_model", "TextEmbedding3Small")
+            .unwrap()
+            .set_override("retrieval_stats_store_mode", "in_memory")
+            .unwrap()
+            .set_override("retrieval_stats_path", "./tmp/stats.sqlite3")
+            .unwrap()
+            .set_override("retrieval_stats_health_fail_mode", "conservative")
+            .unwrap()
+            .set_override("selectivity_smoothing_alpha", 2.0)
+            .unwrap()
+            .set_override("selectivity_gamma", 0.5)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let settings = Settings::new(external_config).unwrap();
+
+        assert_eq!(
+            settings.get_retrieval_stats_store_mode(),
+            RetrievalStatsStoreMode::InMemory
+        );
+        assert_eq!(
+            settings.get_retrieval_stats_path(),
+            Path::new("./tmp/stats.sqlite3")
+        );
+        assert_eq!(settings.get_selectivity_smoothing_alpha(), 2.0);
+        assert_eq!(settings.get_selectivity_gamma(), 0.5);
     }
 
     #[test]

--- a/src/config/settings/app_settings.rs
+++ b/src/config/settings/app_settings.rs
@@ -169,7 +169,7 @@ impl Settings {
             .map(|value| parse_positive_f64("SELECTIVITY_GAMMA", &value))
             .unwrap_or(Ok(default_selectivity_gamma()))?;
 
-        Ok(Self {
+        let settings = Self {
             qdrant_connection_string: SecretString::new(qdrant_connection_string.into()),
             oxigraph_connection_string: SecretString::new(oxigraph_connection_string.into()),
             openai_api_key: SecretString::new(openai_api_key.into()),
@@ -180,7 +180,9 @@ impl Settings {
             retrieval_stats_health_fail_mode,
             selectivity_smoothing_alpha,
             selectivity_gamma,
-        })
+        };
+        settings.validate_selectivity_settings()?;
+        Ok(settings)
     }
 
     pub fn get_qdrant_connection(&self) -> &str {

--- a/src/config/settings/app_settings.rs
+++ b/src/config/settings/app_settings.rs
@@ -109,9 +109,11 @@ impl Settings {
     /// - `Ok`: A new `Settings` instance with the provided configuration
     /// - `Err`: A `CustomError` if any required settings are missing or invalid
     pub fn new(config: Config) -> Result<Self, CustomError> {
-        config.try_deserialize().map_err(|e| {
+        let settings: Self = config.try_deserialize().map_err(|e| {
             CustomError::ConfigParseError(format!("Failed to parse external configuration: {e}"))
-        })
+        })?;
+        settings.validate_selectivity_settings()?;
+        Ok(settings)
     }
 
     /// Loads settings from environment variables and configuration files using default loaders.
@@ -254,6 +256,14 @@ impl Settings {
     pub(crate) fn get_embedding_model(&self) -> Result<EmbeddingModel, CustomError> {
         self.embedding_model.expose_secret().parse()
     }
+
+    fn validate_selectivity_settings(&self) -> Result<(), CustomError> {
+        validate_positive_f64(
+            "selectivity_smoothing_alpha",
+            self.selectivity_smoothing_alpha,
+        )?;
+        validate_positive_f64("selectivity_gamma", self.selectivity_gamma)
+    }
 }
 
 #[cfg(test)]
@@ -295,12 +305,21 @@ fn parse_positive_f64(name: &str, value: &str) -> Result<f64, CustomError> {
     let parsed = value.parse::<f64>().map_err(|error| {
         CustomError::ConfigParseError(format!("{name} must be a finite positive number: {error}"))
     })?;
-    if !parsed.is_finite() || parsed <= 0.0 {
+    validate_positive_f64(name, parsed).map_err(|_| {
+        CustomError::ConfigParseError(format!(
+            "{name} must be a finite positive number, got {value}"
+        ))
+    })?;
+    Ok(parsed)
+}
+
+fn validate_positive_f64(name: &str, value: f64) -> Result<(), CustomError> {
+    if !value.is_finite() || value <= 0.0 {
         return Err(CustomError::ConfigParseError(format!(
             "{name} must be a finite positive number, got {value}"
         )));
     }
-    Ok(parsed)
+    Ok(())
 }
 
 #[cfg(test)]
@@ -427,6 +446,41 @@ mod tests {
         );
         assert_eq!(settings.get_selectivity_smoothing_alpha(), 2.0);
         assert_eq!(settings.get_selectivity_gamma(), 0.5);
+    }
+
+    #[test]
+    fn test_settings_new_rejects_invalid_selectivity_numbers() {
+        for (key, value) in [
+            ("selectivity_smoothing_alpha", 0.0),
+            ("selectivity_smoothing_alpha", -1.0),
+            ("selectivity_smoothing_alpha", f64::INFINITY),
+            ("selectivity_smoothing_alpha", f64::NAN),
+            ("selectivity_gamma", 0.0),
+            ("selectivity_gamma", -1.0),
+            ("selectivity_gamma", f64::INFINITY),
+            ("selectivity_gamma", f64::NAN),
+        ] {
+            let external_config = Config::builder()
+                .set_override("qdrant_connection_string", "external_qdrant")
+                .unwrap()
+                .set_override("oxigraph_connection_string", "external_oxigraph")
+                .unwrap()
+                .set_override("openai_api_key", "external_openai")
+                .unwrap()
+                .set_override("embedding_model", "TextEmbedding3Small")
+                .unwrap()
+                .set_override(key, value)
+                .unwrap()
+                .build()
+                .unwrap();
+
+            let result = Settings::new(external_config);
+
+            assert!(
+                matches!(result, Err(CustomError::ConfigParseError(_))),
+                "{key}={value:?} should be rejected"
+            );
+        }
     }
 
     #[test]

--- a/src/internal/infrastructures.rs
+++ b/src/internal/infrastructures.rs
@@ -1,2 +1,3 @@
 pub(crate) mod external_services;
 pub(crate) mod graph;
+pub(crate) mod retrieval_stats;

--- a/src/internal/infrastructures/retrieval_stats.rs
+++ b/src/internal/infrastructures/retrieval_stats.rs
@@ -89,6 +89,33 @@ impl RetrievalStatsStore for SqliteRetrievalStatsStore {
             .map_err(sqlite_error)
     }
 
+    async fn global_counter(
+        &self,
+        relation_kind: crate::api::types::RelationType,
+        object_type: crate::api::types::ObjectType,
+    ) -> Result<Option<RetrievalStatsCounter>, CustomError> {
+        let connection = lock(&self.connection)?;
+        connection
+            .query_row(
+                "SELECT total_count, active_count, current_count
+                 FROM global_relation_counts
+                 WHERE relation_kind = ?1 AND object_type = ?2",
+                params![
+                    relation_type_key(relation_kind),
+                    object_type_key(object_type)
+                ],
+                |row| {
+                    Ok(RetrievalStatsCounter {
+                        total_count: non_negative_count(row.get(0)?)?,
+                        active_count: non_negative_count(row.get(1)?)?,
+                        current_count: non_negative_count(row.get(2)?)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(sqlite_error)
+    }
+
     async fn health(&self) -> Result<RetrievalStatsHealth, CustomError> {
         let connection = lock(&self.connection)?;
         let state =
@@ -535,6 +562,43 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(counter.total_count, 1);
+        assert_eq!(counter.active_count, 1);
+        assert_eq!(counter.current_count, 1);
+    }
+
+    #[tokio::test]
+    async fn sqlite_store_counts_global_relation_object_pairs() {
+        let dir = tempdir().unwrap();
+        let store = SqliteRetrievalStatsStore::open(dir.path().join("stats.sqlite3")).unwrap();
+        let first_entity_id = id("550e8400-e29b-41d4-a716-446655461031");
+        let second_entity_id = id("550e8400-e29b-41d4-a716-446655461032");
+        let first_episode_id = id("550e8400-e29b-41d4-a716-446655461033");
+        let second_episode_id = id("550e8400-e29b-41d4-a716-446655461034");
+
+        store
+            .record_edges(&[
+                test_edge(
+                    first_entity_id,
+                    first_episode_id,
+                    RetentionState::Active,
+                    true,
+                ),
+                test_edge(
+                    second_entity_id,
+                    second_episode_id,
+                    RetentionState::Suppressed,
+                    false,
+                ),
+            ])
+            .await
+            .unwrap();
+
+        let counter = store
+            .global_counter(RelationType::Involves, ObjectType::Episode)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(counter.total_count, 2);
         assert_eq!(counter.active_count, 1);
         assert_eq!(counter.current_count, 1);
     }

--- a/src/internal/infrastructures/retrieval_stats.rs
+++ b/src/internal/infrastructures/retrieval_stats.rs
@@ -47,7 +47,6 @@ impl RetrievalStatsStore for SqliteRetrievalStatsStore {
         for edge in edges {
             upsert_edge(&transaction, edge)?;
         }
-        set_health(&transaction, RetrievalStatsHealth::default())?;
         transaction.commit().map_err(sqlite_error)
     }
 
@@ -60,7 +59,6 @@ impl RetrievalStatsStore for SqliteRetrievalStatsStore {
         for state in states {
             update_object_state(&transaction, state)?;
         }
-        set_health(&transaction, RetrievalStatsHealth::default())?;
         transaction.commit().map_err(sqlite_error)
     }
 
@@ -654,6 +652,15 @@ mod tests {
             let store = SqliteRetrievalStatsStore::open(&path).unwrap();
             store
                 .mark_unhealthy("transient stats failure".to_owned())
+                .await
+                .unwrap();
+            store
+                .record_edges(&[test_edge(
+                    id("550e8400-e29b-41d4-a716-446655461051"),
+                    id("550e8400-e29b-41d4-a716-446655461052"),
+                    RetentionState::Active,
+                    true,
+                )])
                 .await
                 .unwrap();
         }

--- a/src/internal/infrastructures/retrieval_stats.rs
+++ b/src/internal/infrastructures/retrieval_stats.rs
@@ -193,12 +193,16 @@ fn upsert_edge(connection: &Connection, edge: &RetrievalStatsEdge) -> Result<(),
             connection
                 .execute(
                     "UPDATE entity_edge_index
-                     SET retention_state = ?2, is_current = ?3, last_seen_at = ?4
+                     SET retention_state = ?2,
+                         is_current = ?3,
+                         first_seen_at = MIN(first_seen_at, ?4),
+                         last_seen_at = MAX(last_seen_at, ?5)
                      WHERE edge_key = ?1",
                     params![
                         edge.edge_key,
                         retention_state_key(edge.retention_state),
                         bool_int(edge.is_current),
+                        edge.first_seen_at.to_rfc3339(),
                         edge.last_seen_at.to_rfc3339()
                     ],
                 )
@@ -499,6 +503,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sqlite_store_merges_duplicate_edge_timestamps_monotonically() {
+        let dir = tempdir().unwrap();
+        let store = SqliteRetrievalStatsStore::open(dir.path().join("stats.sqlite3")).unwrap();
+        let entity_id = id("550e8400-e29b-41d4-a716-446655461031");
+        let episode_id = id("550e8400-e29b-41d4-a716-446655461032");
+        let mut later_edge = test_edge(entity_id, episode_id, RetentionState::Active, true);
+        later_edge.first_seen_at = timestamp_at("2026-04-28T12:00:00Z");
+        later_edge.last_seen_at = timestamp_at("2026-04-28T13:00:00Z");
+        let mut earlier_edge = later_edge.clone();
+        earlier_edge.first_seen_at = timestamp_at("2026-04-28T11:00:00Z");
+        earlier_edge.last_seen_at = timestamp_at("2026-04-28T12:30:00Z");
+
+        store.record_edges(&[later_edge]).await.unwrap();
+        store.record_edges(&[earlier_edge]).await.unwrap();
+
+        let connection = lock(&store.connection).unwrap();
+        let (first_seen_at, last_seen_at): (String, String) = connection
+            .query_row(
+                "SELECT first_seen_at, last_seen_at
+                 FROM entity_edge_index
+                 WHERE edge_key = ?1",
+                params![format!("{}:involves:episode:{}", entity_id, episode_id)],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(first_seen_at, "2026-04-28T11:00:00+00:00");
+        assert_eq!(last_seen_at, "2026-04-28T13:00:00+00:00");
+    }
+
+    #[tokio::test]
     async fn sqlite_store_persists_counters_across_reopen() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("stats.sqlite3");
@@ -613,7 +647,11 @@ mod tests {
     }
 
     fn timestamp() -> DateTime<Utc> {
-        DateTime::parse_from_rfc3339("2026-04-28T12:00:00Z")
+        timestamp_at("2026-04-28T12:00:00Z")
+    }
+
+    fn timestamp_at(value: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(value)
             .unwrap()
             .with_timezone(&Utc)
     }

--- a/src/internal/infrastructures/retrieval_stats.rs
+++ b/src/internal/infrastructures/retrieval_stats.rs
@@ -107,14 +107,16 @@ impl RetrievalStatsStore for SqliteRetrievalStatsStore {
     }
 
     async fn mark_unhealthy(&self, message: String) -> Result<(), CustomError> {
-        let connection = lock(&self.connection)?;
+        let mut connection = lock(&self.connection)?;
+        let transaction = connection.transaction().map_err(sqlite_error)?;
         set_health(
-            &connection,
+            &transaction,
             RetrievalStatsHealth {
                 state: RetrievalStatsHealthState::Unhealthy,
                 last_error_message: Some(message),
             },
-        )
+        )?;
+        transaction.commit().map_err(sqlite_error)
     }
 }
 
@@ -282,7 +284,9 @@ fn update_object_state(
         connection
             .execute(
                 "UPDATE entity_edge_index
-                 SET retention_state = ?2, is_current = ?3, last_seen_at = ?4
+                 SET retention_state = ?2,
+                     is_current = ?3,
+                     last_seen_at = MAX(last_seen_at, ?4)
                  WHERE edge_key = ?1",
                 params![
                     edge_key,
@@ -621,6 +625,41 @@ mod tests {
         assert_eq!(counter.total_count, 1);
         assert_eq!(counter.active_count, 0);
         assert_eq!(counter.current_count, 0);
+    }
+
+    #[tokio::test]
+    async fn sqlite_object_state_updates_do_not_regress_last_seen_at() {
+        let dir = tempdir().unwrap();
+        let store = SqliteRetrievalStatsStore::open(dir.path().join("stats.sqlite3")).unwrap();
+        let entity_id = id("550e8400-e29b-41d4-a716-446655461041");
+        let episode_id = id("550e8400-e29b-41d4-a716-446655461042");
+        let mut edge = test_edge(entity_id, episode_id, RetentionState::Active, true);
+        edge.first_seen_at = timestamp_at("2026-04-28T13:00:00Z");
+        edge.last_seen_at = timestamp_at("2026-04-28T13:00:00Z");
+        store.record_edges(&[edge]).await.unwrap();
+
+        store
+            .record_object_states(&[RetrievalStatsObjectState {
+                object_id: episode_id,
+                object_type: ObjectType::Episode,
+                retention_state: RetentionState::Suppressed,
+                is_current: false,
+                observed_at: timestamp_at("2026-04-28T11:00:00Z"),
+            }])
+            .await
+            .unwrap();
+
+        let connection = lock(&store.connection).unwrap();
+        let last_seen_at: String = connection
+            .query_row(
+                "SELECT last_seen_at
+                 FROM entity_edge_index
+                 WHERE edge_key = ?1",
+                params![format!("{}:involves:episode:{}", entity_id, episode_id)],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(last_seen_at, "2026-04-28T13:00:00+00:00");
     }
 
     fn test_edge(

--- a/src/internal/infrastructures/retrieval_stats.rs
+++ b/src/internal/infrastructures/retrieval_stats.rs
@@ -163,7 +163,14 @@ fn initialize_schema(connection: &Connection) -> Result<(), CustomError> {
             ",
         )
         .map_err(sqlite_error)?;
-    set_health(connection, RetrievalStatsHealth::default())
+    initialize_health_metadata(connection)
+}
+
+fn initialize_health_metadata(connection: &Connection) -> Result<(), CustomError> {
+    if meta_value(connection, "health_state")?.is_none() {
+        set_health(connection, RetrievalStatsHealth::default())?;
+    }
+    Ok(())
 }
 
 fn upsert_edge(connection: &Connection, edge: &RetrievalStatsEdge) -> Result<(), CustomError> {
@@ -523,6 +530,28 @@ mod tests {
         assert_eq!(
             reopened.health().await.unwrap(),
             RetrievalStatsHealth::default()
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_store_preserves_unhealthy_marker_across_reopen() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("stats.sqlite3");
+
+        {
+            let store = SqliteRetrievalStatsStore::open(&path).unwrap();
+            store
+                .mark_unhealthy("transient stats failure".to_owned())
+                .await
+                .unwrap();
+        }
+
+        let reopened = SqliteRetrievalStatsStore::open(&path).unwrap();
+        let health = reopened.health().await.unwrap();
+        assert_eq!(health.state, RetrievalStatsHealthState::Unhealthy);
+        assert_eq!(
+            health.last_error_message.as_deref(),
+            Some("transient stats failure")
         );
     }
 

--- a/src/internal/infrastructures/retrieval_stats.rs
+++ b/src/internal/infrastructures/retrieval_stats.rs
@@ -1,0 +1,540 @@
+use std::fs;
+use std::path::Path;
+use std::sync::{Mutex, MutexGuard};
+
+use async_trait::async_trait;
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::api::types::RetentionState;
+use crate::errors::CustomError;
+use crate::internal::repositories::{
+    object_type_key, relation_type_key, retention_state_key, RetrievalStatsCounter,
+    RetrievalStatsCounterKey, RetrievalStatsEdge, RetrievalStatsHealth, RetrievalStatsHealthState,
+    RetrievalStatsObjectState, RetrievalStatsStore,
+};
+
+#[derive(Debug)]
+pub(crate) struct SqliteRetrievalStatsStore {
+    connection: Mutex<Connection>,
+}
+
+impl SqliteRetrievalStatsStore {
+    pub(crate) fn open(path: impl AsRef<Path>) -> Result<Self, CustomError> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent).map_err(|error| {
+                    CustomError::DatabaseError(format!(
+                        "failed to create retrieval stats directory {}: {error}",
+                        parent.display()
+                    ))
+                })?;
+            }
+        }
+        let connection = Connection::open(path).map_err(sqlite_error)?;
+        initialize_schema(&connection)?;
+        Ok(Self {
+            connection: Mutex::new(connection),
+        })
+    }
+}
+
+#[async_trait]
+impl RetrievalStatsStore for SqliteRetrievalStatsStore {
+    async fn record_edges(&self, edges: &[RetrievalStatsEdge]) -> Result<(), CustomError> {
+        let mut connection = lock(&self.connection)?;
+        let transaction = connection.transaction().map_err(sqlite_error)?;
+        for edge in edges {
+            upsert_edge(&transaction, edge)?;
+        }
+        set_health(&transaction, RetrievalStatsHealth::default())?;
+        transaction.commit().map_err(sqlite_error)
+    }
+
+    async fn record_object_states(
+        &self,
+        states: &[RetrievalStatsObjectState],
+    ) -> Result<(), CustomError> {
+        let mut connection = lock(&self.connection)?;
+        let transaction = connection.transaction().map_err(sqlite_error)?;
+        for state in states {
+            update_object_state(&transaction, state)?;
+        }
+        set_health(&transaction, RetrievalStatsHealth::default())?;
+        transaction.commit().map_err(sqlite_error)
+    }
+
+    async fn counter(
+        &self,
+        key: &RetrievalStatsCounterKey,
+    ) -> Result<Option<RetrievalStatsCounter>, CustomError> {
+        let connection = lock(&self.connection)?;
+        connection
+            .query_row(
+                "SELECT total_count, active_count, current_count
+                 FROM entity_relation_counts
+                 WHERE entity_id = ?1 AND relation_kind = ?2 AND object_type = ?3",
+                params![
+                    key.entity_id.to_string(),
+                    relation_type_key(key.relation_kind),
+                    object_type_key(key.object_type)
+                ],
+                |row| {
+                    Ok(RetrievalStatsCounter {
+                        total_count: row.get::<_, i64>(0)? as u64,
+                        active_count: row.get::<_, i64>(1)? as u64,
+                        current_count: row.get::<_, i64>(2)? as u64,
+                    })
+                },
+            )
+            .optional()
+            .map_err(sqlite_error)
+    }
+
+    async fn health(&self) -> Result<RetrievalStatsHealth, CustomError> {
+        let connection = lock(&self.connection)?;
+        let state =
+            meta_value(&connection, "health_state")?.unwrap_or_else(|| "healthy".to_owned());
+        let last_error_message = meta_value(&connection, "last_error_message")?;
+        Ok(RetrievalStatsHealth {
+            state: if state == "unhealthy" {
+                RetrievalStatsHealthState::Unhealthy
+            } else {
+                RetrievalStatsHealthState::Healthy
+            },
+            last_error_message,
+        })
+    }
+
+    async fn mark_unhealthy(&self, message: String) -> Result<(), CustomError> {
+        let connection = lock(&self.connection)?;
+        set_health(
+            &connection,
+            RetrievalStatsHealth {
+                state: RetrievalStatsHealthState::Unhealthy,
+                last_error_message: Some(message),
+            },
+        )
+    }
+}
+
+fn initialize_schema(connection: &Connection) -> Result<(), CustomError> {
+    connection
+        .execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS entity_edge_index (
+                edge_key TEXT PRIMARY KEY,
+                entity_id TEXT NOT NULL,
+                relation_kind TEXT NOT NULL,
+                object_id TEXT NOT NULL,
+                object_type TEXT NOT NULL,
+                retention_state TEXT NOT NULL,
+                is_current INTEGER NOT NULL,
+                first_seen_at TEXT NOT NULL,
+                last_seen_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS entity_relation_counts (
+                entity_id TEXT NOT NULL,
+                relation_kind TEXT NOT NULL,
+                object_type TEXT NOT NULL,
+                total_count INTEGER NOT NULL DEFAULT 0,
+                active_count INTEGER NOT NULL DEFAULT 0,
+                current_count INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (entity_id, relation_kind, object_type)
+            );
+
+            CREATE TABLE IF NOT EXISTS global_relation_counts (
+                relation_kind TEXT NOT NULL,
+                object_type TEXT NOT NULL,
+                total_count INTEGER NOT NULL DEFAULT 0,
+                active_count INTEGER NOT NULL DEFAULT 0,
+                current_count INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (relation_kind, object_type)
+            );
+
+            CREATE TABLE IF NOT EXISTS stats_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            ",
+        )
+        .map_err(sqlite_error)?;
+    set_health(connection, RetrievalStatsHealth::default())
+}
+
+fn upsert_edge(connection: &Connection, edge: &RetrievalStatsEdge) -> Result<(), CustomError> {
+    let existing = connection
+        .query_row(
+            "SELECT retention_state, is_current FROM entity_edge_index WHERE edge_key = ?1",
+            params![edge.edge_key],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? != 0)),
+        )
+        .optional()
+        .map_err(sqlite_error)?;
+
+    match existing {
+        Some((old_retention, old_is_current)) => {
+            let old_active = old_retention == "active";
+            let new_active = edge.is_active();
+            let active_delta = bool_delta(old_active, new_active);
+            let current_delta =
+                bool_delta(old_active && old_is_current, new_active && edge.is_current);
+            connection
+                .execute(
+                    "UPDATE entity_edge_index
+                     SET retention_state = ?2, is_current = ?3, last_seen_at = ?4
+                     WHERE edge_key = ?1",
+                    params![
+                        edge.edge_key,
+                        retention_state_key(edge.retention_state),
+                        bool_int(edge.is_current),
+                        edge.last_seen_at.to_rfc3339()
+                    ],
+                )
+                .map_err(sqlite_error)?;
+            apply_count_delta(connection, edge, 0, active_delta, current_delta)
+        }
+        None => {
+            connection
+                .execute(
+                    "INSERT INTO entity_edge_index
+                     (edge_key, entity_id, relation_kind, object_id, object_type,
+                      retention_state, is_current, first_seen_at, last_seen_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                    params![
+                        edge.edge_key,
+                        edge.entity_id.to_string(),
+                        relation_type_key(edge.relation_kind),
+                        edge.object_id.to_string(),
+                        object_type_key(edge.object_type),
+                        retention_state_key(edge.retention_state),
+                        bool_int(edge.is_current),
+                        edge.first_seen_at.to_rfc3339(),
+                        edge.last_seen_at.to_rfc3339()
+                    ],
+                )
+                .map_err(sqlite_error)?;
+            apply_count_delta(
+                connection,
+                edge,
+                1,
+                i64::from(edge.is_active()),
+                i64::from(edge.is_active() && edge.is_current),
+            )
+        }
+    }
+}
+
+fn update_object_state(
+    connection: &Connection,
+    state: &RetrievalStatsObjectState,
+) -> Result<(), CustomError> {
+    let mut statement = connection
+        .prepare(
+            "SELECT edge_key, entity_id, relation_kind, object_type, retention_state, is_current
+             FROM entity_edge_index
+             WHERE object_id = ?1 AND object_type = ?2",
+        )
+        .map_err(sqlite_error)?;
+    let rows = statement
+        .query_map(
+            params![
+                state.object_id.to_string(),
+                object_type_key(state.object_type)
+            ],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, i64>(5)? != 0,
+                ))
+            },
+        )
+        .map_err(sqlite_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_error)?;
+    drop(statement);
+
+    for (edge_key, entity_id, relation_kind, object_type, old_retention, old_is_current) in rows {
+        let old_active = old_retention == "active";
+        let new_active = state.retention_state == RetentionState::Active;
+        let active_delta = bool_delta(old_active, new_active);
+        let current_delta =
+            bool_delta(old_active && old_is_current, new_active && state.is_current);
+        connection
+            .execute(
+                "UPDATE entity_edge_index
+                 SET retention_state = ?2, is_current = ?3, last_seen_at = ?4
+                 WHERE edge_key = ?1",
+                params![
+                    edge_key,
+                    retention_state_key(state.retention_state),
+                    bool_int(state.is_current),
+                    state.observed_at.to_rfc3339()
+                ],
+            )
+            .map_err(sqlite_error)?;
+        apply_count_delta_by_names(
+            connection,
+            &entity_id,
+            &relation_kind,
+            &object_type,
+            0,
+            active_delta,
+            current_delta,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn apply_count_delta(
+    connection: &Connection,
+    edge: &RetrievalStatsEdge,
+    total_delta: i64,
+    active_delta: i64,
+    current_delta: i64,
+) -> Result<(), CustomError> {
+    apply_count_delta_by_names(
+        connection,
+        &edge.entity_id.to_string(),
+        relation_type_key(edge.relation_kind),
+        object_type_key(edge.object_type),
+        total_delta,
+        active_delta,
+        current_delta,
+    )
+}
+
+fn apply_count_delta_by_names(
+    connection: &Connection,
+    entity_id: &str,
+    relation_kind: &str,
+    object_type: &str,
+    total_delta: i64,
+    active_delta: i64,
+    current_delta: i64,
+) -> Result<(), CustomError> {
+    connection
+        .execute(
+            "INSERT INTO entity_relation_counts
+             (entity_id, relation_kind, object_type, total_count, active_count, current_count)
+             VALUES (?1, ?2, ?3, 0, 0, 0)
+             ON CONFLICT(entity_id, relation_kind, object_type) DO NOTHING",
+            params![entity_id, relation_kind, object_type],
+        )
+        .map_err(sqlite_error)?;
+    connection
+        .execute(
+            "UPDATE entity_relation_counts
+             SET total_count = total_count + ?4,
+                 active_count = active_count + ?5,
+                 current_count = current_count + ?6
+             WHERE entity_id = ?1 AND relation_kind = ?2 AND object_type = ?3",
+            params![
+                entity_id,
+                relation_kind,
+                object_type,
+                total_delta,
+                active_delta,
+                current_delta
+            ],
+        )
+        .map_err(sqlite_error)?;
+
+    connection
+        .execute(
+            "INSERT INTO global_relation_counts
+             (relation_kind, object_type, total_count, active_count, current_count)
+             VALUES (?1, ?2, 0, 0, 0)
+             ON CONFLICT(relation_kind, object_type) DO NOTHING",
+            params![relation_kind, object_type],
+        )
+        .map_err(sqlite_error)?;
+    connection
+        .execute(
+            "UPDATE global_relation_counts
+             SET total_count = total_count + ?3,
+                 active_count = active_count + ?4,
+                 current_count = current_count + ?5
+             WHERE relation_kind = ?1 AND object_type = ?2",
+            params![
+                relation_kind,
+                object_type,
+                total_delta,
+                active_delta,
+                current_delta
+            ],
+        )
+        .map_err(sqlite_error)?;
+    Ok(())
+}
+
+fn set_health(connection: &Connection, health: RetrievalStatsHealth) -> Result<(), CustomError> {
+    let state = match health.state {
+        RetrievalStatsHealthState::Healthy => "healthy",
+        RetrievalStatsHealthState::Unhealthy => "unhealthy",
+    };
+    set_meta_value(connection, "health_state", Some(state))?;
+    set_meta_value(
+        connection,
+        "last_error_message",
+        health.last_error_message.as_deref(),
+    )
+}
+
+fn set_meta_value(
+    connection: &Connection,
+    key: &str,
+    value: Option<&str>,
+) -> Result<(), CustomError> {
+    connection
+        .execute(
+            "INSERT INTO stats_meta (key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![key, value],
+        )
+        .map_err(sqlite_error)?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn meta_value(connection: &Connection, key: &str) -> Result<Option<String>, CustomError> {
+    connection
+        .query_row(
+            "SELECT value FROM stats_meta WHERE key = ?1",
+            params![key],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(sqlite_error)
+}
+
+fn bool_delta(old: bool, new: bool) -> i64 {
+    match (old, new) {
+        (false, true) => 1,
+        (true, false) => -1,
+        _ => 0,
+    }
+}
+
+fn bool_int(value: bool) -> i64 {
+    i64::from(value)
+}
+
+fn sqlite_error(error: rusqlite::Error) -> CustomError {
+    CustomError::DatabaseError(format!("retrieval stats sqlite error: {error}"))
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, CustomError> {
+    mutex.lock().map_err(|_| {
+        CustomError::DatabaseError("retrieval stats sqlite mutex was poisoned".to_owned())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+    use tempfile::tempdir;
+
+    use crate::api::types::{MemoryId, ObjectType, RelationType};
+
+    #[tokio::test]
+    async fn sqlite_store_persists_idempotent_counters() {
+        let dir = tempdir().unwrap();
+        let store = SqliteRetrievalStatsStore::open(dir.path().join("stats.sqlite3")).unwrap();
+        let entity_id = id("550e8400-e29b-41d4-a716-446655461001");
+        let episode_id = id("550e8400-e29b-41d4-a716-446655461002");
+        let edge = test_edge(entity_id, episode_id, RetentionState::Active, true);
+
+        store
+            .record_edges(std::slice::from_ref(&edge))
+            .await
+            .unwrap();
+        store
+            .record_edges(std::slice::from_ref(&edge))
+            .await
+            .unwrap();
+
+        let counter = store
+            .counter(&RetrievalStatsCounterKey {
+                entity_id,
+                relation_kind: RelationType::Involves,
+                object_type: ObjectType::Episode,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(counter.total_count, 1);
+        assert_eq!(counter.active_count, 1);
+        assert_eq!(counter.current_count, 1);
+    }
+
+    #[tokio::test]
+    async fn sqlite_store_updates_lifecycle_counts() {
+        let dir = tempdir().unwrap();
+        let store = SqliteRetrievalStatsStore::open(dir.path().join("stats.sqlite3")).unwrap();
+        let entity_id = id("550e8400-e29b-41d4-a716-446655461011");
+        let episode_id = id("550e8400-e29b-41d4-a716-446655461012");
+        let edge = test_edge(entity_id, episode_id, RetentionState::Active, true);
+        store.record_edges(&[edge]).await.unwrap();
+
+        store
+            .record_object_states(&[RetrievalStatsObjectState {
+                object_id: episode_id,
+                object_type: ObjectType::Episode,
+                retention_state: RetentionState::Suppressed,
+                is_current: true,
+                observed_at: timestamp(),
+            }])
+            .await
+            .unwrap();
+
+        let counter = store
+            .counter(&RetrievalStatsCounterKey {
+                entity_id,
+                relation_kind: RelationType::Involves,
+                object_type: ObjectType::Episode,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(counter.total_count, 1);
+        assert_eq!(counter.active_count, 0);
+        assert_eq!(counter.current_count, 0);
+    }
+
+    fn test_edge(
+        entity_id: MemoryId,
+        object_id: MemoryId,
+        retention_state: RetentionState,
+        is_current: bool,
+    ) -> RetrievalStatsEdge {
+        RetrievalStatsEdge {
+            edge_key: format!("{}:involves:episode:{}", entity_id, object_id),
+            entity_id,
+            relation_kind: RelationType::Involves,
+            object_id,
+            object_type: ObjectType::Episode,
+            retention_state,
+            is_current,
+            first_seen_at: timestamp(),
+            last_seen_at: timestamp(),
+        }
+    }
+
+    fn id(value: &str) -> MemoryId {
+        uuid::Uuid::parse_str(value).unwrap()
+    }
+
+    fn timestamp() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-04-28T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+}

--- a/src/internal/infrastructures/retrieval_stats.rs
+++ b/src/internal/infrastructures/retrieval_stats.rs
@@ -188,10 +188,15 @@ fn upsert_edge(connection: &Connection, edge: &RetrievalStatsEdge) -> Result<(),
     match existing {
         Some((old_retention, old_is_current)) => {
             let old_active = old_retention == "active";
-            let new_active = edge.is_active();
+            let merged_retention =
+                more_restrictive_retention_key(&old_retention, edge.retention_state);
+            let merged_is_current = old_is_current && edge.is_current;
+            let new_active = merged_retention == RetentionState::Active;
             let active_delta = bool_delta(old_active, new_active);
-            let current_delta =
-                bool_delta(old_active && old_is_current, new_active && edge.is_current);
+            let current_delta = bool_delta(
+                old_active && old_is_current,
+                new_active && merged_is_current,
+            );
             connection
                 .execute(
                     "UPDATE entity_edge_index
@@ -202,8 +207,8 @@ fn upsert_edge(connection: &Connection, edge: &RetrievalStatsEdge) -> Result<(),
                      WHERE edge_key = ?1",
                     params![
                         edge.edge_key,
-                        retention_state_key(edge.retention_state),
-                        bool_int(edge.is_current),
+                        retention_state_key(merged_retention),
+                        bool_int(merged_is_current),
                         edge.first_seen_at.to_rfc3339(),
                         edge.last_seen_at.to_rfc3339()
                     ],
@@ -441,6 +446,36 @@ fn bool_delta(old: bool, new: bool) -> i64 {
     }
 }
 
+fn more_restrictive_retention_key(existing: &str, incoming: RetentionState) -> RetentionState {
+    if retention_rank(incoming) > retention_key_rank(existing) {
+        incoming
+    } else {
+        retention_from_key(existing)
+    }
+}
+
+fn retention_from_key(value: &str) -> RetentionState {
+    match value {
+        "suppressed" => RetentionState::Suppressed,
+        "archived" => RetentionState::Archived,
+        "deleted" => RetentionState::Deleted,
+        _ => RetentionState::Active,
+    }
+}
+
+fn retention_key_rank(value: &str) -> u8 {
+    retention_rank(retention_from_key(value))
+}
+
+fn retention_rank(retention_state: RetentionState) -> u8 {
+    match retention_state {
+        RetentionState::Active => 0,
+        RetentionState::Archived => 1,
+        RetentionState::Suppressed => 2,
+        RetentionState::Deleted => 3,
+    }
+}
+
 fn bool_int(value: bool) -> i64 {
     i64::from(value)
 }
@@ -534,6 +569,45 @@ mod tests {
             .unwrap();
         assert_eq!(first_seen_at, "2026-04-28T11:00:00+00:00");
         assert_eq!(last_seen_at, "2026-04-28T13:00:00+00:00");
+    }
+
+    #[tokio::test]
+    async fn sqlite_store_keeps_restrictive_lifecycle_on_incomplete_edge_update() {
+        let dir = tempdir().unwrap();
+        let store = SqliteRetrievalStatsStore::open(dir.path().join("stats.sqlite3")).unwrap();
+        let entity_id = id("550e8400-e29b-41d4-a716-446655461041");
+        let episode_id = id("550e8400-e29b-41d4-a716-446655461042");
+        let suppressed_edge = test_edge(entity_id, episode_id, RetentionState::Suppressed, false);
+        let active_edge = test_edge(entity_id, episode_id, RetentionState::Active, true);
+
+        store.record_edges(&[suppressed_edge]).await.unwrap();
+        store.record_edges(&[active_edge]).await.unwrap();
+
+        let counter = store
+            .counter(&RetrievalStatsCounterKey {
+                entity_id,
+                relation_kind: RelationType::Involves,
+                object_type: ObjectType::Episode,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(counter.total_count, 1);
+        assert_eq!(counter.active_count, 0);
+        assert_eq!(counter.current_count, 0);
+
+        let connection = lock(&store.connection).unwrap();
+        let (retention_state, is_current): (String, i64) = connection
+            .query_row(
+                "SELECT retention_state, is_current
+                 FROM entity_edge_index
+                 WHERE edge_key = ?1",
+                params![format!("{}:involves:episode:{}", entity_id, episode_id)],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(retention_state, "suppressed");
+        assert_eq!(is_current, 0);
     }
 
     #[tokio::test]

--- a/src/internal/infrastructures/retrieval_stats.rs
+++ b/src/internal/infrastructures/retrieval_stats.rs
@@ -79,9 +79,9 @@ impl RetrievalStatsStore for SqliteRetrievalStatsStore {
                 ],
                 |row| {
                     Ok(RetrievalStatsCounter {
-                        total_count: non_negative_count(row.get(0)?)?,
-                        active_count: non_negative_count(row.get(1)?)?,
-                        current_count: non_negative_count(row.get(2)?)?,
+                        total_count: non_negative_count(0, row.get(0)?)?,
+                        active_count: non_negative_count(1, row.get(1)?)?,
+                        current_count: non_negative_count(2, row.get(2)?)?,
                     })
                 },
             )
@@ -106,9 +106,9 @@ impl RetrievalStatsStore for SqliteRetrievalStatsStore {
                 ],
                 |row| {
                     Ok(RetrievalStatsCounter {
-                        total_count: non_negative_count(row.get(0)?)?,
-                        active_count: non_negative_count(row.get(1)?)?,
-                        current_count: non_negative_count(row.get(2)?)?,
+                        total_count: non_negative_count(0, row.get(0)?)?,
+                        active_count: non_negative_count(1, row.get(1)?)?,
+                        current_count: non_negative_count(2, row.get(2)?)?,
                     })
                 },
             )
@@ -509,10 +509,10 @@ fn sqlite_error(error: rusqlite::Error) -> CustomError {
     CustomError::DatabaseError(format!("retrieval stats sqlite error: {error}"))
 }
 
-fn non_negative_count(value: i64) -> rusqlite::Result<u64> {
+fn non_negative_count(column_index: usize, value: i64) -> rusqlite::Result<u64> {
     u64::try_from(value).map_err(|_| {
         rusqlite::Error::FromSqlConversionFailure(
-            0,
+            column_index,
             rusqlite::types::Type::Integer,
             Box::new(CustomError::DatabaseError(format!(
                 "retrieval stats counter was negative: {value}"

--- a/src/internal/infrastructures/retrieval_stats.rs
+++ b/src/internal/infrastructures/retrieval_stats.rs
@@ -81,9 +81,9 @@ impl RetrievalStatsStore for SqliteRetrievalStatsStore {
                 ],
                 |row| {
                     Ok(RetrievalStatsCounter {
-                        total_count: row.get::<_, i64>(0)? as u64,
-                        active_count: row.get::<_, i64>(1)? as u64,
-                        current_count: row.get::<_, i64>(2)? as u64,
+                        total_count: non_negative_count(row.get(0)?)?,
+                        active_count: non_negative_count(row.get(1)?)?,
+                        current_count: non_negative_count(row.get(2)?)?,
                     })
                 },
             )
@@ -133,6 +133,9 @@ fn initialize_schema(connection: &Connection) -> Result<(), CustomError> {
                 first_seen_at TEXT NOT NULL,
                 last_seen_at TEXT NOT NULL
             );
+
+            CREATE INDEX IF NOT EXISTS entity_edge_index_object
+            ON entity_edge_index(object_id, object_type);
 
             CREATE TABLE IF NOT EXISTS entity_relation_counts (
                 entity_id TEXT NOT NULL,
@@ -408,9 +411,10 @@ fn meta_value(connection: &Connection, key: &str) -> Result<Option<String>, Cust
         .query_row(
             "SELECT value FROM stats_meta WHERE key = ?1",
             params![key],
-            |row| row.get(0),
+            |row| row.get::<_, Option<String>>(0),
         )
         .optional()
+        .map(|value| value.flatten())
         .map_err(sqlite_error)
 }
 
@@ -428,6 +432,18 @@ fn bool_int(value: bool) -> i64 {
 
 fn sqlite_error(error: rusqlite::Error) -> CustomError {
     CustomError::DatabaseError(format!("retrieval stats sqlite error: {error}"))
+}
+
+fn non_negative_count(value: i64) -> rusqlite::Result<u64> {
+    u64::try_from(value).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Integer,
+            Box::new(CustomError::DatabaseError(format!(
+                "retrieval stats counter was negative: {value}"
+            ))),
+        )
+    })
 }
 
 fn lock<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, CustomError> {
@@ -473,6 +489,41 @@ mod tests {
         assert_eq!(counter.total_count, 1);
         assert_eq!(counter.active_count, 1);
         assert_eq!(counter.current_count, 1);
+    }
+
+    #[tokio::test]
+    async fn sqlite_store_persists_counters_across_reopen() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("stats.sqlite3");
+        let entity_id = id("550e8400-e29b-41d4-a716-446655461021");
+        let episode_id = id("550e8400-e29b-41d4-a716-446655461022");
+        let edge = test_edge(entity_id, episode_id, RetentionState::Active, true);
+
+        {
+            let store = SqliteRetrievalStatsStore::open(&path).unwrap();
+            store
+                .record_edges(std::slice::from_ref(&edge))
+                .await
+                .unwrap();
+        }
+
+        let reopened = SqliteRetrievalStatsStore::open(&path).unwrap();
+        let counter = reopened
+            .counter(&RetrievalStatsCounterKey {
+                entity_id,
+                relation_kind: RelationType::Involves,
+                object_type: ObjectType::Episode,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(counter.total_count, 1);
+        assert_eq!(counter.active_count, 1);
+        assert_eq!(counter.current_count, 1);
+        assert_eq!(
+            reopened.health().await.unwrap(),
+            RetrievalStatsHealth::default()
+        );
     }
 
     #[tokio::test]

--- a/src/internal/repositories.rs
+++ b/src/internal/repositories.rs
@@ -61,9 +61,8 @@ pub(crate) use retrieval_stats_store::noop_retrieval_stats_store;
 pub(crate) use retrieval_stats_store::{
     object_type_key, record_stats_after_write, relation_type_key, retention_state_key,
     retrieval_stats_edges, retrieval_stats_object_states, InMemoryRetrievalStatsStore,
-    NoopRetrievalStatsStore, RetrievalStatsCounter, RetrievalStatsCounterKey, RetrievalStatsEdge,
-    RetrievalStatsHealth, RetrievalStatsHealthState, RetrievalStatsObjectState,
-    RetrievalStatsStore,
+    RetrievalStatsCounter, RetrievalStatsCounterKey, RetrievalStatsEdge, RetrievalStatsHealth,
+    RetrievalStatsHealthState, RetrievalStatsObjectState, RetrievalStatsStore,
 };
 
 // Continuity retrieval pipeline surface.

--- a/src/internal/repositories.rs
+++ b/src/internal/repositories.rs
@@ -5,6 +5,7 @@ mod link_pipeline;
 mod raw_reference_resolver;
 mod reconciliation;
 mod remember_pipeline;
+mod retrieval_stats_store;
 mod retrieve_pipeline;
 #[cfg(test)]
 pub(crate) mod test_support;
@@ -52,6 +53,17 @@ pub(crate) use reconciliation::{
 pub(crate) use remember_pipeline::{
     RememberPipeline, RememberPipelineDraft, RememberPipelineOutcome,
     VectorIndexingFailure as InternalVectorIndexingFailure,
+};
+
+#[cfg(test)]
+pub(crate) use retrieval_stats_store::noop_retrieval_stats_store;
+#[allow(unused_imports)]
+pub(crate) use retrieval_stats_store::{
+    object_type_key, record_stats_after_write, relation_type_key, retention_state_key,
+    retrieval_stats_edges, retrieval_stats_object_states, InMemoryRetrievalStatsStore,
+    NoopRetrievalStatsStore, RetrievalStatsCounter, RetrievalStatsCounterKey, RetrievalStatsEdge,
+    RetrievalStatsHealth, RetrievalStatsHealthState, RetrievalStatsObjectState,
+    RetrievalStatsStore,
 };
 
 // Continuity retrieval pipeline surface.

--- a/src/internal/repositories/correction_forget_pipeline.rs
+++ b/src/internal/repositories/correction_forget_pipeline.rs
@@ -16,9 +16,9 @@ use crate::internal::models::vector::{
     memory_object_vector_record, VectorRecord, VectorRecordEmbedding,
 };
 use crate::internal::repositories::{
-    GraphAuthorityStore, GraphDerivedMemoryProvenanceQuery, GraphDerivedMemoryThreadQuery,
-    GraphExpansionLifecyclePolicy, GraphObjectQuery, GraphObjectRef, MemoryEmbedder,
-    VectorCandidateStore,
+    record_stats_after_write, GraphAuthorityStore, GraphDerivedMemoryProvenanceQuery,
+    GraphDerivedMemoryThreadQuery, GraphExpansionLifecyclePolicy, GraphObjectQuery, GraphObjectRef,
+    MemoryEmbedder, RetrievalStatsStore, VectorCandidateStore,
 };
 
 pub(crate) struct CorrectionForgetPipeline<'a, G, V, E>
@@ -30,6 +30,7 @@ where
     graph_store: &'a G,
     vector_store: &'a V,
     embedder: &'a E,
+    stats_store: &'a dyn RetrievalStatsStore,
 }
 
 impl<'a, G, V, E> CorrectionForgetPipeline<'a, G, V, E>
@@ -38,11 +39,27 @@ where
     V: VectorCandidateStore + ?Sized,
     E: MemoryEmbedder + ?Sized,
 {
+    #[cfg(test)]
     pub(crate) fn new(graph_store: &'a G, vector_store: &'a V, embedder: &'a E) -> Self {
         Self {
             graph_store,
             vector_store,
             embedder,
+            stats_store: crate::internal::repositories::noop_retrieval_stats_store(),
+        }
+    }
+
+    pub(crate) fn new_with_stats(
+        graph_store: &'a G,
+        vector_store: &'a V,
+        embedder: &'a E,
+        stats_store: &'a dyn RetrievalStatsStore,
+    ) -> Self {
+        Self {
+            graph_store,
+            vector_store,
+            embedder,
+            stats_store,
         }
     }
 
@@ -62,6 +79,7 @@ where
             .maintain_vectors(&plan.vector_delete_refs, &plan.vector_upsert_objects)
             .await;
         apply_vector_result(&mut outcome, vector_result);
+        record_stats_after_write(self.stats_store, &plan.graph_objects, &plan.graph_links).await;
         Ok(outcome)
     }
 
@@ -77,6 +95,7 @@ where
         let mut outcome = plan.outcome_after_graph_success();
         let vector_result = self.maintain_vectors(&plan.vector_delete_refs, &[]).await;
         apply_vector_result(&mut outcome, vector_result);
+        record_stats_after_write(self.stats_store, &plan.graph_objects, &plan.graph_links).await;
         Ok(outcome)
     }
 

--- a/src/internal/repositories/correction_forget_pipeline.rs
+++ b/src/internal/repositories/correction_forget_pipeline.rs
@@ -1133,7 +1133,10 @@ mod tests {
         representative_fixtures, DeterministicMemoryEmbedder, FakeGraphAuthorityStore,
         FakeVectorCandidateStore,
     };
-    use crate::internal::repositories::{GraphExpansion, GraphExpansionQuery, RetrievePipeline};
+    use crate::internal::repositories::{
+        GraphExpansion, GraphExpansionQuery, RetrievalStatsCounter, RetrievalStatsCounterKey,
+        RetrievalStatsEdge, RetrievalStatsHealth, RetrievalStatsObjectState, RetrievePipeline,
+    };
 
     #[tokio::test]
     async fn correction_writes_graph_before_vector_maintenance_in_stable_order() {
@@ -1182,6 +1185,92 @@ mod tests {
             ]
         );
         assert!(outcome.vector_maintenance_failure.is_none());
+    }
+
+    #[tokio::test]
+    async fn correction_stats_failure_runs_after_vector_and_preserves_outcome() {
+        let ids = fixed_ids();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let graph = RecordingGraphStore {
+            objects: Mutex::new(vec![MemoryObject::DerivedMemory(old_memory(&ids))]),
+            calls: calls.clone(),
+            ..RecordingGraphStore::default()
+        };
+        let vector = RecordingVectorStore {
+            calls: calls.clone(),
+            fail_delete: false,
+        };
+        let embedder = RecordingEmbedder {
+            calls: calls.clone(),
+        };
+        let stats = RecordingStatsStore {
+            calls: calls.clone(),
+            fail_edges: true,
+        };
+        let pipeline = CorrectionForgetPipeline::new_with_stats(&graph, &vector, &embedder, &stats);
+
+        let outcome = pipeline
+            .correct(correction_draft(&ids))
+            .await
+            .expect("stats failure should not change lifecycle outcome");
+
+        assert!(outcome.vector_maintenance_failure.is_none());
+        assert_eq!(
+            lock(&calls).clone(),
+            vec![
+                StoreCall::GraphQuery(vec![ids.old]),
+                StoreCall::GraphObjects(vec![ids.old, ids.replacement]),
+                StoreCall::GraphLinks(vec![(ids.replacement, ids.old)]),
+                StoreCall::VectorDelete(vec![ids.old]),
+                StoreCall::EmbedBatch(vec![ids.replacement]),
+                StoreCall::VectorUpsert(vec![ids.replacement]),
+                StoreCall::StatsEdges(0),
+                StoreCall::StatsUnhealthy,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn forget_records_stats_after_vector_maintenance() {
+        let ids = fixed_ids();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let graph = RecordingGraphStore {
+            objects: Mutex::new(vec![MemoryObject::DerivedMemory(old_memory(&ids))]),
+            calls: calls.clone(),
+            ..RecordingGraphStore::default()
+        };
+        let vector = RecordingVectorStore {
+            calls: calls.clone(),
+            fail_delete: false,
+        };
+        let embedder = RecordingEmbedder {
+            calls: calls.clone(),
+        };
+        let stats = RecordingStatsStore {
+            calls: calls.clone(),
+            fail_edges: false,
+        };
+        let pipeline = CorrectionForgetPipeline::new_with_stats(&graph, &vector, &embedder, &stats);
+
+        let outcome = pipeline
+            .forget(ForgetMemoryDraft::suppress(
+                LifecycleTargetRef::DerivedMemory(ids.old),
+                "Suppress stale derived memory.",
+            ))
+            .await
+            .expect("forget should record stats after vector maintenance");
+
+        assert!(outcome.vector_maintenance_failure.is_none());
+        assert_eq!(
+            lock(&calls).clone(),
+            vec![
+                StoreCall::GraphQuery(vec![ids.old]),
+                StoreCall::GraphObjects(vec![ids.old]),
+                StoreCall::VectorDelete(vec![ids.old]),
+                StoreCall::StatsEdges(0),
+                StoreCall::StatsObjectStates(1),
+            ]
+        );
     }
 
     #[tokio::test]
@@ -2157,6 +2246,9 @@ mod tests {
         EmbedBatch(Vec<MemoryId>),
         VectorUpsert(Vec<MemoryId>),
         VectorDelete(Vec<MemoryId>),
+        StatsEdges(usize),
+        StatsObjectStates(usize),
+        StatsUnhealthy,
     }
 
     #[derive(Debug, Default)]
@@ -2424,6 +2516,49 @@ mod tests {
                 inputs.iter().filter_map(|input| input.object_id).collect(),
             ));
             Ok(inputs.iter().map(|_| vec![1.0, 0.0, 0.0, 0.0]).collect())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingStatsStore {
+        calls: Arc<Mutex<Vec<StoreCall>>>,
+        fail_edges: bool,
+    }
+
+    #[async_trait]
+    impl RetrievalStatsStore for RecordingStatsStore {
+        async fn record_edges(&self, edges: &[RetrievalStatsEdge]) -> Result<(), CustomError> {
+            lock(&self.calls).push(StoreCall::StatsEdges(edges.len()));
+            if self.fail_edges {
+                return Err(CustomError::DatabaseError(
+                    "stats edge write failed".to_owned(),
+                ));
+            }
+            Ok(())
+        }
+
+        async fn record_object_states(
+            &self,
+            states: &[RetrievalStatsObjectState],
+        ) -> Result<(), CustomError> {
+            lock(&self.calls).push(StoreCall::StatsObjectStates(states.len()));
+            Ok(())
+        }
+
+        async fn counter(
+            &self,
+            _key: &RetrievalStatsCounterKey,
+        ) -> Result<Option<RetrievalStatsCounter>, CustomError> {
+            Ok(None)
+        }
+
+        async fn health(&self) -> Result<RetrievalStatsHealth, CustomError> {
+            Ok(RetrievalStatsHealth::default())
+        }
+
+        async fn mark_unhealthy(&self, _message: String) -> Result<(), CustomError> {
+            lock(&self.calls).push(StoreCall::StatsUnhealthy);
+            Ok(())
         }
     }
 

--- a/src/internal/repositories/correction_forget_pipeline.rs
+++ b/src/internal/repositories/correction_forget_pipeline.rs
@@ -2552,6 +2552,14 @@ mod tests {
             Ok(None)
         }
 
+        async fn global_counter(
+            &self,
+            _relation_kind: RelationType,
+            _object_type: ObjectType,
+        ) -> Result<Option<RetrievalStatsCounter>, CustomError> {
+            Ok(None)
+        }
+
         async fn health(&self) -> Result<RetrievalStatsHealth, CustomError> {
             Ok(RetrievalStatsHealth::default())
         }

--- a/src/internal/repositories/link_pipeline.rs
+++ b/src/internal/repositories/link_pipeline.rs
@@ -1,9 +1,10 @@
 // Typed-link pipeline used by the public facade and internal tests. Some
 // helpers remain available for focused test and validation paths.
-use crate::api::types::{DraftDefaults, MemoryLink, MemoryLinkDraft};
+use crate::api::types::{DraftDefaults, MemoryLink, MemoryLinkDraft, ObjectType};
 use crate::errors::CustomError;
 use crate::internal::repositories::{
-    record_stats_after_write, GraphAuthorityStore, RetrievalStatsStore,
+    record_stats_after_write, GraphAuthorityStore, GraphObjectQuery, GraphObjectRef,
+    RetrievalStatsStore,
 };
 
 pub(crate) struct LinkPipeline<'a, G>
@@ -52,9 +53,49 @@ where
         self.graph_store
             .upsert_links(std::slice::from_ref(&link))
             .await?;
-        record_stats_after_write(self.stats_store, &[], std::slice::from_ref(&link)).await;
+        self.record_link_stats_after_write(&link).await;
         Ok(link)
     }
+
+    async fn record_link_stats_after_write(&self, link: &MemoryLink) {
+        let endpoint_refs = link_stats_endpoint_refs(link);
+        if endpoint_refs.is_empty() {
+            record_stats_after_write(self.stats_store, &[], std::slice::from_ref(link)).await;
+            return;
+        }
+
+        match self
+            .graph_store
+            .query_objects(&GraphObjectQuery::by_refs(endpoint_refs))
+            .await
+        {
+            Ok(objects) => {
+                record_stats_after_write(self.stats_store, &objects, std::slice::from_ref(link))
+                    .await;
+            }
+            Err(error) => {
+                let _ = self.stats_store.mark_unhealthy(error.to_string()).await;
+            }
+        }
+    }
+}
+
+fn link_stats_endpoint_refs(link: &MemoryLink) -> Vec<GraphObjectRef> {
+    let mut refs = Vec::new();
+    if object_type_has_stats_state(link.from_type) {
+        refs.push(GraphObjectRef::new(link.from_id, link.from_type));
+    }
+    if object_type_has_stats_state(link.to_type) {
+        refs.push(GraphObjectRef::new(link.to_id, link.to_type));
+    }
+    refs
+}
+
+fn object_type_has_stats_state(object_type: ObjectType) -> bool {
+    matches!(
+        object_type,
+        ObjectType::Episode | ObjectType::Observation | ObjectType::DerivedMemory
+    )
 }
 
 fn validation_error(error: impl ToString) -> CustomError {
@@ -68,7 +109,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::api::types::{
-        MemoryId, MemoryObject, ObjectType, RelationType, DEFAULT_SCHEMA_VERSION,
+        MemoryId, MemoryObject, ObjectType, RelationType, RetentionState, DEFAULT_SCHEMA_VERSION,
     };
     use crate::internal::repositories::test_support::{
         representative_fixtures, FakeGraphAuthorityStore,
@@ -214,6 +255,45 @@ mod tests {
         assert_eq!(counter.total_count, 1);
         assert_eq!(counter.active_count, 1);
         assert_eq!(counter.current_count, 1);
+    }
+
+    #[tokio::test]
+    async fn link_pipeline_records_endpoint_lifecycle_state_in_stats() {
+        let graph = FakeGraphAuthorityStore::new();
+        let fixtures = representative_fixtures();
+        let mut suppressed_episode = fixtures.episode.clone();
+        suppressed_episode.retention_state = RetentionState::Suppressed;
+        graph
+            .upsert_objects(&[
+                MemoryObject::Entity(fixtures.hub_entity.clone()),
+                MemoryObject::Episode(suppressed_episode.clone()),
+            ])
+            .await
+            .unwrap();
+        let stats = InMemoryRetrievalStatsStore::new();
+        let pipeline = LinkPipeline::new_with_stats(&graph, &stats);
+        let draft = MemoryLinkDraft::new(
+            ObjectType::Entity,
+            fixtures.hub_entity.id,
+            RelationType::Involves,
+            ObjectType::Episode,
+            suppressed_episode.id,
+        );
+
+        let persisted = pipeline.link(draft).await.unwrap();
+
+        let counter = stats
+            .counter(&RetrievalStatsCounterKey {
+                entity_id: fixtures.hub_entity.id,
+                relation_kind: persisted.relation,
+                object_type: ObjectType::Episode,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(counter.total_count, 1);
+        assert_eq!(counter.active_count, 0);
+        assert_eq!(counter.current_count, 0);
     }
 
     fn valid_link_draft() -> MemoryLinkDraft {

--- a/src/internal/repositories/link_pipeline.rs
+++ b/src/internal/repositories/link_pipeline.rs
@@ -1,6 +1,6 @@
 // Typed-link pipeline used by the public facade and internal tests. Some
 // helpers remain available for focused test and validation paths.
-use crate::api::types::{DraftDefaults, MemoryLink, MemoryLinkDraft, ObjectType};
+use crate::api::types::{DraftDefaults, MemoryId, MemoryLink, MemoryLinkDraft, ObjectType};
 use crate::errors::CustomError;
 use crate::internal::repositories::{
     record_stats_after_write, GraphAuthorityStore, GraphObjectQuery, GraphObjectRef,
@@ -85,12 +85,25 @@ where
 fn link_stats_endpoint_refs(link: &MemoryLink) -> Vec<GraphObjectRef> {
     let mut refs = Vec::new();
     if object_type_has_stats_state(link.from_type) {
-        refs.push(GraphObjectRef::new(link.from_id, link.from_type));
+        push_link_stats_endpoint_ref(&mut refs, link.from_id, link.from_type);
     }
     if object_type_has_stats_state(link.to_type) {
-        refs.push(GraphObjectRef::new(link.to_id, link.to_type));
+        push_link_stats_endpoint_ref(&mut refs, link.to_id, link.to_type);
     }
     refs
+}
+
+fn push_link_stats_endpoint_ref(
+    refs: &mut Vec<GraphObjectRef>,
+    object_id: MemoryId,
+    object_type: ObjectType,
+) {
+    let object_ref = GraphObjectRef::new(object_id, object_type);
+    if refs.contains(&object_ref) {
+        return;
+    }
+
+    refs.push(object_ref);
 }
 
 fn object_type_has_stats_state(object_type: ObjectType) -> bool {
@@ -207,6 +220,31 @@ mod tests {
         assert!(error
             .to_string()
             .contains("cannot point from an object to itself"));
+    }
+
+    #[test]
+    fn link_stats_endpoint_refs_dedupes_self_referential_endpoint() {
+        let object_id = id("550e8400-e29b-41d4-a716-446655444010");
+        let link = MemoryLink {
+            id: id("550e8400-e29b-41d4-a716-446655444011"),
+            object_type: ObjectType::MemoryLink,
+            from_id: object_id,
+            from_type: ObjectType::Observation,
+            to_id: object_id,
+            to_type: ObjectType::Observation,
+            relation: RelationType::AssociatedWith,
+            confidence: 0.8,
+            rationale: None,
+            created_at: timestamp(),
+            schema_version: DEFAULT_SCHEMA_VERSION.to_string(),
+        };
+
+        let refs = link_stats_endpoint_refs(&link);
+
+        assert_eq!(
+            refs,
+            vec![GraphObjectRef::new(object_id, ObjectType::Observation)]
+        );
     }
 
     #[tokio::test]

--- a/src/internal/repositories/link_pipeline.rs
+++ b/src/internal/repositories/link_pipeline.rs
@@ -74,7 +74,9 @@ where
                     .await;
             }
             Err(error) => {
-                let _ = self.stats_store.mark_unhealthy(error.to_string()).await;
+                let error_message = error.to_string();
+                record_stats_after_write(self.stats_store, &[], std::slice::from_ref(link)).await;
+                let _ = self.stats_store.mark_unhealthy(error_message).await;
             }
         }
     }
@@ -105,18 +107,21 @@ fn validation_error(error: impl ToString) -> CustomError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
     use chrono::{DateTime, Utc};
     use uuid::Uuid;
 
     use crate::api::types::{
-        MemoryId, MemoryObject, ObjectType, RelationType, RetentionState, DEFAULT_SCHEMA_VERSION,
+        DerivedMemory, MemoryId, MemoryObject, ObjectType, RelationType, RetentionState,
+        DEFAULT_SCHEMA_VERSION,
     };
     use crate::internal::repositories::test_support::{
         representative_fixtures, FakeGraphAuthorityStore,
     };
     use crate::internal::repositories::{
-        GraphAuthorityStore, GraphExpansionQuery, InMemoryRetrievalStatsStore,
-        RetrievalStatsCounterKey, RetrievalStatsStore,
+        GraphAuthorityStore, GraphDerivedMemoryProvenanceQuery, GraphDerivedMemoryThreadQuery,
+        GraphExpansion, GraphExpansionQuery, InMemoryRetrievalStatsStore, RetrievalStatsCounterKey,
+        RetrievalStatsStore,
     };
 
     #[tokio::test]
@@ -294,6 +299,97 @@ mod tests {
         assert_eq!(counter.total_count, 1);
         assert_eq!(counter.active_count, 0);
         assert_eq!(counter.current_count, 0);
+    }
+
+    #[tokio::test]
+    async fn link_pipeline_records_fallback_stats_when_endpoint_lookup_fails() {
+        let graph = QueryObjectsFailingGraph::default();
+        let stats = InMemoryRetrievalStatsStore::new();
+        let pipeline = LinkPipeline::new_with_stats(&graph, &stats);
+        let draft = valid_link_draft();
+        let entity_id = draft.to_id;
+
+        let persisted = pipeline.link(draft).await.unwrap();
+
+        let counter = stats
+            .counter(&RetrievalStatsCounterKey {
+                entity_id,
+                relation_kind: persisted.relation,
+                object_type: ObjectType::Episode,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(counter.total_count, 1);
+        assert_eq!(counter.active_count, 1);
+        assert_eq!(counter.current_count, 1);
+        assert_eq!(
+            stats.health().await.unwrap().state,
+            crate::internal::repositories::RetrievalStatsHealthState::Unhealthy
+        );
+    }
+
+    #[derive(Default)]
+    struct QueryObjectsFailingGraph {
+        links: std::sync::Mutex<Vec<MemoryLink>>,
+    }
+
+    #[async_trait]
+    impl GraphAuthorityStore for QueryObjectsFailingGraph {
+        async fn upsert_objects(&self, _objects: &[MemoryObject]) -> Result<(), CustomError> {
+            Ok(())
+        }
+
+        async fn upsert_links(&self, links: &[MemoryLink]) -> Result<(), CustomError> {
+            self.links.lock().unwrap().extend_from_slice(links);
+            Ok(())
+        }
+
+        async fn upsert_objects_and_links(
+            &self,
+            _objects: &[MemoryObject],
+            links: &[MemoryLink],
+        ) -> Result<(), CustomError> {
+            self.upsert_links(links).await
+        }
+
+        async fn query_objects(
+            &self,
+            _query: &GraphObjectQuery,
+        ) -> Result<Vec<MemoryObject>, CustomError> {
+            Err(CustomError::DatabaseError(
+                "endpoint lifecycle lookup failed".to_owned(),
+            ))
+        }
+
+        async fn query_derived_memories_by_provenance(
+            &self,
+            _query: &GraphDerivedMemoryProvenanceQuery,
+        ) -> Result<Vec<DerivedMemory>, CustomError> {
+            Ok(Vec::new())
+        }
+
+        async fn query_derived_memories_by_thread(
+            &self,
+            _query: &GraphDerivedMemoryThreadQuery,
+        ) -> Result<Vec<DerivedMemory>, CustomError> {
+            Ok(Vec::new())
+        }
+
+        async fn expand_bounded(
+            &self,
+            _query: &GraphExpansionQuery,
+        ) -> Result<GraphExpansion, CustomError> {
+            Ok(GraphExpansion::new(Vec::new(), Vec::new()))
+        }
+
+        async fn list_diagnostic_objects(&self) -> Result<Vec<MemoryObject>, CustomError> {
+            Ok(Vec::new())
+        }
+
+        async fn list_diagnostic_links(&self) -> Result<Vec<MemoryLink>, CustomError> {
+            Ok(self.links.lock().unwrap().clone())
+        }
     }
 
     fn valid_link_draft() -> MemoryLinkDraft {

--- a/src/internal/repositories/link_pipeline.rs
+++ b/src/internal/repositories/link_pipeline.rs
@@ -2,21 +2,38 @@
 // helpers remain available for focused test and validation paths.
 use crate::api::types::{DraftDefaults, MemoryLink, MemoryLinkDraft};
 use crate::errors::CustomError;
-use crate::internal::repositories::GraphAuthorityStore;
+use crate::internal::repositories::{
+    record_stats_after_write, GraphAuthorityStore, RetrievalStatsStore,
+};
 
 pub(crate) struct LinkPipeline<'a, G>
 where
     G: GraphAuthorityStore + ?Sized,
 {
     graph_store: &'a G,
+    stats_store: &'a dyn RetrievalStatsStore,
 }
 
 impl<'a, G> LinkPipeline<'a, G>
 where
     G: GraphAuthorityStore + ?Sized,
 {
+    #[cfg(test)]
     pub(crate) fn new(graph_store: &'a G) -> Self {
-        Self { graph_store }
+        Self {
+            graph_store,
+            stats_store: crate::internal::repositories::noop_retrieval_stats_store(),
+        }
+    }
+
+    pub(crate) fn new_with_stats(
+        graph_store: &'a G,
+        stats_store: &'a dyn RetrievalStatsStore,
+    ) -> Self {
+        Self {
+            graph_store,
+            stats_store,
+        }
     }
 
     pub(crate) async fn link(&self, draft: MemoryLinkDraft) -> Result<MemoryLink, CustomError> {
@@ -35,6 +52,7 @@ where
         self.graph_store
             .upsert_links(std::slice::from_ref(&link))
             .await?;
+        record_stats_after_write(self.stats_store, &[], std::slice::from_ref(&link)).await;
         Ok(link)
     }
 }
@@ -55,7 +73,10 @@ mod tests {
     use crate::internal::repositories::test_support::{
         representative_fixtures, FakeGraphAuthorityStore,
     };
-    use crate::internal::repositories::{GraphAuthorityStore, GraphExpansionQuery};
+    use crate::internal::repositories::{
+        GraphAuthorityStore, GraphExpansionQuery, InMemoryRetrievalStatsStore,
+        RetrievalStatsCounterKey, RetrievalStatsStore,
+    };
 
     #[tokio::test]
     async fn persists_caller_supplied_link_as_graph_authoritative_record() {
@@ -169,6 +190,30 @@ mod tests {
         let persisted = pipeline.link(valid_link_draft()).await.unwrap();
 
         assert_eq!(persisted.object_type, ObjectType::MemoryLink);
+    }
+
+    #[tokio::test]
+    async fn link_pipeline_records_entity_relation_stats_after_graph_success() {
+        let graph = FakeGraphAuthorityStore::new();
+        let stats = InMemoryRetrievalStatsStore::new();
+        let pipeline = LinkPipeline::new_with_stats(&graph, &stats);
+        let draft = valid_link_draft();
+        let entity_id = draft.to_id;
+
+        let persisted = pipeline.link(draft).await.unwrap();
+
+        let counter = stats
+            .counter(&RetrievalStatsCounterKey {
+                entity_id,
+                relation_kind: persisted.relation,
+                object_type: ObjectType::Episode,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(counter.total_count, 1);
+        assert_eq!(counter.active_count, 1);
+        assert_eq!(counter.current_count, 1);
     }
 
     fn valid_link_draft() -> MemoryLinkDraft {

--- a/src/internal/repositories/remember_pipeline.rs
+++ b/src/internal/repositories/remember_pipeline.rs
@@ -7,7 +7,10 @@ use crate::errors::CustomError;
 use crate::internal::models::vector::{
     memory_object_vector_record, VectorRecord, VectorRecordEmbedding,
 };
-use crate::internal::repositories::{GraphAuthorityStore, MemoryEmbedder, VectorCandidateStore};
+use crate::internal::repositories::{
+    record_stats_after_write, GraphAuthorityStore, MemoryEmbedder, RetrievalStatsStore,
+    VectorCandidateStore,
+};
 
 #[derive(Debug, Clone)]
 pub(crate) struct RememberPipelineDraft {
@@ -69,6 +72,7 @@ where
     graph_store: &'a G,
     vector_store: &'a V,
     embedder: &'a E,
+    stats_store: &'a dyn RetrievalStatsStore,
 }
 
 impl<'a, G, V, E> RememberPipeline<'a, G, V, E>
@@ -77,11 +81,27 @@ where
     V: VectorCandidateStore + ?Sized,
     E: MemoryEmbedder + ?Sized,
 {
+    #[cfg(test)]
     pub(crate) fn new(graph_store: &'a G, vector_store: &'a V, embedder: &'a E) -> Self {
         Self {
             graph_store,
             vector_store,
             embedder,
+            stats_store: crate::internal::repositories::noop_retrieval_stats_store(),
+        }
+    }
+
+    pub(crate) fn new_with_stats(
+        graph_store: &'a G,
+        vector_store: &'a V,
+        embedder: &'a E,
+        stats_store: &'a dyn RetrievalStatsStore,
+    ) -> Self {
+        Self {
+            graph_store,
+            vector_store,
+            embedder,
+            stats_store,
         }
     }
 
@@ -97,6 +117,7 @@ where
 
         let mut outcome = RememberPipelineOutcome::graph_persisted(&objects, &links);
         if vector_records.is_empty() {
+            record_stats_after_write(self.stats_store, &objects, &links).await;
             return Ok(outcome);
         }
 
@@ -114,6 +135,8 @@ where
                 });
             }
         }
+
+        record_stats_after_write(self.stats_store, &objects, &links).await;
 
         Ok(outcome)
     }
@@ -223,6 +246,9 @@ mod tests {
         EmbeddingInput, VectorCandidateMatch, VectorCandidateSearch,
     };
     use crate::internal::repositories::{GraphExpansion, GraphExpansionQuery, GraphObjectQuery};
+    use crate::internal::repositories::{
+        InMemoryRetrievalStatsStore, RetrievalStatsCounterKey, RetrievalStatsStore,
+    };
 
     #[tokio::test]
     async fn persists_graph_objects_links_then_vectors_in_stable_order() {
@@ -460,6 +486,44 @@ mod tests {
             "embedder returned 4 embeddings for 5 vector records"
         );
         assert!(vector.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn remember_pipeline_records_stats_after_vector_attempt() {
+        let ids = fixed_ids();
+        let graph = RecordingGraphStore::default();
+        let vector = RecordingVectorStore::default();
+        let embedder = RecordingEmbedder::default();
+        let stats = InMemoryRetrievalStatsStore::new();
+        let pipeline = RememberPipeline::new_with_stats(&graph, &vector, &embedder, &stats);
+
+        pipeline
+            .remember(RememberPipelineDraft::new(
+                [MemoryObjectDraft::Entity(entity_draft(ids.entity))],
+                [typed_link_draft(
+                    ids.extra_link,
+                    ObjectType::Entity,
+                    ids.entity,
+                    RelationType::Mentions,
+                    ObjectType::Episode,
+                    ids.episode,
+                )],
+            ))
+            .await
+            .expect("stats should not change remember outcome");
+
+        let counter = stats
+            .counter(&RetrievalStatsCounterKey {
+                entity_id: ids.entity,
+                relation_kind: RelationType::Mentions,
+                object_type: ObjectType::Episode,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(counter.total_count, 1);
+        assert_eq!(counter.active_count, 1);
+        assert_eq!(counter.current_count, 1);
     }
 
     #[derive(Debug, Clone, Copy)]

--- a/src/internal/repositories/remember_pipeline.rs
+++ b/src/internal/repositories/remember_pipeline.rs
@@ -2,14 +2,15 @@
 // builders remain available for focused test and validation paths.
 use crate::api::types::{
     DraftDefaults, MemoryId, MemoryLink, MemoryLinkDraft, MemoryObject, MemoryObjectDraft,
+    ObjectType,
 };
 use crate::errors::CustomError;
 use crate::internal::models::vector::{
     memory_object_vector_record, VectorRecord, VectorRecordEmbedding,
 };
 use crate::internal::repositories::{
-    record_stats_after_write, GraphAuthorityStore, MemoryEmbedder, RetrievalStatsStore,
-    VectorCandidateStore,
+    record_stats_after_write, GraphAuthorityStore, GraphObjectQuery, GraphObjectRef,
+    MemoryEmbedder, RetrievalStatsStore, VectorCandidateStore,
 };
 
 #[derive(Debug, Clone)]
@@ -117,7 +118,8 @@ where
 
         let mut outcome = RememberPipelineOutcome::graph_persisted(&objects, &links);
         if vector_records.is_empty() {
-            record_stats_after_write(self.stats_store, &objects, &links).await;
+            self.record_remember_stats_after_write(&objects, &links)
+                .await;
             return Ok(outcome);
         }
 
@@ -136,9 +138,39 @@ where
             }
         }
 
-        record_stats_after_write(self.stats_store, &objects, &links).await;
+        self.record_remember_stats_after_write(&objects, &links)
+            .await;
 
         Ok(outcome)
+    }
+
+    async fn record_remember_stats_after_write(
+        &self,
+        objects: &[MemoryObject],
+        links: &[MemoryLink],
+    ) {
+        let endpoint_refs = remember_stats_endpoint_refs(objects, links);
+        if endpoint_refs.is_empty() {
+            record_stats_after_write(self.stats_store, objects, links).await;
+            return;
+        }
+
+        match self
+            .graph_store
+            .query_objects(&GraphObjectQuery::by_refs(endpoint_refs))
+            .await
+        {
+            Ok(endpoint_objects) => {
+                let stats_objects =
+                    stats_objects_with_endpoint_lifecycle(objects, endpoint_objects);
+                record_stats_after_write(self.stats_store, &stats_objects, links).await;
+            }
+            Err(error) => {
+                let error_message = error.to_string();
+                record_stats_after_write(self.stats_store, objects, links).await;
+                let _ = self.stats_store.mark_unhealthy(error_message).await;
+            }
+        }
     }
 
     async fn index_vector_records(
@@ -215,18 +247,76 @@ fn vector_records_for_objects(objects: &[MemoryObject]) -> Vec<VectorRecord> {
         .collect()
 }
 
+fn remember_stats_endpoint_refs(
+    objects: &[MemoryObject],
+    links: &[MemoryLink],
+) -> Vec<GraphObjectRef> {
+    let mut refs = Vec::new();
+    for link in links {
+        push_stats_endpoint_ref(&mut refs, objects, link.from_id, link.from_type);
+        push_stats_endpoint_ref(&mut refs, objects, link.to_id, link.to_type);
+    }
+    refs
+}
+
+fn push_stats_endpoint_ref(
+    refs: &mut Vec<GraphObjectRef>,
+    objects: &[MemoryObject],
+    object_id: MemoryId,
+    object_type: ObjectType,
+) {
+    if !object_type_has_stats_state(object_type)
+        || objects
+            .iter()
+            .any(|object| memory_object_identity(object) == (object_id, object_type))
+        || refs.iter().any(|object_ref| {
+            object_ref.object_id == object_id && object_ref.object_type == object_type
+        })
+    {
+        return;
+    }
+
+    refs.push(GraphObjectRef::new(object_id, object_type));
+}
+
+fn stats_objects_with_endpoint_lifecycle(
+    objects: &[MemoryObject],
+    endpoint_objects: Vec<MemoryObject>,
+) -> Vec<MemoryObject> {
+    let mut stats_objects = objects.to_vec();
+    for endpoint_object in endpoint_objects {
+        if !stats_objects.iter().any(|object| {
+            memory_object_identity(object) == memory_object_identity(&endpoint_object)
+        }) {
+            stats_objects.push(endpoint_object);
+        }
+    }
+    stats_objects
+}
+
+fn object_type_has_stats_state(object_type: ObjectType) -> bool {
+    matches!(
+        object_type,
+        ObjectType::Episode | ObjectType::Observation | ObjectType::DerivedMemory
+    )
+}
+
 fn validation_error(error: impl ToString) -> CustomError {
     CustomError::MemoryValidation(error.to_string())
 }
 
 fn memory_object_id(object: &MemoryObject) -> MemoryId {
+    memory_object_identity(object).0
+}
+
+fn memory_object_identity(object: &MemoryObject) -> (MemoryId, ObjectType) {
     match object {
-        MemoryObject::Episode(object) => object.id,
-        MemoryObject::Observation(object) => object.id,
-        MemoryObject::Entity(object) => object.id,
-        MemoryObject::MemoryThread(object) => object.id,
-        MemoryObject::DerivedMemory(object) => object.id,
-        MemoryObject::MemoryLink(object) => object.id,
+        MemoryObject::Episode(object) => (object.id, object.object_type),
+        MemoryObject::Observation(object) => (object.id, object.object_type),
+        MemoryObject::Entity(object) => (object.id, object.object_type),
+        MemoryObject::MemoryThread(object) => (object.id, object.object_type),
+        MemoryObject::DerivedMemory(object) => (object.id, object.object_type),
+        MemoryObject::MemoryLink(object) => (object.id, object.object_type),
     }
 }
 
@@ -240,10 +330,13 @@ mod tests {
 
     use crate::api::types::{
         DerivedMemoryDraft, DerivedType, EntityDraft, EntityType, EpisodeDraft, MemoryThreadDraft,
-        ObjectType, ObservationDraft, RelationType,
+        ObjectType, ObservationDraft, RelationType, RetentionState,
     };
     use crate::internal::models::vector::{
         EmbeddingInput, VectorCandidateMatch, VectorCandidateSearch,
+    };
+    use crate::internal::repositories::test_support::{
+        representative_fixtures, FakeGraphAuthorityStore,
     };
     use crate::internal::repositories::{GraphExpansion, GraphExpansionQuery, GraphObjectQuery};
     use crate::internal::repositories::{
@@ -524,6 +617,56 @@ mod tests {
         assert_eq!(counter.total_count, 1);
         assert_eq!(counter.active_count, 1);
         assert_eq!(counter.current_count, 1);
+    }
+
+    #[tokio::test]
+    async fn remember_pipeline_uses_existing_endpoint_lifecycle_for_link_stats() {
+        let fixtures = representative_fixtures();
+        let graph = FakeGraphAuthorityStore::new();
+        graph
+            .upsert_objects(&[
+                MemoryObject::Entity(fixtures.hub_entity.clone()),
+                MemoryObject::DerivedMemory(fixtures.suppressed_seed.clone()),
+            ])
+            .await
+            .unwrap();
+        let vector = RecordingVectorStore::default();
+        let embedder = RecordingEmbedder::default();
+        let stats = InMemoryRetrievalStatsStore::new();
+        let pipeline = RememberPipeline::new_with_stats(&graph, &vector, &embedder, &stats);
+
+        pipeline
+            .remember(RememberPipelineDraft::new(
+                Vec::<MemoryObjectDraft>::new(),
+                [typed_link_draft(
+                    id("550e8400-e29b-41d4-a716-446655443008"),
+                    ObjectType::Entity,
+                    fixtures.hub_entity.id,
+                    RelationType::About,
+                    ObjectType::DerivedMemory,
+                    fixtures.suppressed_seed.id,
+                )],
+            ))
+            .await
+            .expect("link-only remember should persist and record stats");
+
+        let counter = stats
+            .counter(&RetrievalStatsCounterKey {
+                entity_id: fixtures.hub_entity.id,
+                relation_kind: RelationType::About,
+                object_type: ObjectType::DerivedMemory,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            fixtures.suppressed_seed.retention_state,
+            RetentionState::Suppressed
+        );
+        assert!(!fixtures.suppressed_seed.is_current);
+        assert_eq!(counter.total_count, 1);
+        assert_eq!(counter.active_count, 0);
+        assert_eq!(counter.current_count, 0);
     }
 
     #[derive(Debug, Clone, Copy)]

--- a/src/internal/repositories/retrieval_stats_store.rs
+++ b/src/internal/repositories/retrieval_stats_store.rs
@@ -96,9 +96,11 @@ impl Default for RetrievalStatsHealth {
     }
 }
 
+#[cfg(test)]
 #[derive(Debug, Default)]
 pub(crate) struct NoopRetrievalStatsStore;
 
+#[cfg(test)]
 #[async_trait]
 impl RetrievalStatsStore for NoopRetrievalStatsStore {
     async fn record_edges(&self, _edges: &[RetrievalStatsEdge]) -> Result<(), CustomError> {
@@ -151,6 +153,7 @@ impl InMemoryRetrievalStatsStore {
                     state: RetrievalStatsHealthState::Unhealthy,
                     last_error_message: Some(message),
                 },
+                preserve_unhealthy_on_success: true,
                 ..InMemoryState::default()
             }),
         }
@@ -161,6 +164,7 @@ impl InMemoryRetrievalStatsStore {
 struct InMemoryState {
     edges: HashMap<String, RetrievalStatsEdge>,
     health: RetrievalStatsHealth,
+    preserve_unhealthy_on_success: bool,
 }
 
 #[async_trait]
@@ -170,7 +174,7 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
         for edge in edges {
             state.edges.insert(edge.edge_key.clone(), edge.clone());
         }
-        state.health = RetrievalStatsHealth::default();
+        state.mark_healthy_after_success();
         Ok(())
     }
 
@@ -190,7 +194,7 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
                 }
             }
         }
-        state.health = RetrievalStatsHealth::default();
+        state.mark_healthy_after_success();
         Ok(())
     }
 
@@ -214,6 +218,14 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
             last_error_message: Some(message),
         };
         Ok(())
+    }
+}
+
+impl InMemoryState {
+    fn mark_healthy_after_success(&mut self) {
+        if !self.preserve_unhealthy_on_success {
+            self.health = RetrievalStatsHealth::default();
+        }
     }
 }
 
@@ -778,6 +790,36 @@ mod tests {
             health.last_error_message.as_deref(),
             Some("stats write failed")
         );
+    }
+
+    #[tokio::test]
+    async fn fallback_health_marker_survives_successful_writes() {
+        let store = InMemoryRetrievalStatsStore::unhealthy(
+            "sqlite retrieval stats unavailable; using in-memory fallback".to_owned(),
+        );
+        let entity_id = id("550e8400-e29b-41d4-a716-446655460051");
+        let episode_id = id("550e8400-e29b-41d4-a716-446655460052");
+
+        store
+            .record_edges(&[edge(
+                entity_id,
+                RelationType::Involves,
+                episode_id,
+                ObjectType::Episode,
+                RetentionState::Active,
+                true,
+                timestamp(),
+            )])
+            .await
+            .unwrap();
+
+        let health = store.health().await.unwrap();
+        assert_eq!(health.state, RetrievalStatsHealthState::Unhealthy);
+        assert!(health
+            .last_error_message
+            .as_deref()
+            .unwrap()
+            .contains("in-memory fallback"));
     }
 
     fn id(value: &str) -> MemoryId {

--- a/src/internal/repositories/retrieval_stats_store.rs
+++ b/src/internal/repositories/retrieval_stats_store.rs
@@ -235,7 +235,7 @@ pub(crate) async fn record_stats_after_write(
     links: &[MemoryLink],
 ) {
     let states = retrieval_stats_object_states(objects);
-    let edges = retrieval_stats_edges(objects, links);
+    let edges = retrieval_stats_edges_with_states(objects, links, &states);
     if let Err(error) = stats_store.record_edges(&edges).await {
         let _ = stats_store.mark_unhealthy(error.to_string()).await;
         return;
@@ -250,16 +250,21 @@ pub(crate) async fn record_stats_after_write(
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn retrieval_stats_edges(
     objects: &[MemoryObject],
     links: &[MemoryLink],
 ) -> Vec<RetrievalStatsEdge> {
-    let object_states = retrieval_stats_object_states(objects);
-    let mut object_state_lookup = HashMap::new();
-    for state in &object_states {
-        object_state_lookup.insert((state.object_id, state.object_type), state.clone());
-    }
+    let states = retrieval_stats_object_states(objects);
+    retrieval_stats_edges_with_states(objects, links, &states)
+}
 
+fn retrieval_stats_edges_with_states(
+    objects: &[MemoryObject],
+    links: &[MemoryLink],
+    object_states: &[RetrievalStatsObjectState],
+) -> Vec<RetrievalStatsEdge> {
+    let object_state_lookup = object_state_lookup(object_states);
     let mut edges: HashMap<String, RetrievalStatsEdge> = HashMap::new();
     for object in objects {
         append_intrinsic_edges(&mut edges, object);
@@ -270,6 +275,16 @@ pub(crate) fn retrieval_stats_edges(
     let mut edges = edges.into_values().collect::<Vec<_>>();
     edges.sort_by(|left, right| left.edge_key.cmp(&right.edge_key));
     edges
+}
+
+fn object_state_lookup(
+    object_states: &[RetrievalStatsObjectState],
+) -> HashMap<(MemoryId, ObjectType), RetrievalStatsObjectState> {
+    let mut object_state_lookup = HashMap::new();
+    for state in object_states {
+        object_state_lookup.insert((state.object_id, state.object_type), state.clone());
+    }
+    object_state_lookup
 }
 
 pub(crate) fn retrieval_stats_object_states(
@@ -335,22 +350,7 @@ fn append_intrinsic_edges(edges: &mut HashMap<String, RetrievalStatsEdge>, objec
                 );
             }
         }
-        MemoryObject::Observation(observation) => {
-            if let Some(entity_id) = observation.speaker_entity_id {
-                insert_edge(
-                    edges,
-                    edge(
-                        entity_id,
-                        RelationType::Mentions,
-                        observation.id,
-                        ObjectType::Observation,
-                        observation.retention_state,
-                        true,
-                        observation.created_at,
-                    ),
-                );
-            }
-        }
+        MemoryObject::Observation(_) => {}
         MemoryObject::DerivedMemory(memory) => {
             for entity_id in &memory.entity_ids {
                 insert_edge(
@@ -802,6 +802,30 @@ mod tests {
             .unwrap();
         assert_eq!(edge.retention_state, RetentionState::Suppressed);
         assert!(!edge.is_current);
+    }
+
+    #[test]
+    fn speaker_entity_id_does_not_count_as_mentions() {
+        let entity_id = id("550e8400-e29b-41d4-a716-446655460061");
+        let observation_id = id("550e8400-e29b-41d4-a716-446655460062");
+        let objects = vec![MemoryObject::Observation(crate::api::types::Observation {
+            id: observation_id,
+            object_type: ObjectType::Observation,
+            episode_id: id("550e8400-e29b-41d4-a716-446655460063"),
+            speaker_entity_id: Some(entity_id),
+            observed_at: None,
+            modality: Modality::Chat,
+            text: "speaker relationship is not a mentions edge".to_owned(),
+            raw_ref: None,
+            salience_score: 0.5,
+            retention_state: RetentionState::Active,
+            created_at: timestamp(),
+            schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+        })];
+
+        let edges = retrieval_stats_edges(&objects, &[]);
+
+        assert!(edges.is_empty());
     }
 
     #[test]

--- a/src/internal/repositories/retrieval_stats_store.rs
+++ b/src/internal/repositories/retrieval_stats_store.rs
@@ -143,6 +143,18 @@ impl InMemoryRetrievalStatsStore {
     pub(crate) fn new() -> Self {
         Self::default()
     }
+
+    pub(crate) fn unhealthy(message: String) -> Self {
+        Self {
+            state: Mutex::new(InMemoryState {
+                health: RetrievalStatsHealth {
+                    state: RetrievalStatsHealthState::Unhealthy,
+                    last_error_message: Some(message),
+                },
+                ..InMemoryState::default()
+            }),
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -211,13 +223,17 @@ pub(crate) async fn record_stats_after_write(
     links: &[MemoryLink],
 ) {
     let states = retrieval_stats_object_states(objects);
-    if let Err(error) = stats_store.record_object_states(&states).await {
+    let edges = retrieval_stats_edges(objects, links);
+    if let Err(error) = stats_store.record_edges(&edges).await {
         let _ = stats_store.mark_unhealthy(error.to_string()).await;
         return;
     }
 
-    let edges = retrieval_stats_edges(objects, links);
-    if let Err(error) = stats_store.record_edges(&edges).await {
+    if states.is_empty() {
+        return;
+    }
+
+    if let Err(error) = stats_store.record_object_states(&states).await {
         let _ = stats_store.mark_unhealthy(error.to_string()).await;
     }
 }
@@ -226,15 +242,21 @@ pub(crate) fn retrieval_stats_edges(
     objects: &[MemoryObject],
     links: &[MemoryLink],
 ) -> Vec<RetrievalStatsEdge> {
-    let mut edges = Vec::new();
+    let object_states = retrieval_stats_object_states(objects);
+    let mut object_state_lookup = HashMap::new();
+    for state in &object_states {
+        object_state_lookup.insert((state.object_id, state.object_type), state.clone());
+    }
+
+    let mut edges: HashMap<String, RetrievalStatsEdge> = HashMap::new();
     for object in objects {
         append_intrinsic_edges(&mut edges, object);
     }
     for link in links {
-        append_link_edges(&mut edges, link);
+        append_link_edges(&mut edges, link, &object_state_lookup);
     }
+    let mut edges = edges.into_values().collect::<Vec<_>>();
     edges.sort_by(|left, right| left.edge_key.cmp(&right.edge_key));
-    edges.dedup_by(|left, right| left.edge_key == right.edge_key);
     edges
 }
 
@@ -283,73 +305,138 @@ pub(crate) fn retention_state_key(retention_state: RetentionState) -> &'static s
     }
 }
 
-fn append_intrinsic_edges(edges: &mut Vec<RetrievalStatsEdge>, object: &MemoryObject) {
+fn append_intrinsic_edges(edges: &mut HashMap<String, RetrievalStatsEdge>, object: &MemoryObject) {
     match object {
         MemoryObject::Episode(episode) => {
             for entity_id in &episode.participant_entity_ids {
-                edges.push(edge(
-                    *entity_id,
-                    RelationType::Involves,
-                    episode.id,
-                    ObjectType::Episode,
-                    episode.retention_state,
-                    true,
-                    episode.created_at,
-                ));
+                insert_edge(
+                    edges,
+                    edge(
+                        *entity_id,
+                        RelationType::Involves,
+                        episode.id,
+                        ObjectType::Episode,
+                        episode.retention_state,
+                        true,
+                        episode.created_at,
+                    ),
+                );
             }
         }
         MemoryObject::Observation(observation) => {
             if let Some(entity_id) = observation.speaker_entity_id {
-                edges.push(edge(
-                    entity_id,
-                    RelationType::Mentions,
-                    observation.id,
-                    ObjectType::Observation,
-                    observation.retention_state,
-                    true,
-                    observation.created_at,
-                ));
+                insert_edge(
+                    edges,
+                    edge(
+                        entity_id,
+                        RelationType::Mentions,
+                        observation.id,
+                        ObjectType::Observation,
+                        observation.retention_state,
+                        true,
+                        observation.created_at,
+                    ),
+                );
             }
         }
         MemoryObject::DerivedMemory(memory) => {
             for entity_id in &memory.entity_ids {
-                edges.push(edge(
-                    *entity_id,
-                    RelationType::About,
-                    memory.id,
-                    ObjectType::DerivedMemory,
-                    memory.retention_state,
-                    memory.is_current,
-                    memory.created_at,
-                ));
+                insert_edge(
+                    edges,
+                    edge(
+                        *entity_id,
+                        RelationType::About,
+                        memory.id,
+                        ObjectType::DerivedMemory,
+                        memory.retention_state,
+                        memory.is_current,
+                        memory.created_at,
+                    ),
+                );
             }
         }
         MemoryObject::Entity(_) | MemoryObject::MemoryThread(_) | MemoryObject::MemoryLink(_) => {}
     }
 }
 
-fn append_link_edges(edges: &mut Vec<RetrievalStatsEdge>, link: &MemoryLink) {
+fn append_link_edges(
+    edges: &mut HashMap<String, RetrievalStatsEdge>,
+    link: &MemoryLink,
+    object_states: &HashMap<(MemoryId, ObjectType), RetrievalStatsObjectState>,
+) {
     if link.from_type == ObjectType::Entity && link.to_type != ObjectType::MemoryLink {
-        edges.push(edge(
-            link.from_id,
-            link.relation,
-            link.to_id,
-            link.to_type,
-            RetentionState::Active,
-            true,
-            link.created_at,
-        ));
+        let (retention_state, is_current) = edge_lifecycle(link.to_id, link.to_type, object_states);
+        insert_edge(
+            edges,
+            edge(
+                link.from_id,
+                link.relation,
+                link.to_id,
+                link.to_type,
+                retention_state,
+                is_current,
+                link.created_at,
+            ),
+        );
     }
     if link.to_type == ObjectType::Entity && link.from_type != ObjectType::MemoryLink {
-        edges.push(edge(
-            link.to_id,
-            link.relation,
-            link.from_id,
-            link.from_type,
-            RetentionState::Active,
-            true,
-            link.created_at,
-        ));
+        let (retention_state, is_current) =
+            edge_lifecycle(link.from_id, link.from_type, object_states);
+        insert_edge(
+            edges,
+            edge(
+                link.to_id,
+                link.relation,
+                link.from_id,
+                link.from_type,
+                retention_state,
+                is_current,
+                link.created_at,
+            ),
+        );
+    }
+}
+
+fn edge_lifecycle(
+    object_id: MemoryId,
+    object_type: ObjectType,
+    object_states: &HashMap<(MemoryId, ObjectType), RetrievalStatsObjectState>,
+) -> (RetentionState, bool) {
+    object_states
+        .get(&(object_id, object_type))
+        .map(|state| (state.retention_state, state.is_current))
+        .unwrap_or((RetentionState::Active, true))
+}
+
+fn insert_edge(edges: &mut HashMap<String, RetrievalStatsEdge>, edge: RetrievalStatsEdge) {
+    edges
+        .entry(edge.edge_key.clone())
+        .and_modify(|existing| merge_edge(existing, &edge))
+        .or_insert(edge);
+}
+
+fn merge_edge(existing: &mut RetrievalStatsEdge, incoming: &RetrievalStatsEdge) {
+    existing.first_seen_at = existing.first_seen_at.min(incoming.first_seen_at);
+    existing.last_seen_at = existing.last_seen_at.max(incoming.last_seen_at);
+    existing.retention_state =
+        more_restrictive_retention(existing.retention_state, incoming.retention_state);
+    existing.is_current = existing.is_current && incoming.is_current;
+}
+
+fn more_restrictive_retention(left: RetentionState, right: RetentionState) -> RetentionState {
+    if retention_rank(right) > retention_rank(left) {
+        right
+    } else {
+        left
+    }
+}
+
+fn retention_rank(retention_state: RetentionState) -> u8 {
+    match retention_state {
+        RetentionState::Active => 0,
+        RetentionState::Archived => 1,
+        RetentionState::Suppressed => 2,
+        RetentionState::Deleted => 3,
     }
 }
 
@@ -582,6 +669,99 @@ mod tests {
                 && edge.relation_kind == RelationType::About
                 && edge.object_id == memory_id
         }));
+    }
+
+    #[test]
+    fn link_edges_use_available_object_lifecycle() {
+        let entity_id = id("550e8400-e29b-41d4-a716-446655460031");
+        let memory_id = id("550e8400-e29b-41d4-a716-446655460032");
+        let link_id = id("550e8400-e29b-41d4-a716-446655460033");
+        let objects = vec![MemoryObject::DerivedMemory(DerivedMemory {
+            id: memory_id,
+            object_type: ObjectType::DerivedMemory,
+            derived_type: DerivedType::Reflection,
+            text: "memory".to_owned(),
+            derived_from_episode_ids: Vec::new(),
+            derived_from_observation_ids: Vec::new(),
+            thread_ids: Vec::new(),
+            entity_ids: Vec::new(),
+            confidence: 0.7,
+            salience_score: 0.7,
+            stability: Stability::Medium,
+            is_current: false,
+            supersedes: Vec::new(),
+            retention_state: RetentionState::Suppressed,
+            created_at: timestamp(),
+            updated_at: timestamp(),
+            schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+        })];
+        let link = MemoryLink {
+            id: link_id,
+            object_type: ObjectType::MemoryLink,
+            from_id: entity_id,
+            from_type: ObjectType::Entity,
+            to_id: memory_id,
+            to_type: ObjectType::DerivedMemory,
+            relation: RelationType::About,
+            confidence: 1.0,
+            rationale: None,
+            created_at: timestamp(),
+            schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+        };
+
+        let edges = retrieval_stats_edges(&objects, &[link]);
+
+        let edge = edges
+            .iter()
+            .find(|edge| edge.entity_id == entity_id && edge.object_id == memory_id)
+            .unwrap();
+        assert_eq!(edge.retention_state, RetentionState::Suppressed);
+        assert!(!edge.is_current);
+    }
+
+    #[test]
+    fn duplicate_edge_derivations_merge_lifecycle_deterministically() {
+        let entity_id = id("550e8400-e29b-41d4-a716-446655460041");
+        let memory_id = id("550e8400-e29b-41d4-a716-446655460042");
+        let link_id = id("550e8400-e29b-41d4-a716-446655460043");
+        let memory = MemoryObject::DerivedMemory(DerivedMemory {
+            id: memory_id,
+            object_type: ObjectType::DerivedMemory,
+            derived_type: DerivedType::Reflection,
+            text: "memory".to_owned(),
+            derived_from_episode_ids: Vec::new(),
+            derived_from_observation_ids: Vec::new(),
+            thread_ids: Vec::new(),
+            entity_ids: vec![entity_id],
+            confidence: 0.7,
+            salience_score: 0.7,
+            stability: Stability::Medium,
+            is_current: false,
+            supersedes: Vec::new(),
+            retention_state: RetentionState::Suppressed,
+            created_at: timestamp(),
+            updated_at: timestamp(),
+            schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+        });
+        let link = MemoryLink {
+            id: link_id,
+            object_type: ObjectType::MemoryLink,
+            from_id: entity_id,
+            from_type: ObjectType::Entity,
+            to_id: memory_id,
+            to_type: ObjectType::DerivedMemory,
+            relation: RelationType::About,
+            confidence: 1.0,
+            rationale: None,
+            created_at: timestamp(),
+            schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+        };
+
+        let edges = retrieval_stats_edges(&[memory], &[link]);
+
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].retention_state, RetentionState::Suppressed);
+        assert!(!edges[0].is_current);
     }
 
     #[tokio::test]

--- a/src/internal/repositories/retrieval_stats_store.rs
+++ b/src/internal/repositories/retrieval_stats_store.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 #[cfg(test)]
 use std::sync::OnceLock;
-use std::sync::{Mutex, MutexGuard};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use tokio::sync::Mutex;
 
 use crate::api::types::{
     MemoryId, MemoryLink, MemoryObject, ObjectType, RelationType, RetentionState,
@@ -185,7 +185,7 @@ struct InMemoryState {
 #[async_trait]
 impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
     async fn record_edges(&self, edges: &[RetrievalStatsEdge]) -> Result<(), CustomError> {
-        let mut state = lock(&self.state)?;
+        let mut state = self.state.lock().await;
         for edge in edges {
             insert_edge(&mut state.edges, edge.clone());
         }
@@ -197,7 +197,7 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
         &self,
         states: &[RetrievalStatsObjectState],
     ) -> Result<(), CustomError> {
-        let mut state = lock(&self.state)?;
+        let mut state = self.state.lock().await;
         for object_state in states {
             for edge in state.edges.values_mut() {
                 if edge.object_id == object_state.object_id
@@ -217,7 +217,7 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
         &self,
         key: &RetrievalStatsCounterKey,
     ) -> Result<Option<RetrievalStatsCounter>, CustomError> {
-        let mut state = lock(&self.state)?;
+        let mut state = self.state.lock().await;
         state.refresh_counters_if_dirty();
         Ok(state.counters.get(key).copied())
     }
@@ -227,7 +227,7 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
         relation_kind: RelationType,
         object_type: ObjectType,
     ) -> Result<Option<RetrievalStatsCounter>, CustomError> {
-        let mut state = lock(&self.state)?;
+        let mut state = self.state.lock().await;
         state.refresh_counters_if_dirty();
         Ok(state
             .global_counters
@@ -236,11 +236,11 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
     }
 
     async fn health(&self) -> Result<RetrievalStatsHealth, CustomError> {
-        Ok(lock(&self.state)?.health.clone())
+        Ok(self.state.lock().await.health.clone())
     }
 
     async fn mark_unhealthy(&self, message: String) -> Result<(), CustomError> {
-        let mut state = lock(&self.state)?;
+        let mut state = self.state.lock().await;
         state.health = RetrievalStatsHealth {
             state: RetrievalStatsHealthState::Unhealthy,
             last_error_message: Some(message),
@@ -584,12 +584,6 @@ fn recomputed_global_counters(
     counters
 }
 
-fn lock<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, CustomError> {
-    mutex
-        .lock()
-        .map_err(|_| CustomError::DatabaseError("retrieval stats mutex was poisoned".to_owned()))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -704,7 +698,7 @@ mod tests {
         store.record_edges(&[later_edge]).await.unwrap();
         store.record_edges(&[earlier_edge]).await.unwrap();
 
-        let state = lock(&store.state).unwrap();
+        let state = store.state.lock().await;
         let stored = state
             .edges
             .get(&format!("{}:involves:episode:{}", entity_id, episode_id))
@@ -784,7 +778,7 @@ mod tests {
             .await
             .unwrap();
 
-        let state = lock(&store.state).unwrap();
+        let state = store.state.lock().await;
         let stored = state
             .edges
             .get(&format!("{}:about:derived_memory:{}", entity_id, memory_id))

--- a/src/internal/repositories/retrieval_stats_store.rs
+++ b/src/internal/repositories/retrieval_stats_store.rs
@@ -26,6 +26,12 @@ pub(crate) trait RetrievalStatsStore: Send + Sync {
         key: &RetrievalStatsCounterKey,
     ) -> Result<Option<RetrievalStatsCounter>, CustomError>;
 
+    async fn global_counter(
+        &self,
+        relation_kind: RelationType,
+        object_type: ObjectType,
+    ) -> Result<Option<RetrievalStatsCounter>, CustomError>;
+
     async fn health(&self) -> Result<RetrievalStatsHealth, CustomError>;
 
     async fn mark_unhealthy(&self, message: String) -> Result<(), CustomError>;
@@ -121,6 +127,14 @@ impl RetrievalStatsStore for NoopRetrievalStatsStore {
         Ok(None)
     }
 
+    async fn global_counter(
+        &self,
+        _relation_kind: RelationType,
+        _object_type: ObjectType,
+    ) -> Result<Option<RetrievalStatsCounter>, CustomError> {
+        Ok(None)
+    }
+
     async fn health(&self) -> Result<RetrievalStatsHealth, CustomError> {
         Ok(RetrievalStatsHealth::default())
     }
@@ -200,6 +214,16 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
     ) -> Result<Option<RetrievalStatsCounter>, CustomError> {
         Ok(recomputed_counters(&lock(&self.state)?.edges)
             .get(key)
+            .copied())
+    }
+
+    async fn global_counter(
+        &self,
+        relation_kind: RelationType,
+        object_type: ObjectType,
+    ) -> Result<Option<RetrievalStatsCounter>, CustomError> {
+        Ok(recomputed_global_counters(&lock(&self.state)?.edges)
+            .get(&(relation_kind, object_type))
             .copied())
     }
 
@@ -521,6 +545,25 @@ fn recomputed_counters(
     counters
 }
 
+fn recomputed_global_counters(
+    edges: &HashMap<String, RetrievalStatsEdge>,
+) -> HashMap<(RelationType, ObjectType), RetrievalStatsCounter> {
+    let mut counters = HashMap::new();
+    for edge in edges.values() {
+        let counter = counters
+            .entry((edge.relation_kind, edge.object_type))
+            .or_insert_with(RetrievalStatsCounter::default);
+        counter.total_count += 1;
+        if edge.is_active() {
+            counter.active_count += 1;
+        }
+        if edge.is_active() && edge.is_current {
+            counter.current_count += 1;
+        }
+    }
+    counters
+}
+
 fn lock<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, CustomError> {
     mutex
         .lock()
@@ -568,6 +611,48 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(counter.total_count, 1);
+        assert_eq!(counter.active_count, 1);
+        assert_eq!(counter.current_count, 1);
+    }
+
+    #[tokio::test]
+    async fn in_memory_store_counts_global_relation_object_pairs() {
+        let store = InMemoryRetrievalStatsStore::new();
+        let first_entity_id = id("550e8400-e29b-41d4-a716-446655460031");
+        let second_entity_id = id("550e8400-e29b-41d4-a716-446655460032");
+        let first_episode_id = id("550e8400-e29b-41d4-a716-446655460033");
+        let second_episode_id = id("550e8400-e29b-41d4-a716-446655460034");
+
+        store
+            .record_edges(&[
+                edge(
+                    first_entity_id,
+                    RelationType::Involves,
+                    first_episode_id,
+                    ObjectType::Episode,
+                    RetentionState::Active,
+                    true,
+                    timestamp(),
+                ),
+                edge(
+                    second_entity_id,
+                    RelationType::Involves,
+                    second_episode_id,
+                    ObjectType::Episode,
+                    RetentionState::Suppressed,
+                    false,
+                    timestamp(),
+                ),
+            ])
+            .await
+            .unwrap();
+
+        let counter = store
+            .global_counter(RelationType::Involves, ObjectType::Episode)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(counter.total_count, 2);
         assert_eq!(counter.active_count, 1);
         assert_eq!(counter.current_count, 1);
     }

--- a/src/internal/repositories/retrieval_stats_store.rs
+++ b/src/internal/repositories/retrieval_stats_store.rs
@@ -153,7 +153,6 @@ impl InMemoryRetrievalStatsStore {
                     state: RetrievalStatsHealthState::Unhealthy,
                     last_error_message: Some(message),
                 },
-                preserve_unhealthy_on_success: true,
                 ..InMemoryState::default()
             }),
         }
@@ -164,7 +163,6 @@ impl InMemoryRetrievalStatsStore {
 struct InMemoryState {
     edges: HashMap<String, RetrievalStatsEdge>,
     health: RetrievalStatsHealth,
-    preserve_unhealthy_on_success: bool,
 }
 
 #[async_trait]
@@ -174,7 +172,6 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
         for edge in edges {
             insert_edge(&mut state.edges, edge.clone());
         }
-        state.mark_healthy_after_success();
         Ok(())
     }
 
@@ -194,7 +191,6 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
                 }
             }
         }
-        state.mark_healthy_after_success();
         Ok(())
     }
 
@@ -218,14 +214,6 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
             last_error_message: Some(message),
         };
         Ok(())
-    }
-}
-
-impl InMemoryState {
-    fn mark_healthy_after_success(&mut self) {
-        if !self.preserve_unhealthy_on_success {
-            self.health = RetrievalStatsHealth::default();
-        }
     }
 }
 
@@ -878,6 +866,18 @@ mod tests {
         let store = InMemoryRetrievalStatsStore::new();
         store
             .mark_unhealthy("stats write failed".to_owned())
+            .await
+            .unwrap();
+        store
+            .record_edges(&[edge(
+                id("550e8400-e29b-41d4-a716-446655460071"),
+                RelationType::Involves,
+                id("550e8400-e29b-41d4-a716-446655460072"),
+                ObjectType::Episode,
+                RetentionState::Active,
+                true,
+                timestamp(),
+            )])
             .await
             .unwrap();
 

--- a/src/internal/repositories/retrieval_stats_store.rs
+++ b/src/internal/repositories/retrieval_stats_store.rs
@@ -190,7 +190,7 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
                 {
                     edge.retention_state = object_state.retention_state;
                     edge.is_current = object_state.is_current;
-                    edge.last_seen_at = object_state.observed_at;
+                    edge.last_seen_at = edge.last_seen_at.max(object_state.observed_at);
                 }
             }
         }
@@ -660,6 +660,43 @@ mod tests {
         assert_eq!(counter.total_count, 1);
         assert_eq!(counter.active_count, 0);
         assert_eq!(counter.current_count, 0);
+    }
+
+    #[tokio::test]
+    async fn in_memory_object_state_updates_do_not_regress_last_seen_at() {
+        let store = InMemoryRetrievalStatsStore::new();
+        let entity_id = id("550e8400-e29b-41d4-a716-446655460051");
+        let memory_id = id("550e8400-e29b-41d4-a716-446655460052");
+        store
+            .record_edges(&[edge(
+                entity_id,
+                RelationType::About,
+                memory_id,
+                ObjectType::DerivedMemory,
+                RetentionState::Active,
+                true,
+                timestamp_at("2026-04-28T13:00:00Z"),
+            )])
+            .await
+            .unwrap();
+
+        store
+            .record_object_states(&[RetrievalStatsObjectState {
+                object_id: memory_id,
+                object_type: ObjectType::DerivedMemory,
+                retention_state: RetentionState::Suppressed,
+                is_current: false,
+                observed_at: timestamp_at("2026-04-28T11:00:00Z"),
+            }])
+            .await
+            .unwrap();
+
+        let state = lock(&store.state).unwrap();
+        let stored = state
+            .edges
+            .get(&format!("{}:about:derived_memory:{}", entity_id, memory_id))
+            .unwrap();
+        assert_eq!(stored.last_seen_at, timestamp_at("2026-04-28T13:00:00Z"));
     }
 
     #[test]

--- a/src/internal/repositories/retrieval_stats_store.rs
+++ b/src/internal/repositories/retrieval_stats_store.rs
@@ -1,0 +1,612 @@
+use std::collections::HashMap;
+#[cfg(test)]
+use std::sync::OnceLock;
+use std::sync::{Mutex, MutexGuard};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+use crate::api::types::{
+    MemoryId, MemoryLink, MemoryObject, ObjectType, RelationType, RetentionState,
+};
+use crate::errors::CustomError;
+
+#[allow(dead_code)]
+#[async_trait]
+pub(crate) trait RetrievalStatsStore: Send + Sync {
+    async fn record_edges(&self, edges: &[RetrievalStatsEdge]) -> Result<(), CustomError>;
+
+    async fn record_object_states(
+        &self,
+        states: &[RetrievalStatsObjectState],
+    ) -> Result<(), CustomError>;
+
+    async fn counter(
+        &self,
+        key: &RetrievalStatsCounterKey,
+    ) -> Result<Option<RetrievalStatsCounter>, CustomError>;
+
+    async fn health(&self) -> Result<RetrievalStatsHealth, CustomError>;
+
+    async fn mark_unhealthy(&self, message: String) -> Result<(), CustomError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RetrievalStatsEdge {
+    pub(crate) edge_key: String,
+    pub(crate) entity_id: MemoryId,
+    pub(crate) relation_kind: RelationType,
+    pub(crate) object_id: MemoryId,
+    pub(crate) object_type: ObjectType,
+    pub(crate) retention_state: RetentionState,
+    pub(crate) is_current: bool,
+    pub(crate) first_seen_at: DateTime<Utc>,
+    pub(crate) last_seen_at: DateTime<Utc>,
+}
+
+impl RetrievalStatsEdge {
+    pub(crate) fn is_active(&self) -> bool {
+        self.retention_state == RetentionState::Active
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RetrievalStatsObjectState {
+    pub(crate) object_id: MemoryId,
+    pub(crate) object_type: ObjectType,
+    pub(crate) retention_state: RetentionState,
+    pub(crate) is_current: bool,
+    pub(crate) observed_at: DateTime<Utc>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct RetrievalStatsCounterKey {
+    pub(crate) entity_id: MemoryId,
+    pub(crate) relation_kind: RelationType,
+    pub(crate) object_type: ObjectType,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RetrievalStatsCounter {
+    pub(crate) total_count: u64,
+    pub(crate) active_count: u64,
+    pub(crate) current_count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RetrievalStatsHealth {
+    pub(crate) state: RetrievalStatsHealthState,
+    pub(crate) last_error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RetrievalStatsHealthState {
+    Healthy,
+    Unhealthy,
+}
+
+impl Default for RetrievalStatsHealth {
+    fn default() -> Self {
+        Self {
+            state: RetrievalStatsHealthState::Healthy,
+            last_error_message: None,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct NoopRetrievalStatsStore;
+
+#[async_trait]
+impl RetrievalStatsStore for NoopRetrievalStatsStore {
+    async fn record_edges(&self, _edges: &[RetrievalStatsEdge]) -> Result<(), CustomError> {
+        Ok(())
+    }
+
+    async fn record_object_states(
+        &self,
+        _states: &[RetrievalStatsObjectState],
+    ) -> Result<(), CustomError> {
+        Ok(())
+    }
+
+    async fn counter(
+        &self,
+        _key: &RetrievalStatsCounterKey,
+    ) -> Result<Option<RetrievalStatsCounter>, CustomError> {
+        Ok(None)
+    }
+
+    async fn health(&self) -> Result<RetrievalStatsHealth, CustomError> {
+        Ok(RetrievalStatsHealth::default())
+    }
+
+    async fn mark_unhealthy(&self, _message: String) -> Result<(), CustomError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn noop_retrieval_stats_store() -> &'static dyn RetrievalStatsStore {
+    static STORE: OnceLock<NoopRetrievalStatsStore> = OnceLock::new();
+    STORE.get_or_init(NoopRetrievalStatsStore::default)
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct InMemoryRetrievalStatsStore {
+    state: Mutex<InMemoryState>,
+}
+
+impl InMemoryRetrievalStatsStore {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Default)]
+struct InMemoryState {
+    edges: HashMap<String, RetrievalStatsEdge>,
+    health: RetrievalStatsHealth,
+}
+
+#[async_trait]
+impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
+    async fn record_edges(&self, edges: &[RetrievalStatsEdge]) -> Result<(), CustomError> {
+        let mut state = lock(&self.state)?;
+        for edge in edges {
+            state.edges.insert(edge.edge_key.clone(), edge.clone());
+        }
+        state.health = RetrievalStatsHealth::default();
+        Ok(())
+    }
+
+    async fn record_object_states(
+        &self,
+        states: &[RetrievalStatsObjectState],
+    ) -> Result<(), CustomError> {
+        let mut state = lock(&self.state)?;
+        for object_state in states {
+            for edge in state.edges.values_mut() {
+                if edge.object_id == object_state.object_id
+                    && edge.object_type == object_state.object_type
+                {
+                    edge.retention_state = object_state.retention_state;
+                    edge.is_current = object_state.is_current;
+                    edge.last_seen_at = object_state.observed_at;
+                }
+            }
+        }
+        state.health = RetrievalStatsHealth::default();
+        Ok(())
+    }
+
+    async fn counter(
+        &self,
+        key: &RetrievalStatsCounterKey,
+    ) -> Result<Option<RetrievalStatsCounter>, CustomError> {
+        Ok(recomputed_counters(&lock(&self.state)?.edges)
+            .get(key)
+            .copied())
+    }
+
+    async fn health(&self) -> Result<RetrievalStatsHealth, CustomError> {
+        Ok(lock(&self.state)?.health.clone())
+    }
+
+    async fn mark_unhealthy(&self, message: String) -> Result<(), CustomError> {
+        let mut state = lock(&self.state)?;
+        state.health = RetrievalStatsHealth {
+            state: RetrievalStatsHealthState::Unhealthy,
+            last_error_message: Some(message),
+        };
+        Ok(())
+    }
+}
+
+pub(crate) async fn record_stats_after_write(
+    stats_store: &dyn RetrievalStatsStore,
+    objects: &[MemoryObject],
+    links: &[MemoryLink],
+) {
+    let states = retrieval_stats_object_states(objects);
+    if let Err(error) = stats_store.record_object_states(&states).await {
+        let _ = stats_store.mark_unhealthy(error.to_string()).await;
+        return;
+    }
+
+    let edges = retrieval_stats_edges(objects, links);
+    if let Err(error) = stats_store.record_edges(&edges).await {
+        let _ = stats_store.mark_unhealthy(error.to_string()).await;
+    }
+}
+
+pub(crate) fn retrieval_stats_edges(
+    objects: &[MemoryObject],
+    links: &[MemoryLink],
+) -> Vec<RetrievalStatsEdge> {
+    let mut edges = Vec::new();
+    for object in objects {
+        append_intrinsic_edges(&mut edges, object);
+    }
+    for link in links {
+        append_link_edges(&mut edges, link);
+    }
+    edges.sort_by(|left, right| left.edge_key.cmp(&right.edge_key));
+    edges.dedup_by(|left, right| left.edge_key == right.edge_key);
+    edges
+}
+
+pub(crate) fn retrieval_stats_object_states(
+    objects: &[MemoryObject],
+) -> Vec<RetrievalStatsObjectState> {
+    objects.iter().filter_map(object_state).collect()
+}
+
+pub(crate) fn relation_type_key(relation: RelationType) -> &'static str {
+    match relation {
+        RelationType::HasObservation => "has_observation",
+        RelationType::ObservedIn => "observed_in",
+        RelationType::Mentions => "mentions",
+        RelationType::Involves => "involves",
+        RelationType::About => "about",
+        RelationType::DerivedFrom => "derived_from",
+        RelationType::PartOfThread => "part_of_thread",
+        RelationType::Supports => "supports",
+        RelationType::Contradicts => "contradicts",
+        RelationType::Supersedes => "supersedes",
+        RelationType::Resolves => "resolves",
+        RelationType::CreatesOpenLoop => "creates_open_loop",
+        RelationType::FulfillsCommitment => "fulfills_commitment",
+        RelationType::AssociatedWith => "associated_with",
+    }
+}
+
+pub(crate) fn object_type_key(object_type: ObjectType) -> &'static str {
+    match object_type {
+        ObjectType::Episode => "episode",
+        ObjectType::Observation => "observation",
+        ObjectType::Entity => "entity",
+        ObjectType::MemoryThread => "memory_thread",
+        ObjectType::DerivedMemory => "derived_memory",
+        ObjectType::MemoryLink => "memory_link",
+    }
+}
+
+pub(crate) fn retention_state_key(retention_state: RetentionState) -> &'static str {
+    match retention_state {
+        RetentionState::Active => "active",
+        RetentionState::Suppressed => "suppressed",
+        RetentionState::Archived => "archived",
+        RetentionState::Deleted => "deleted",
+    }
+}
+
+fn append_intrinsic_edges(edges: &mut Vec<RetrievalStatsEdge>, object: &MemoryObject) {
+    match object {
+        MemoryObject::Episode(episode) => {
+            for entity_id in &episode.participant_entity_ids {
+                edges.push(edge(
+                    *entity_id,
+                    RelationType::Involves,
+                    episode.id,
+                    ObjectType::Episode,
+                    episode.retention_state,
+                    true,
+                    episode.created_at,
+                ));
+            }
+        }
+        MemoryObject::Observation(observation) => {
+            if let Some(entity_id) = observation.speaker_entity_id {
+                edges.push(edge(
+                    entity_id,
+                    RelationType::Mentions,
+                    observation.id,
+                    ObjectType::Observation,
+                    observation.retention_state,
+                    true,
+                    observation.created_at,
+                ));
+            }
+        }
+        MemoryObject::DerivedMemory(memory) => {
+            for entity_id in &memory.entity_ids {
+                edges.push(edge(
+                    *entity_id,
+                    RelationType::About,
+                    memory.id,
+                    ObjectType::DerivedMemory,
+                    memory.retention_state,
+                    memory.is_current,
+                    memory.created_at,
+                ));
+            }
+        }
+        MemoryObject::Entity(_) | MemoryObject::MemoryThread(_) | MemoryObject::MemoryLink(_) => {}
+    }
+}
+
+fn append_link_edges(edges: &mut Vec<RetrievalStatsEdge>, link: &MemoryLink) {
+    if link.from_type == ObjectType::Entity && link.to_type != ObjectType::MemoryLink {
+        edges.push(edge(
+            link.from_id,
+            link.relation,
+            link.to_id,
+            link.to_type,
+            RetentionState::Active,
+            true,
+            link.created_at,
+        ));
+    }
+    if link.to_type == ObjectType::Entity && link.from_type != ObjectType::MemoryLink {
+        edges.push(edge(
+            link.to_id,
+            link.relation,
+            link.from_id,
+            link.from_type,
+            RetentionState::Active,
+            true,
+            link.created_at,
+        ));
+    }
+}
+
+fn edge(
+    entity_id: MemoryId,
+    relation_kind: RelationType,
+    object_id: MemoryId,
+    object_type: ObjectType,
+    retention_state: RetentionState,
+    is_current: bool,
+    observed_at: DateTime<Utc>,
+) -> RetrievalStatsEdge {
+    RetrievalStatsEdge {
+        edge_key: format!(
+            "{}:{}:{}:{}",
+            entity_id,
+            relation_type_key(relation_kind),
+            object_type_key(object_type),
+            object_id
+        ),
+        entity_id,
+        relation_kind,
+        object_id,
+        object_type,
+        retention_state,
+        is_current,
+        first_seen_at: observed_at,
+        last_seen_at: observed_at,
+    }
+}
+
+fn object_state(object: &MemoryObject) -> Option<RetrievalStatsObjectState> {
+    match object {
+        MemoryObject::Episode(object) => Some(RetrievalStatsObjectState {
+            object_id: object.id,
+            object_type: ObjectType::Episode,
+            retention_state: object.retention_state,
+            is_current: true,
+            observed_at: object.created_at,
+        }),
+        MemoryObject::Observation(object) => Some(RetrievalStatsObjectState {
+            object_id: object.id,
+            object_type: ObjectType::Observation,
+            retention_state: object.retention_state,
+            is_current: true,
+            observed_at: object.created_at,
+        }),
+        MemoryObject::DerivedMemory(object) => Some(RetrievalStatsObjectState {
+            object_id: object.id,
+            object_type: ObjectType::DerivedMemory,
+            retention_state: object.retention_state,
+            is_current: object.is_current,
+            observed_at: object.updated_at,
+        }),
+        MemoryObject::Entity(_) | MemoryObject::MemoryThread(_) | MemoryObject::MemoryLink(_) => {
+            None
+        }
+    }
+}
+
+fn recomputed_counters(
+    edges: &HashMap<String, RetrievalStatsEdge>,
+) -> HashMap<RetrievalStatsCounterKey, RetrievalStatsCounter> {
+    let mut counters = HashMap::new();
+    for edge in edges.values() {
+        let key = RetrievalStatsCounterKey {
+            entity_id: edge.entity_id,
+            relation_kind: edge.relation_kind,
+            object_type: edge.object_type,
+        };
+        let counter = counters
+            .entry(key)
+            .or_insert_with(RetrievalStatsCounter::default);
+        counter.total_count += 1;
+        if edge.is_active() {
+            counter.active_count += 1;
+        }
+        if edge.is_active() && edge.is_current {
+            counter.current_count += 1;
+        }
+    }
+    counters
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, CustomError> {
+    mutex
+        .lock()
+        .map_err(|_| CustomError::DatabaseError("retrieval stats mutex was poisoned".to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::{
+        DerivedMemory, DerivedType, Episode, Modality, Stability, DEFAULT_SCHEMA_VERSION,
+    };
+
+    #[tokio::test]
+    async fn in_memory_store_counts_edges_idempotently() {
+        let store = InMemoryRetrievalStatsStore::new();
+        let entity_id = id("550e8400-e29b-41d4-a716-446655460001");
+        let episode_id = id("550e8400-e29b-41d4-a716-446655460002");
+        let edge = edge(
+            entity_id,
+            RelationType::Involves,
+            episode_id,
+            ObjectType::Episode,
+            RetentionState::Active,
+            true,
+            timestamp(),
+        );
+
+        store
+            .record_edges(std::slice::from_ref(&edge))
+            .await
+            .unwrap();
+        store
+            .record_edges(std::slice::from_ref(&edge))
+            .await
+            .unwrap();
+
+        let counter = store
+            .counter(&RetrievalStatsCounterKey {
+                entity_id,
+                relation_kind: RelationType::Involves,
+                object_type: ObjectType::Episode,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(counter.total_count, 1);
+        assert_eq!(counter.active_count, 1);
+        assert_eq!(counter.current_count, 1);
+    }
+
+    #[tokio::test]
+    async fn in_memory_store_updates_lifecycle_counts() {
+        let store = InMemoryRetrievalStatsStore::new();
+        let entity_id = id("550e8400-e29b-41d4-a716-446655460011");
+        let memory_id = id("550e8400-e29b-41d4-a716-446655460012");
+        store
+            .record_edges(&[edge(
+                entity_id,
+                RelationType::About,
+                memory_id,
+                ObjectType::DerivedMemory,
+                RetentionState::Active,
+                true,
+                timestamp(),
+            )])
+            .await
+            .unwrap();
+        store
+            .record_object_states(&[RetrievalStatsObjectState {
+                object_id: memory_id,
+                object_type: ObjectType::DerivedMemory,
+                retention_state: RetentionState::Suppressed,
+                is_current: false,
+                observed_at: timestamp(),
+            }])
+            .await
+            .unwrap();
+
+        let counter = store
+            .counter(&RetrievalStatsCounterKey {
+                entity_id,
+                relation_kind: RelationType::About,
+                object_type: ObjectType::DerivedMemory,
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(counter.total_count, 1);
+        assert_eq!(counter.active_count, 0);
+        assert_eq!(counter.current_count, 0);
+    }
+
+    #[test]
+    fn derives_entity_edges_from_objects_and_links() {
+        let entity_id = id("550e8400-e29b-41d4-a716-446655460021");
+        let episode_id = id("550e8400-e29b-41d4-a716-446655460022");
+        let memory_id = id("550e8400-e29b-41d4-a716-446655460023");
+        let objects = vec![
+            MemoryObject::Episode(Episode {
+                id: episode_id,
+                object_type: ObjectType::Episode,
+                modality: Modality::Chat,
+                source_conversation_id: None,
+                started_at: None,
+                ended_at: None,
+                participant_entity_ids: vec![entity_id],
+                summary: "episode".to_owned(),
+                raw_ref: None,
+                salience_score: 0.5,
+                retention_state: RetentionState::Active,
+                created_at: timestamp(),
+                schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+            }),
+            MemoryObject::DerivedMemory(DerivedMemory {
+                id: memory_id,
+                object_type: ObjectType::DerivedMemory,
+                derived_type: DerivedType::Reflection,
+                text: "memory".to_owned(),
+                derived_from_episode_ids: vec![episode_id],
+                derived_from_observation_ids: Vec::new(),
+                thread_ids: Vec::new(),
+                entity_ids: vec![entity_id],
+                confidence: 0.7,
+                salience_score: 0.7,
+                stability: Stability::Medium,
+                is_current: true,
+                supersedes: Vec::new(),
+                retention_state: RetentionState::Active,
+                created_at: timestamp(),
+                updated_at: timestamp(),
+                schema_version: DEFAULT_SCHEMA_VERSION.to_owned(),
+            }),
+        ];
+
+        let edges = retrieval_stats_edges(&objects, &[]);
+
+        assert_eq!(edges.len(), 2);
+        assert!(edges.iter().any(|edge| {
+            edge.entity_id == entity_id
+                && edge.relation_kind == RelationType::Involves
+                && edge.object_id == episode_id
+        }));
+        assert!(edges.iter().any(|edge| {
+            edge.entity_id == entity_id
+                && edge.relation_kind == RelationType::About
+                && edge.object_id == memory_id
+        }));
+    }
+
+    #[tokio::test]
+    async fn health_tracks_internal_failure_markers() {
+        let store = InMemoryRetrievalStatsStore::new();
+        store
+            .mark_unhealthy("stats write failed".to_owned())
+            .await
+            .unwrap();
+
+        let health = store.health().await.unwrap();
+        assert_eq!(health.state, RetrievalStatsHealthState::Unhealthy);
+        assert_eq!(
+            health.last_error_message.as_deref(),
+            Some("stats write failed")
+        );
+    }
+
+    fn id(value: &str) -> MemoryId {
+        uuid::Uuid::parse_str(value).unwrap()
+    }
+
+    fn timestamp() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-04-28T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+}

--- a/src/internal/repositories/retrieval_stats_store.rs
+++ b/src/internal/repositories/retrieval_stats_store.rs
@@ -172,7 +172,7 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
     async fn record_edges(&self, edges: &[RetrievalStatsEdge]) -> Result<(), CustomError> {
         let mut state = lock(&self.state)?;
         for edge in edges {
-            state.edges.insert(edge.edge_key.clone(), edge.clone());
+            insert_edge(&mut state.edges, edge.clone());
         }
         state.mark_healthy_after_success();
         Ok(())
@@ -585,6 +585,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn in_memory_store_merges_duplicate_edge_timestamps() {
+        let store = InMemoryRetrievalStatsStore::new();
+        let entity_id = id("550e8400-e29b-41d4-a716-446655460041");
+        let episode_id = id("550e8400-e29b-41d4-a716-446655460042");
+        let later_edge = edge(
+            entity_id,
+            RelationType::Involves,
+            episode_id,
+            ObjectType::Episode,
+            RetentionState::Active,
+            true,
+            timestamp_at("2026-04-28T13:00:00Z"),
+        );
+        let earlier_edge = edge(
+            entity_id,
+            RelationType::Involves,
+            episode_id,
+            ObjectType::Episode,
+            RetentionState::Active,
+            true,
+            timestamp_at("2026-04-28T11:00:00Z"),
+        );
+
+        store.record_edges(&[later_edge]).await.unwrap();
+        store.record_edges(&[earlier_edge]).await.unwrap();
+
+        let state = lock(&store.state).unwrap();
+        let stored = state
+            .edges
+            .get(&format!("{}:involves:episode:{}", entity_id, episode_id))
+            .unwrap();
+        assert_eq!(stored.first_seen_at, timestamp_at("2026-04-28T11:00:00Z"));
+        assert_eq!(stored.last_seen_at, timestamp_at("2026-04-28T13:00:00Z"));
+    }
+
+    #[tokio::test]
     async fn in_memory_store_updates_lifecycle_counts() {
         let store = InMemoryRetrievalStatsStore::new();
         let entity_id = id("550e8400-e29b-41d4-a716-446655460011");
@@ -827,7 +863,11 @@ mod tests {
     }
 
     fn timestamp() -> DateTime<Utc> {
-        DateTime::parse_from_rfc3339("2026-04-28T12:00:00Z")
+        timestamp_at("2026-04-28T12:00:00Z")
+    }
+
+    fn timestamp_at(value: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(value)
             .unwrap()
             .with_timezone(&Utc)
     }

--- a/src/internal/repositories/retrieval_stats_store.rs
+++ b/src/internal/repositories/retrieval_stats_store.rs
@@ -176,6 +176,9 @@ impl InMemoryRetrievalStatsStore {
 #[derive(Debug, Default)]
 struct InMemoryState {
     edges: HashMap<String, RetrievalStatsEdge>,
+    counters: HashMap<RetrievalStatsCounterKey, RetrievalStatsCounter>,
+    global_counters: HashMap<(RelationType, ObjectType), RetrievalStatsCounter>,
+    counters_dirty: bool,
     health: RetrievalStatsHealth,
 }
 
@@ -186,6 +189,7 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
         for edge in edges {
             insert_edge(&mut state.edges, edge.clone());
         }
+        state.counters_dirty = true;
         Ok(())
     }
 
@@ -205,6 +209,7 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
                 }
             }
         }
+        state.counters_dirty = true;
         Ok(())
     }
 
@@ -212,9 +217,9 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
         &self,
         key: &RetrievalStatsCounterKey,
     ) -> Result<Option<RetrievalStatsCounter>, CustomError> {
-        Ok(recomputed_counters(&lock(&self.state)?.edges)
-            .get(key)
-            .copied())
+        let mut state = lock(&self.state)?;
+        state.refresh_counters_if_dirty();
+        Ok(state.counters.get(key).copied())
     }
 
     async fn global_counter(
@@ -222,7 +227,10 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
         relation_kind: RelationType,
         object_type: ObjectType,
     ) -> Result<Option<RetrievalStatsCounter>, CustomError> {
-        Ok(recomputed_global_counters(&lock(&self.state)?.edges)
+        let mut state = lock(&self.state)?;
+        state.refresh_counters_if_dirty();
+        Ok(state
+            .global_counters
             .get(&(relation_kind, object_type))
             .copied())
     }
@@ -238,6 +246,18 @@ impl RetrievalStatsStore for InMemoryRetrievalStatsStore {
             last_error_message: Some(message),
         };
         Ok(())
+    }
+}
+
+impl InMemoryState {
+    fn refresh_counters_if_dirty(&mut self) {
+        if !self.counters_dirty {
+            return;
+        }
+
+        self.counters = recomputed_counters(&self.edges);
+        self.global_counters = recomputed_global_counters(&self.edges);
+        self.counters_dirty = false;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,9 @@ use crate::internal::infrastructures::graph::{
 use crate::internal::infrastructures::retrieval_stats::SqliteRetrievalStatsStore;
 use crate::internal::models::vector::EmbeddingInput;
 use crate::internal::repositories::{
-    CorrectionForgetPipeline, GraphAuthorityStore, LinkPipeline, MemoryEmbedder, RememberPipeline,
-    RememberPipelineDraft, RetrievalStatsStore, RetrievePipeline, VectorCandidateStore,
+    CorrectionForgetPipeline, GraphAuthorityStore, InMemoryRetrievalStatsStore, LinkPipeline,
+    MemoryEmbedder, RememberPipeline, RememberPipelineDraft, RetrievalStatsStore, RetrievePipeline,
+    VectorCandidateStore,
 };
 
 // Re-export types for public use
@@ -324,12 +325,15 @@ impl CharacterMemory {
 
 fn retrieval_stats_store(settings: &Settings) -> Result<Box<dyn RetrievalStatsStore>, CustomError> {
     match settings.get_retrieval_stats_store_mode() {
-        ConfigRetrievalStatsStoreMode::Sqlite => Ok(Box::new(SqliteRetrievalStatsStore::open(
-            settings.get_retrieval_stats_path(),
-        )?)),
-        ConfigRetrievalStatsStoreMode::InMemory => Ok(Box::new(
-            crate::internal::repositories::InMemoryRetrievalStatsStore::new(),
-        )),
+        ConfigRetrievalStatsStoreMode::Sqlite => {
+            match SqliteRetrievalStatsStore::open(settings.get_retrieval_stats_path()) {
+                Ok(store) => Ok(Box::new(store)),
+                Err(error) => Ok(Box::new(InMemoryRetrievalStatsStore::unhealthy(format!(
+                    "sqlite retrieval stats unavailable; using in-memory fallback: {error}"
+                )))),
+            }
+        }
+        ConfigRetrievalStatsStoreMode::InMemory => Ok(Box::new(InMemoryRetrievalStatsStore::new())),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,9 +328,13 @@ fn retrieval_stats_store(settings: &Settings) -> Result<Box<dyn RetrievalStatsSt
         ConfigRetrievalStatsStoreMode::Sqlite => {
             match SqliteRetrievalStatsStore::open(settings.get_retrieval_stats_path()) {
                 Ok(store) => Ok(Box::new(store)),
-                Err(error) => Ok(Box::new(InMemoryRetrievalStatsStore::unhealthy(format!(
-                    "sqlite retrieval stats unavailable; using in-memory fallback: {error}"
-                )))),
+                Err(error) => match settings.get_retrieval_stats_health_fail_mode() {
+                    RetrievalStatsHealthFailMode::Conservative => {
+                        Ok(Box::new(InMemoryRetrievalStatsStore::unhealthy(format!(
+                            "sqlite retrieval stats unavailable; using in-memory fallback: {error}"
+                        ))))
+                    }
+                },
             }
         }
         ConfigRetrievalStatsStoreMode::InMemory => Ok(Box::new(InMemoryRetrievalStatsStore::new())),
@@ -725,6 +729,43 @@ mod tests {
             CustomError::EmbeddingInitializationError(message)
                 if message.contains("8") && message.contains("1536")
         ));
+    }
+
+    #[tokio::test]
+    async fn sqlite_stats_open_failure_uses_configured_conservative_fallback() {
+        let settings = Settings::new(
+            ::config::Config::builder()
+                .set_override("qdrant_connection_string", "external_qdrant")
+                .unwrap()
+                .set_override("oxigraph_connection_string", "external_oxigraph")
+                .unwrap()
+                .set_override("openai_api_key", "external_openai")
+                .unwrap()
+                .set_override("embedding_model", "TextEmbedding3Small")
+                .unwrap()
+                .set_override("retrieval_stats_store_mode", "sqlite")
+                .unwrap()
+                .set_override("retrieval_stats_path", ".")
+                .unwrap()
+                .set_override("retrieval_stats_health_fail_mode", "conservative")
+                .unwrap()
+                .build()
+                .unwrap(),
+        )
+        .unwrap();
+
+        let store = retrieval_stats_store(&settings).unwrap();
+        let health = store.health().await.unwrap();
+
+        assert_eq!(
+            health.state,
+            crate::internal::repositories::RetrievalStatsHealthState::Unhealthy
+        );
+        assert!(health
+            .last_error_message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("using in-memory fallback"));
     }
 
     fn injected_memory() -> CharacterMemory {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,17 +7,21 @@ mod internal;
 
 use async_trait::async_trait;
 
-use crate::config::settings::{EmbeddingProviderSettings, GraphStoreMode as ConfigGraphStoreMode};
+use crate::config::settings::{
+    EmbeddingProviderSettings, GraphStoreMode as ConfigGraphStoreMode,
+    RetrievalStatsStoreMode as ConfigRetrievalStatsStoreMode,
+};
 use crate::internal::infrastructures::external_services::{
     OpenAIEmbeddingProvider, QdrantVectorCandidateStore,
 };
 use crate::internal::infrastructures::graph::{
     OxigraphGraphAuthorityStore, OxigraphHttpGraphAuthorityStore,
 };
+use crate::internal::infrastructures::retrieval_stats::SqliteRetrievalStatsStore;
 use crate::internal::models::vector::EmbeddingInput;
 use crate::internal::repositories::{
     CorrectionForgetPipeline, GraphAuthorityStore, LinkPipeline, MemoryEmbedder, RememberPipeline,
-    RememberPipelineDraft, RetrievePipeline, VectorCandidateStore,
+    RememberPipelineDraft, RetrievalStatsStore, RetrievePipeline, VectorCandidateStore,
 };
 
 // Re-export types for public use
@@ -45,7 +49,9 @@ pub use crate::api::types::{
     VectorIndexingFailure, VectorMaintenanceFailure, CURRENT_SCHEMA_VERSION,
     DEFAULT_SCHEMA_VERSION, EPISODIC_MEMORY_SCHEMA_VERSION,
 };
-pub use crate::config::settings::{GraphStoreMode, Settings};
+pub use crate::config::settings::{
+    GraphStoreMode, RetrievalStatsHealthFailMode, RetrievalStatsStoreMode, Settings,
+};
 pub use crate::errors::CustomError;
 
 // Re-export for integration tests
@@ -88,6 +94,7 @@ struct MemoryComposition {
     graph_store: Box<dyn GraphAuthorityStore>,
     vector_store: Box<dyn VectorCandidateStore>,
     embedder: Box<dyn MemoryEmbedder>,
+    stats_store: Box<dyn RetrievalStatsStore>,
 }
 
 struct EmbeddingProviderMemoryEmbedder {
@@ -114,6 +121,7 @@ impl MemoryEmbedder for EmbeddingProviderMemoryEmbedder {
 
 impl CharacterMemory {
     /// Builds CharacterMemory from provider-neutral graph, vector, and embedder parts.
+    #[cfg(test)]
     pub(crate) fn from_parts(
         graph_store: Box<dyn GraphAuthorityStore>,
         vector_store: Box<dyn VectorCandidateStore>,
@@ -124,6 +132,25 @@ impl CharacterMemory {
                 graph_store,
                 vector_store,
                 embedder,
+                stats_store: Box::new(
+                    crate::internal::repositories::InMemoryRetrievalStatsStore::new(),
+                ),
+            },
+        }
+    }
+
+    fn from_parts_with_stats(
+        graph_store: Box<dyn GraphAuthorityStore>,
+        vector_store: Box<dyn VectorCandidateStore>,
+        embedder: Box<dyn MemoryEmbedder>,
+        stats_store: Box<dyn RetrievalStatsStore>,
+    ) -> Self {
+        Self {
+            memory_composition: MemoryComposition {
+                graph_store,
+                vector_store,
+                embedder,
+                stats_store,
             },
         }
     }
@@ -183,11 +210,13 @@ impl CharacterMemory {
                 Box::new(OxigraphGraphAuthorityStore::new_in_memory()?)
             }
         };
+        let stats_store = retrieval_stats_store(&settings)?;
 
-        Ok(Self::from_parts(
+        Ok(Self::from_parts_with_stats(
             graph_store,
             Box::new(vector_store),
             Box::new(EmbeddingProviderMemoryEmbedder::new(embed_provider)),
+            stats_store,
         ))
     }
 
@@ -218,10 +247,11 @@ impl CharacterMemory {
     /// Persists a remember draft through the graph-authoritative write pipeline.
     pub async fn remember(&self, draft: RememberDraft) -> Result<RememberOutcome, CustomError> {
         let parts = self.memory_composition();
-        let pipeline = RememberPipeline::new(
+        let pipeline = RememberPipeline::new_with_stats(
             parts.graph_store.as_ref(),
             parts.vector_store.as_ref(),
             parts.embedder.as_ref(),
+            parts.stats_store.as_ref(),
         );
         let outcome = pipeline
             .remember(RememberPipelineDraft::new(
@@ -235,7 +265,7 @@ impl CharacterMemory {
     /// Persists a canonical typed relationship through the graph-authoritative link pipeline.
     pub async fn link(&self, draft: MemoryLinkDraft) -> Result<MemoryLink, CustomError> {
         let parts = self.memory_composition();
-        LinkPipeline::new(parts.graph_store.as_ref())
+        LinkPipeline::new_with_stats(parts.graph_store.as_ref(), parts.stats_store.as_ref())
             .link(draft)
             .await
     }
@@ -261,10 +291,11 @@ impl CharacterMemory {
         draft: CorrectMemoryDraft,
     ) -> Result<LifecycleMutationOutcome, CustomError> {
         let parts = self.memory_composition();
-        CorrectionForgetPipeline::new(
+        CorrectionForgetPipeline::new_with_stats(
             parts.graph_store.as_ref(),
             parts.vector_store.as_ref(),
             parts.embedder.as_ref(),
+            parts.stats_store.as_ref(),
         )
         .correct(draft)
         .await
@@ -276,10 +307,11 @@ impl CharacterMemory {
         draft: ForgetMemoryDraft,
     ) -> Result<LifecycleMutationOutcome, CustomError> {
         let parts = self.memory_composition();
-        CorrectionForgetPipeline::new(
+        CorrectionForgetPipeline::new_with_stats(
             parts.graph_store.as_ref(),
             parts.vector_store.as_ref(),
             parts.embedder.as_ref(),
+            parts.stats_store.as_ref(),
         )
         .forget(draft)
         .await
@@ -287,6 +319,17 @@ impl CharacterMemory {
 
     fn memory_composition(&self) -> &MemoryComposition {
         &self.memory_composition
+    }
+}
+
+fn retrieval_stats_store(settings: &Settings) -> Result<Box<dyn RetrievalStatsStore>, CustomError> {
+    match settings.get_retrieval_stats_store_mode() {
+        ConfigRetrievalStatsStoreMode::Sqlite => Ok(Box::new(SqliteRetrievalStatsStore::open(
+            settings.get_retrieval_stats_path(),
+        )?)),
+        ConfigRetrievalStatsStoreMode::InMemory => Ok(Box::new(
+            crate::internal::repositories::InMemoryRetrievalStatsStore::new(),
+        )),
     }
 }
 


### PR DESCRIPTION
## Summary
- add internal retrieval stats store contract with in-memory and bundled SQLite implementations
- add retrieval stats settings, conservative health fail mode, and selectivity constants
- wire remember/link/correction/forget write paths to update stats after graph/vector work without changing public outcomes

## Validation
- cargo fmt --check
- cargo check
- cargo test settings --no-fail-fast
- cargo test retrieval_stats --no-fail-fast
- cargo test remember_pipeline --no-fail-fast
- cargo test link_pipeline --no-fail-fast
- cargo test correction_forget_pipeline --no-fail-fast
- CARGO_INCREMENTAL=0 cargo test --no-run

## Notes
- Full cargo test currently fails live integration tests because local Qdrant is not running at 127.0.0.1:6334.