### PR TITLE
📝 Add v0.1 closeout roadmap and memory permanence ADR

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Character Memory is not:
 
 It is a memory layer for persistent AI assistants and companions.
 
+## Memory permanence and data erasure
+
+Character Memory treats the memory record as append-only. Forgetting works through suppression, supersession, and decay — it removes influence, not history. There is no destructive deletion in the memory operations, because deleting memory rewrites a character's perceived history and breaks continuity.
+
+Applications with personal-data erasure obligations (for example GDPR/CCPA deletion requests) own that compliance policy themselves. Erasure is an out-of-band operational action, not a memory operation; see ADR-D-0017 in `docs/decisions/` for the full decision and its boundaries.
+
 ## Typical usage
 
 A typical assistant loop looks like this:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ It is a memory layer for persistent AI assistants and companions.
 
 ## Memory permanence and data erasure
 
-Character Memory treats the memory record as append-only. Forgetting works through suppression, supersession, and decay — it removes influence, not history. There is no destructive deletion in the memory operations, because deleting memory rewrites a character's perceived history and breaks continuity.
+Character Memory treats the memory record as append-only. Forgetting works through suppression, archival, supersession, and decay — it removes influence, not history. There is no destructive deletion in the memory operations, because deleting memory rewrites a character's perceived history and breaks continuity.
 
 Applications with personal-data erasure obligations (for example, GDPR/CCPA deletion requests) own that compliance policy themselves. Erasure is an out-of-band operational action, not a memory operation; see [ADR-D-0017](docs/decisions/design/ADR-D-0017-append-only-memory-record-with-out-of-band-purge.md) for the full decision and its boundaries.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ It is a memory layer for persistent AI assistants and companions.
 
 Character Memory treats the memory record as append-only. Forgetting works through suppression, supersession, and decay — it removes influence, not history. There is no destructive deletion in the memory operations, because deleting memory rewrites a character's perceived history and breaks continuity.
 
-Applications with personal-data erasure obligations (for example GDPR/CCPA deletion requests) own that compliance policy themselves. Erasure is an out-of-band operational action, not a memory operation; see ADR-D-0017 in `docs/decisions/` for the full decision and its boundaries.
+Applications with personal-data erasure obligations (for example, GDPR/CCPA deletion requests) own that compliance policy themselves. Erasure is an out-of-band operational action, not a memory operation; see [ADR-D-0017](docs/decisions/design/ADR-D-0017-append-only-memory-record-with-out-of-band-purge.md) for the full decision and its boundaries.
 
 ## Typical usage
 

--- a/docs/coding-agent/lessons.md
+++ b/docs/coding-agent/lessons.md
@@ -21,6 +21,29 @@ Purpose:
 
 ## Entries
 
+## 2026-06-14 - Prefer Root-Cause Fixes Over Symptom Patches  [tags: maintainability, review, validation]
+
+Context:
+- Plan: v0.1.2 closeout divergence fixes
+- Task/Wave: PR review and CI remediation follow-up
+- Roles involved: Orchestrator
+
+Symptom:
+- A warning-deny CI failure was initially approached with a broad suppression attribute before stepping back to consider whether the test helper structure itself was the root cause.
+
+Root cause:
+- Treated the immediate failing warning as the problem, instead of first asking what design or ownership boundary made the warning appear.
+
+Fix applied:
+- Reworked the integration test support layout so each test target imports only the helpers it needs, eliminating the warning naturally.
+
+Prevention:
+- When fixing a defect, first identify the smallest root cause that explains the symptom. Prefer structural or semantic fixes over suppressions, wrappers, retries, or local patches that merely hide the failure.
+- Use symptom patches only when the root cause is out of scope, externally owned, or explicitly accepted as a tradeoff; document that decision.
+
+Evidence:
+- The test support split removed the need for `dead_code` allowances and passed Clippy/test-target validation with warnings denied.
+
 ## 2026-06-14 - Prefer Targeted Test Support Modules Over Broad `dead_code` Allows  [tags: validation, ci, maintainability]
 
 Context:

--- a/docs/coding-agent/lessons.md
+++ b/docs/coding-agent/lessons.md
@@ -21,6 +21,72 @@ Purpose:
 
 ## Entries
 
+## 2026-06-12 - Cast usize To i64 For config Crate set_override In Test Settings  [tags: tooling, validation]
+
+Context:
+- Plan: v0.1.2 closeout divergence fixes
+- Task/Wave: Task_3 facade integration tests
+- Roles involved: Worker
+
+Symptom:
+- Integration test compilation failed when passing `usize` values to `config::ConfigBuilder::set_override`.
+
+Root cause:
+- The config crate's `Value` conversion supports signed integer types such as `i64` but not `usize`.
+
+Fix applied:
+- Cast fanout override values to `i64` before calling `set_override`.
+
+Prevention:
+- When constructing test `Settings` through `config::ConfigBuilder`, cast `usize` numeric overrides to `i64` or another supported config value type.
+
+Evidence:
+- tests/test_utils.rs helper compiles and full validation passes after the cast.
+
+## 2026-06-12 - Constrain Graph Roots When Asserting Entity-Root Fanout  [tags: planning, validation]
+
+Context:
+- Plan: v0.1.2 closeout divergence fixes
+- Task/Wave: Task_3 facade integration tests
+- Roles involved: Worker
+
+Symptom:
+- A fanout-override assertion failed because returned derived memories were also reachable through additional vector roots, masking the entity-root fanout constraint.
+
+Root cause:
+- The retrieval context allowed multiple graph roots while the test intended to isolate entity-root selectivity behavior.
+
+Fix applied:
+- Limited the test retrieval context to a single selected entity graph root.
+
+Prevention:
+- Facade tests for entity-root-only selectivity should constrain graph root selection enough to isolate the entity root under test.
+
+Evidence:
+- tests/v0_1_2_retrieval_guardrails_tests.rs fanout scenario passes with traced fanout and result-count assertions.
+
+## 2026-06-12 - Start Qdrant Before Full cargo test Validation  [tags: validation, tooling]
+
+Context:
+- Plan: v0.1.2 closeout divergence fixes
+- Task/Wave: Task_1 required validation
+- Roles involved: Worker
+
+Symptom:
+- `cargo test` failed in tests/initialization_tests.rs because Qdrant was configured but unreachable at localhost:6334; the failure surfaced as a wrapped Qdrant transport error instead of a clean skip.
+
+Root cause:
+- Live-gated integration tests can fail rather than skip when Qdrant configuration resolves but the service is down.
+
+Fix applied:
+- Started Qdrant with `docker compose -f docker-compose.qdrant.yml up -d` and reran the exact required validation command.
+
+Prevention:
+- Before full `cargo test` validation, verify local Qdrant is up (`docker compose -f docker-compose.qdrant.yml ps`) and start it if needed.
+
+Evidence:
+- Final validation runs in Task_1, Task_3, and Task_4 all passed with Qdrant running.
+
 ## 2026-05-10 - Dispatch Research Before Broad Discovery On Non-Trivial Work  [tags: workflow, planning, delegation]
 
 Context:

--- a/docs/coding-agent/lessons.md
+++ b/docs/coding-agent/lessons.md
@@ -21,7 +21,7 @@ Purpose:
 
 ## Entries
 
-## 2026-06-12 - Cast usize To i64 For config Crate set_override In Test Settings  [tags: tooling, validation]
+## 2026-06-12 - Cast `usize` To `i64` For `config` Crate `set_override` In Test Settings  [tags: tooling, validation]
 
 Context:
 - Plan: v0.1.2 closeout divergence fixes

--- a/docs/coding-agent/lessons.md
+++ b/docs/coding-agent/lessons.md
@@ -21,6 +21,28 @@ Purpose:
 
 ## Entries
 
+## 2026-06-14 - Prefer Targeted Test Support Modules Over Broad `dead_code` Allows  [tags: validation, ci, maintainability]
+
+Context:
+- Plan: v0.1.2 closeout divergence fixes
+- Task/Wave: PR #53 review and CI remediation
+- Roles involved: Orchestrator
+
+Symptom:
+- Initial CI remediation used a broad `#![allow(dead_code)]` in the shared integration test helper module to silence warnings denied by Clippy and test target compilation.
+
+Root cause:
+- `tests/test_utils.rs` was compiled both as a standalone integration test target and as a helper module in each integration test. Different targets used different helper subsets, causing warning-deny failures. The first fix treated the warning as noise instead of the helper layout as the design problem.
+
+Fix applied:
+- Replaced the catch-all integration helper target with targeted modules under `tests/support/`, so each integration test imports only the helper set it needs.
+
+Prevention:
+- When CI fails under `-D warnings`, first ask whether the code layout can avoid the warning naturally. Use `allow` attributes only when unused code is intentional and no cleaner structure exists.
+
+Evidence:
+- `cargo clippy --all-targets -- -D warnings`, `cargo test --no-run`, and `cargo test` pass after splitting test support modules without any dead-code allowance.
+
 ## 2026-06-12 - Cast `usize` To `i64` For `config` Crate `set_override` In Test Settings  [tags: tooling, validation]
 
 Context:

--- a/docs/coding-agent/plans/completed/v0-1-2-closeout-divergence-fixes-plan.md
+++ b/docs/coding-agent/plans/completed/v0-1-2-closeout-divergence-fixes-plan.md
@@ -1,0 +1,191 @@
+# Plan: v0.1.2 Closeout Divergence Fixes
+
+- status: done
+- generated: 2026-06-12
+- last_updated: 2026-06-12
+- work_type: mixed
+
+## Goal
+- Close the known divergences between the v0.1.2 design documents and the implemented code before starting v0.1.3: externally configurable fanout budgets, documented selectivity scope boundary, facade-level integration coverage for v0.1.2 behavior, and design-doc consistency notes.
+
+## Definition of Done
+- Per relation/object fanout budgets are configurable through settings, with current hard-coded values preserved as defaults.
+- The entity-root-only selectivity scope is explicitly documented as the intended v0.1.2 boundary.
+- Facade-level integration tests cover stats persistence/reopen, restart-safe retrieval exclusion behavior, and selectivity-influenced retrieval.
+- `associated_with` admission constraints and the retrieval-trace boundary are documented consistently across the phase design docs.
+- Full validation passes: `cargo fmt --check`, `cargo check`, `cargo test`.
+- Reviewer approves the closeout against v0.1.2 acceptance criteria.
+
+## Scope / Non-goals
+- Scope:
+  - Configuration surface for existing fanout specs (`About -> DerivedMemory`, `Involves -> Episode`, `PartOfThread -> DerivedMemory`) plus a documented default for unlisted pairs.
+  - Documentation alignment in `docs/design/roadmap-phases/` and `docs/design/database/` where affected.
+  - New integration tests under `tests/`.
+- Non-goals:
+  - Widening selectivity beyond entity-root candidates (documented boundary instead; revisit in v0.1.5 with eval data).
+  - New retrieval signals, fanout formula changes, or selectivity math changes.
+  - Public reconciliation/diagnostics facade.
+  - Any v0.1.3 write-plan work.
+  - Destructive deletion (permanently out of scope by project direction).
+
+## Context (workspace)
+- Related files/areas:
+  - `src/internal/repositories/retrieval_selectivity.rs` (hard-coded `fanout_specs()`)
+  - `src/config/settings/app_settings.rs` (existing stats/selectivity config patterns)
+  - `src/internal/repositories/retrieve_pipeline.rs` (selectivity integration)
+  - `tests/initialization_tests.rs`, `tests/v0_1_public_facade_tests.rs` (live-service-gated test pattern)
+  - `docs/design/roadmap-phases/v0_1_2_continuous_entity_selectivity_retrieval_guardrails.md`
+  - `docs/design/roadmap-phases/v0_1_starter_episodic_memory.md`
+  - `docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md`
+  - `docs/design/roadmap-phases/v0_4_retrieval_observability_governance.md`
+  - `docs/roadmap/development_roadmap.md` (conceptual `[retrieval.fanout.*]` config shape)
+- Existing patterns or references:
+  - Stats config already follows `[retrieval.stats]` / `[retrieval.selectivity]` conceptual shapes with env/config wiring in `app_settings.rs`.
+  - Integration tests skip when Qdrant is unavailable; follow the same gating for new tests.
+  - Conservative fallback (fanout <= 1) on missing/unhealthy stats must remain unchanged.
+- Repo reference docs consulted:
+  - `docs/coding-agent/rules/common.md`
+  - `docs/coding-agent/rules/orchestrator.md`
+  - `docs/coding-agent/lessons.md`
+
+## Open Questions (max 3)
+- Q1: Should `Cargo.toml` crate version be bumped (currently `0.1.0` while capability is roadmap v0.1.2), or is crate version intentionally decoupled from roadmap phases?
+
+## Resolved Decisions
+- Selectivity remains entity-root-only in v0.1.2; the fix is to document this boundary explicitly rather than widen behavior. Widening is revisited in v0.1.5 with eval-harness data.
+- Fanout configuration uses the roadmap's conceptual TOML shape (`[retrieval.fanout.<relation>.<object_type>]` with `min`/`max`), mapped onto the existing settings infrastructure. Unknown/unlisted relation-object pairs keep current built-in behavior.
+- `associated_with` remains in the v0.1 relation vocabulary but is documented as admissible only with stronger evidence or explicit application intent until v0.5 associative structures exist (consistent with ADR-I-0011 and the implemented link guard).
+- Retrieval-trace boundary documented as: light per-retrieval rationale/telemetry now (v0.1/v0.1.2), internal/admin reconciliation diagnostics (v0.1.1), durable first-class `RetrievalTrace` objects deferred to v0.4.
+
+## Assumptions
+- A1: Current `fanout_specs()` values (About->DerivedMemory max 20, Involves->Episode max 5, PartOfThread->DerivedMemory max 15) are the correct defaults to preserve.
+- A2: Integration tests may use temp-file SQLite stats stores and in-memory or persistent graph mode; restart-safety is simulated by dropping and reconstructing the facade against the same persistent stores.
+- A3: No schema or persisted-format changes are needed; this is config surface, tests, and docs only.
+
+## Tasks
+
+### Task_1: Externalize fanout budget configuration
+- type: impl
+- owns:
+  - `src/config/settings/app_settings.rs`
+  - `src/internal/repositories/retrieval_selectivity.rs`
+  - `src/lib.rs` (only wiring of settings into selectivity, if required)
+- depends_on: []
+- description: |
+  Replace hard-coded `fanout_specs()` with settings-driven per relation/object fanout budgets
+  following the roadmap's conceptual `[retrieval.fanout.<relation>.<object_type>]` `min`/`max` shape.
+  Current values become defaults. Unlisted pairs keep current default behavior. Conservative
+  fallback on missing/unhealthy stats is unchanged. Add unit tests for config parsing, default
+  preservation, and override behavior.
+- acceptance:
+  - Fanout budgets for the three existing relation/object pairs are configurable via settings/env.
+  - Defaults match the previously hard-coded values exactly; behavior is unchanged without config.
+  - Invalid config (min > max, negative values) is rejected or clamped with a clear error/diagnostic.
+  - Conservative fallback behavior on unhealthy stats is unchanged and still tested.
+  - No entity identity, name, or application role appears in any fanout policy input.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo fmt --check && cargo check && cargo test"
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Diff review: defaults preserved, no behavior change without config, entity-neutrality intact"
+
+### Task_2: Align phase design docs with implemented boundaries
+- type: docs
+- owns:
+  - `docs/design/roadmap-phases/v0_1_2_continuous_entity_selectivity_retrieval_guardrails.md`
+  - `docs/design/roadmap-phases/v0_1_starter_episodic_memory.md`
+  - `docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md`
+  - `docs/design/roadmap-phases/v0_4_retrieval_observability_governance.md`
+- depends_on: []
+- description: |
+  Three documentation alignments per the Resolved Decisions:
+  1. Document entity-root-only selectivity application as the intended v0.1.2 scope, with widening
+     deferred to v0.1.5 eval-driven closeout.
+  2. Add an `associated_with` admission note to the v0.1 starter doc: allowed only with stronger
+     evidence or explicit application intent until v0.5.
+  3. State the retrieval-trace boundary consistently: light rationale/telemetry now, admin-facing
+     reconciliation diagnostics in v0.1.1, durable full traces in v0.4.
+- acceptance:
+  - v0.1.2 doc states the entity-root selectivity boundary and its revisit point.
+  - v0.1 starter doc carries the `associated_with` admission constraint with an ADR-I-0011 reference.
+  - Trace boundary wording is consistent across the v0.1, v0.1.1, and v0.4 docs.
+  - No design content beyond these boundary clarifications is changed.
+- validation:
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Doc review against Resolved Decisions and ADR-I-0011/ADR-D-0013 consistency"
+
+### Task_3: Facade-level integration tests for v0.1.2 behavior
+- type: test
+- owns:
+  - `tests/v0_1_2_retrieval_guardrails_tests.rs`
+  - `tests/test_utils.rs` (additive helpers only)
+- depends_on: [Task_1]
+- description: |
+  Add integration tests at the `CharacterMemory` facade level, following the existing
+  live-service gating pattern (skip when Qdrant unavailable):
+  1. Stats persistence: write memories, drop facade, reconstruct against the same SQLite stats
+     file, verify counters survive and selectivity telemetry reflects accumulated counts.
+  2. Restart-safe retrieval: suppressed/superseded/non-current records remain excluded after
+     facade reconstruction against persistent stores.
+  3. Selectivity behavior: a high-degree entity fixture yields bounded fanout with telemetry,
+     and configured fanout overrides from Task_1 are observable at the facade level.
+- acceptance:
+  - All three scenarios run as integration tests with deterministic fixtures.
+  - Tests use heterogeneous entity fixtures (no role/name special-casing).
+  - Tests skip cleanly when required services are unavailable.
+  - Tests pass against the Task_1 configurable fanout implementation.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "cargo fmt --check && cargo check && cargo test"
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Review test scenarios against v0.1.1/v0.1.2 acceptance criteria coverage gaps"
+
+### Task_4: Closeout review
+- type: review
+- owns: []
+- depends_on: [Task_1, Task_2, Task_3]
+- description: |
+  Independent review of the full diff against v0.1.2 acceptance criteria, entity-neutrality
+  requirements, and the Resolved Decisions in this plan. Confirm no behavior drift beyond
+  the configured surface and no v0.1.3 scope creep.
+- acceptance:
+  - Reviewer status is APPROVED
+  - All required validation evidence present in Worker reports
+- validation:
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Full closeout review: acceptance criteria, entity-neutrality, scope discipline"
+
+## Task Waves (explicit parallel dispatch sets)
+
+- Wave 1 (parallel): [Task_1, Task_2]
+- Wave 2 (parallel): [Task_3]
+- Wave 3 (parallel): [Task_4]
+
+## Rollback / Safety
+- All changes are additive (config with preserved defaults, new tests, doc clarifications); revert via git on the working branch.
+- No schema, persisted-format, or public API shape changes.
+
+## Progress Log (append-only)
+- 2026-06-12 Wave 1 complete.
+  - Task_1 done: fanout budgets externalized to `[retrieval.fanout.<relation>.<object_type>]` settings (about_entity.derived_memory, participant_entity.episode, part_of_thread.derived_memory); defaults preserved exactly (0/20, 0/5, 0/15); invalid config rejected with `ConfigParseError` (min > max rejected; negatives rejected by usize parsing); no entity identity/role in policy inputs. Validation: `cargo fmt --check && cargo check && cargo test` passed (302 passed, 0 failed, 2 ignored) with local Qdrant via docker-compose.
+  - Task_2 done: v0.1.2 doc gained §7.1 entity-root-only application boundary with v0.1.5 revisit link; v0.1 starter doc gained `associated_with` admission note referencing ADR-I-0011 and light rationale/telemetry wording; v0.1.1 and v0.4 docs aligned on trace boundary (light telemetry now, admin reconciliation diagnostics in v0.1.1, durable RetrievalTrace in v0.4). Manual consistency/link review passed.
+  - Orchestrator note: Cargo.toml version corrected 0.1.0 -> 0.1.2 (covered by Task_1 validation run). v0.1.4/v0.1.5 roadmap-phase design docs authored before wave start per user direction.
+- 2026-06-12 Wave 2 complete.
+  - Task_3 done: tests/v0_1_2_retrieval_guardrails_tests.rs created (3 tests, all executed against live Qdrant: stats persistence/reopen via temp SQLite + persistent graph tempdir; restart-safe supersession/suppression exclusion; high-degree heterogeneous entity fixture with selectivity telemetry and configured About->DerivedMemory max=2 override constraining fanout vs default). tests/test_utils.rs gained additive persistent-store setup helper. Validation: `cargo fmt --check && cargo check && cargo test` passed (299 unit + 1 init + 3 new + 2 facade, 0 failed, 2 ignored).
+  - Lesson candidates from Task_3 staged for closeout: config crate set_override needs i64 (not usize); multi-root retrieval can mask entity-root fanout assertions.
+- 2026-06-12 Wave 3 complete. Task_4 Reviewer verdict: APPROVED. Independent validation: `cargo fmt --check && cargo check && cargo test` exit 0 (299 unit + 1 init + 3 guardrails + 2 facade passed, 0 failed, 2 ignored; new tests executed, not skipped). One MINOR non-blocking note: dead_code warnings from integration-test helper modules in tests/test_utils.rs — optional future cleanup. Plan closed and moved to completed.
+
+## Decision Log (append-only)
+- 2026-06-12: Plan drafted. Destructive deletion confirmed permanently out of scope by project owner: memory is permanent; deletion alters perceived history and disrupts character continuity. Selectivity-scope widening deferred to v0.1.5 (eval-driven closeout) rather than fixed here.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -61,6 +61,7 @@ Records in this repository are expected to capture decisions, not undecided prop
 - [ADR-D-0014: Represent associative membership lifecycle separately from associative unit lifecycle](design/ADR-D-0014-represent-associative-membership-lifecycle-separately.md)
 - [ADR-D-0015: Keep raw source storage outside Character Memory core](design/ADR-D-0015-keep-raw-source-storage-outside-core.md)
 - [ADR-D-0016: Do not add a generic MetaMemory plane to core](design/ADR-D-0016-do-not-add-generic-metamemory-plane.md)
+- [ADR-D-0017: Keep the memory record append-only, with erasure as an out-of-band operational action](design/ADR-D-0017-append-only-memory-record-with-out-of-band-purge.md)
 
 ### Implementation Decisions
 

--- a/docs/decisions/design/ADR-D-0006-supersession-and-suppression.md
+++ b/docs/decisions/design/ADR-D-0006-supersession-and-suppression.md
@@ -35,6 +35,8 @@ defer destructive redaction/delete until explicit production policy support exis
 
 Corrections should normally create new records and link them to old records via `supersedes` or equivalent relations. Forgetting should normally suppress or archive records from default retrieval. Physical redaction/delete remains outside v0.1 production support until explicit policy and storage behavior are implemented.
 
+> **Resolved by ADR-D-0017 (2026-06-12):** the deferred destructive-deletion question is now settled. The memory record is append-only; destructive deletion is never a memory operation. Erasure exists only as an out-of-band operational purge. See [ADR-D-0017](ADR-D-0017-append-only-memory-record-with-out-of-band-purge.md).
+
 ## Character Memory Relevance
 
 Character continuity includes mistakes, corrections, and changed understanding. The assistant should be able to stop relying on an outdated memory while still preserving the fact that it once had that memory, unless the user or policy requires deletion.
@@ -79,4 +81,4 @@ This preserves continuity and auditability while respecting forgetting and corre
 
 ## Revisit When
 
-Revisit when privacy, legal, or user-control requirements demand stronger deletion semantics by default.
+Revisit when privacy, legal, or user-control requirements demand stronger deletion semantics by default. (Resolved direction: ADR-D-0017 keeps the record append-only and routes erasure through an out-of-band operational purge.)

--- a/docs/decisions/design/ADR-D-0017-append-only-memory-record-with-out-of-band-purge.md
+++ b/docs/decisions/design/ADR-D-0017-append-only-memory-record-with-out-of-band-purge.md
@@ -1,0 +1,132 @@
+---
+status: accepted
+adr_type: design
+date: 2026-06-12
+deciders: ["ebigunso"]
+consulted: ["Claude Fable 5"]
+informed: []
+supersedes: []
+superseded_by: null
+---
+
+# ADR-D-0017: Keep the memory record append-only, with erasure as an out-of-band operational action
+
+## Context and Problem Statement
+
+ADR-D-0006 made supersession and suppression the default correction/forgetting mechanisms, but deferred destructive deletion "until explicit production policy support exists." The project philosophy and roadmap carried matching hedges ("deletion" listed as a forgetting mechanism; "unless a later explicit destructive policy is implemented"). This left the permanence question open.
+
+Deleting memory alters the perceived history of any character built on the memory base, disrupting character continuity. Deleting an episode that grounds derived memories or character signals leaves behavior-influencing memory with no remembered basis — exactly the false-continuity failure the philosophy exists to prevent. Surgical memory deletion is also non-human-like: humans cannot target a memory and excise it; they forget through decay, interference, and suppression.
+
+At the same time, some erasure pressure is real and external to memory semantics: legal compliance obligations (personal-data erasure rights), security remediation of adversarially contaminated records, and deliberate operator-directed behavioral alteration.
+
+## Decision Drivers
+
+- Character continuity depends on a stable, append-only remembered history.
+- Episode-backed provenance must never dangle silently.
+- Surgical deletion is not a human-like forgetting mechanism; decay and suppression are.
+- Integrators of companion/assistant applications may face legal erasure obligations that suppression cannot satisfy.
+- Adversarially injected ("poisoned") records are contamination of the record, not remembered experience.
+- The vector index is rebuildable and non-authoritative, so index hygiene must not be conflated with memory erasure.
+
+## Decision
+
+The memory record is append-only. Forgetting is suppression, archival, and decay — never erasure. Destructive deletion is not a memory operation and is not part of the memory model, the `forget` semantics, or any character-facing behavior.
+
+Erasure may exist only as an **out-of-band operational purge**: an administrative tool outside memory semantics, analogous to surgery rather than forgetting. Its documented legitimate uses are:
+
+```text
+compliance erasure of personal data
+security remediation of adversarially contaminated records
+explicit operator-directed behavioral alteration
+```
+
+An operational purge:
+
+```text
+is never invoked by memory operations, retrieval, lifecycle policy, or character behavior
+makes no pretense of preserving continuity
+must tombstone dangling provenance targets rather than leave silent gaps
+is owned by the operator/application, with policy outside Character Memory core
+```
+
+### Poisoned records: purge is justified by illegitimate origin, not undesirable content
+
+A poisoned record is content written into the memory store by a third party or compromised path and presented as remembered experience that the character never legitimately had: prompt-injected memory, forged episodes, or records minted through a compromised write path. Append-only protection applies to **remembered experience**; an injected record fails that test. Removing it does not rewrite the character's history — it removes a forgery from the record.
+
+The remediation policy is two-tier:
+
+```text
+1. suppress first
+   immediate, reversible, auditable
+   preserves forensic evidence of how the contamination entered
+
+2. purge as preferred decontamination once illegitimate origin is confirmed
+   removes the record so no future memory operation, un-suppression,
+   or lifecycle change can ever accidentally restore the contamination
+```
+
+The purge trigger is the record's **origin** (injected, forged, compromised write path), never merely its **content** or behavioral effect. Organic bad memories — genuine interactions that led somewhere unhealthy — are remembered experience and remain governed by suppression, supersession, and decay; purging them is history-rewriting and stays outside normal remediation.
+
+For genuine experiences, suppression in this system is stronger than human suppression: suppressed content is guaranteed never to reach retrieval, so the character keeps the continuity benefits of having a past without involuntary intrusion. This is why organic bad memories do not need the purge path.
+
+Permanence applies to the **record**, not to **influence** or to **derived indexes**:
+
+- Influence is lifecycle-managed through suppression, supersession, currentness, and (future) salience decay.
+- Vector de-indexing (removing Qdrant points) is permissible hygiene because the vector store is rebuildable and non-authoritative — provided de-indexing does not prematurely remove access to otherwise-current, behavior-influencing memory.
+
+The compliance posture is documented explicitly: personal-data erasure policy is the application's responsibility; Character Memory core provides non-destructive forgetting as the memory model and acknowledges the operational purge path for applications that need it.
+
+## Character Memory Relevance
+
+A character's perceived history is its retrievable memory. Keeping the record append-only guarantees that history can always be audited, corrected by supersession, and un-suppressed — the substrate never silently rewrites what was experienced. Placing erasure outside memory semantics keeps the philosophy honest: the character never "chooses" to delete, and forgetting remains human-like (decay and suppression), while operators retain a documented escape hatch for obligations the memory model cannot and should not absorb.
+
+## Implementation Impact
+
+- No `forget` mode performs destructive deletion; existing suppress/archive semantics are unchanged.
+- A future operational purge tool (unscheduled; designed when concretely needed) must tombstone provenance targets and span all stores: graph records, vector points, retrieval-stats counters.
+- Vector de-indexing policies (e.g., future RetentionAssessment outcomes in v0.4) may remove or downrank Qdrant points but must never be the sole record of a memory's existence — Oxigraph remains authoritative.
+- README/positioning documents the compliance posture.
+- Suppression robustness becomes more important: suppressed content must never leak into any retrieval path, since suppression is the primary remedy for unwanted content.
+
+## Considered Options
+
+1. Strict permanence: no erasure path exists at all, anywhere.
+2. Append-only memory semantics with an out-of-band operational purge for compliance, security, and operator-directed alteration.
+3. Destructive deletion as a first-class memory operation (e.g., a `forget` mode).
+
+## Decision Outcome
+
+Chosen option: **2. Append-only memory semantics with an out-of-band operational purge**.
+
+Option 1 leaves integrators with no lawful-compliance path short of destroying the entire store and pretends security contamination cannot happen. Option 3 makes deletion part of character-facing memory semantics, inviting false continuity, dangling provenance, and non-human-like surgical forgetting. Option 2 preserves the philosophy completely — the memory model never deletes — while acknowledging that operators occasionally must.
+
+## Consequences
+
+### Positive
+
+- Character-perceived history is never silently rewritten by memory operations.
+- Provenance chains and audit/correction paths remain intact by default.
+- Integrators have a documented, bounded answer to erasure obligations.
+- Poisoned-record remediation has a principled escalation path: suppress for forensics, then purge confirmed-illegitimate records so they can never be accidentally un-suppressed.
+
+### Negative / Tradeoffs
+
+- Storage growth is unbounded by design; mitigation is de-indexing and downranking, never record deletion.
+- A permanent store of intimate interaction history raises breach stakes; encryption at rest and access control matter earlier.
+- Purged records create tombstones, which are a visible scar in provenance rather than seamless history.
+- Suppression must be robust enough to be the sole influence-removal mechanism for genuine remembered experience.
+- Origin classification carries misjudgment risk: purging a record wrongly judged illegitimate destroys genuine experience irreversibly, so origin confirmation should precede purge and suppression covers the interim.
+
+## Validation
+
+- Lifecycle tests continue to verify suppressed/superseded records are excluded from all default retrieval paths.
+- The v0.1.4 evaluation harness correction-safety metric asserts zero suppressed/superseded admissions into context packs.
+- When an operational purge tool is built: tests must verify tombstoned provenance targets, cross-store removal, and that no memory operation can trigger a purge.
+- When an operational purge tool is built: tests must verify a purged record cannot be restored by any un-suppression or lifecycle operation.
+- De-indexing tests (when implemented) must verify graph-authoritative records survive vector point removal.
+
+## Revisit When
+
+- An operational purge tool is concretely needed and its design must be specified.
+- Origin classification proves unreliable in practice (would tighten purge preconditions, not reopen append-only semantics).
+- Legal requirements emerge that tombstoning cannot satisfy.

--- a/docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md
+++ b/docs/design/roadmap-phases/v0_1_1_persistent_graph_authority.md
@@ -210,6 +210,8 @@ Initial reconciliation may report rather than fully repair all cases.
 
 This phase keeps reconciliation internal/admin-facing. It does not expose diagnostics through the public `CharacterMemory` facade.
 
+Retrieval diagnostics in this phase remain reconciliation-oriented and admin-facing. The v0.1 family may expose light per-retrieval rationale or telemetry, but durable first-class `RetrievalTrace` objects are deferred to v0.4.
+
 Minimum behavior:
 
 ```text

--- a/docs/design/roadmap-phases/v0_1_2_continuous_entity_selectivity_retrieval_guardrails.md
+++ b/docs/design/roadmap-phases/v0_1_2_continuous_entity_selectivity_retrieval_guardrails.md
@@ -470,6 +470,12 @@ They must not be the core fanout mechanism.
 
 Revisit the formula if diagnostics show poor correlation between selectivity score and retrieval quality, or if score changes produce unstable context packs. The next step should be adjusting formula/configuration, not persisting categories.
 
+## 7.1 v0.1.2 application boundary
+
+In v0.1.2, continuous selectivity is applied only when the vector root candidate is an Entity. This is the intended phase boundary: selectivity shapes fanout from entity-root retrieval candidates, while non-entity roots continue to use the existing bounded graph expansion and Oxigraph lifecycle/currentness validation.
+
+Do not widen selectivity application to every graph expansion path in this phase. Revisit the scope with eval-harness evidence in [`v0_1_5_eval_driven_v0_1_family_closeout.md`](v0_1_5_eval_driven_v0_1_family_closeout.md), especially if diagnostics show that non-entity roots create the same low-information expansion risks.
+
 ---
 
 # 8. Smooth fanout policy

--- a/docs/design/roadmap-phases/v0_1_4_continuity_evaluation_harness.md
+++ b/docs/design/roadmap-phases/v0_1_4_continuity_evaluation_harness.md
@@ -1,0 +1,343 @@
+# v0.1.4 Design Draft: Continuity Evaluation Harness
+
+## Version intent
+
+Build a deterministic evaluation harness that measures whether the v0.1 family substrate actually serves character continuity, before scoped continuity features are built on top of it.
+
+The v0.1 family has so far been validated through structural acceptance tests and report-only diagnostics:
+
+```text
+objects round-trip across stores
+provenance links resolve
+lifecycle exclusion works
+selectivity math is monotonic
+fanout stays within caps
+```
+
+Those checks prove the machinery works. They do not prove the machinery produces good continuity. The project philosophy's success criteria are behavioral and longitudinal:
+
+```text
+relevant recall after long gaps without exact wording
+recurring entities anchor recall without flooding context
+temporal retrieval beyond semantic similarity
+stable behavior shaped by history while accepting correction
+inspectable retrieval rationale
+```
+
+v0.1.4 builds the instrument that can measure these properties under long-horizon workloads. v0.1.5 then uses that instrument to close out the v0.1 family.
+
+---
+
+# 1. Why this comes after v0.1.3
+
+v0.1.3 completes the generation-ready write path:
+
+```text
+prepare -> validate -> commit
+RememberWritePlan
+MemoryCandidate
+CandidateProvenance
+idempotent retry-safe writes
+```
+
+The harness should exercise the full write surface the library will carry forward, including the write-plan workflow. Building the harness before v0.1.3 would mean re-validating it immediately after the write path changes.
+
+The harness also needs the v0.1.2 guardrails in place, because selectivity and fanout behavior under hub-entity stress is one of the primary things it must measure.
+
+---
+
+# 2. Why this comes before v0.2
+
+v0.2 builds scoped continuity and reflection on top of retrieval behavior:
+
+```text
+ContinuityScope
+ReflectionJob
+RelationshipState
+CharacterSignal
+OpenLoop
+Commitment
+CurrentContinuityView
+```
+
+If retrieval quality, fanout discipline, or correction safety is weak, v0.2 features will inherit and amplify the weakness. Reflection over polluted context produces polluted derived memory. Character signals reinforced from poorly-retrieved evidence produce false continuity.
+
+The safer sequence is:
+
+```text
+first: measure the substrate
+then: fix what measurement reveals (v0.1.5)
+then: build scoped continuity on a measured substrate (v0.2)
+```
+
+A secondary benefit: selectivity smoothing (`alpha`) and fanout shaping (`gamma`) defaults are currently unmeasured guesses. The harness produces the data needed to tune them in v0.1.5, and v0.4 observability work later gains a concrete consumer.
+
+---
+
+# 3. Scope
+
+## 3.1 What the harness is
+
+```text
+a development and measurement tool inside the repository
+deterministic synthetic long-horizon interaction fixtures
+a minimal example assistant loop exercising the public facade
+continuity-oriented retrieval-quality metrics
+selectivity/fanout measurement under hub-entity stress
+persistence and restart measurement under eval workloads
+repeatable machine-readable eval reports
+```
+
+## 3.2 What the harness is not
+
+```text
+not a public benchmark
+not a learned retrieval policy or training loop
+not a CI-blocking quality gate
+not a live-LLM evaluation
+not a new public memory facade API
+not a new memory object type
+```
+
+## 3.3 Non-goals
+
+Do not implement in v0.1.4:
+
+```text
+learned retrieval policy
+model-graded eval scoring
+live LLM calls inside deterministic eval runs
+CI-blocking quality gates
+public benchmark publication or leaderboard
+new memory object types
+new public memory facade APIs
+changes to retrieval behavior or defaults (that is v0.1.5)
+v0.2 continuity concepts in fixtures beyond what v0.1 objects express
+```
+
+The harness observes and reports. It does not change library behavior.
+
+---
+
+# 4. Deliverables
+
+```text
+synthetic long-horizon fixture generator with fixed seeds
+fixture scenario library covering continuity-relevant patterns
+minimal example assistant loop using the public facade
+metric definitions and metric computation
+eval runner producing machine-readable reports
+report format with per-query rationale samples
+documentation for running and extending evals
+```
+
+---
+
+# 5. Fixture design
+
+## 5.1 Determinism requirements
+
+```text
+fixed seeds for any randomized generation
+no external LLM calls during eval runs
+deterministic or fixture-pinned embeddings
+stable fixture IDs across runs
+identical fixture + config => identical report
+```
+
+Embedding determinism options to decide during implementation:
+
+```text
+pinned pre-computed embedding fixtures
+deterministic local embedding stub with controllable similarity structure
+```
+
+A deterministic embedding stub with controllable similarity is preferred, because it lets fixtures express "these episodes are semantically close" as test intent instead of depending on a live provider.
+
+## 5.2 Scenario coverage
+
+Fixtures should simulate months-scale interaction accumulation, compressed into deterministic event sequences:
+
+```text
+long-gap recall:
+  an entity or topic goes dormant for a long simulated interval, then returns
+
+recurring hub entity:
+  one entity accumulates hundreds of incident memories across unrelated contexts
+
+selective entity:
+  an entity appears rarely but with high continuity significance
+
+correction chains:
+  derived memories superseded once, twice, and with suppression mixed in
+
+thread drift:
+  a soft thread accumulates members with declining confidence
+
+temporal structure:
+  ordered sequences, intervals, recurring-date patterns, one-off vs repeated events
+
+mixed-salience accumulation:
+  high- and low-salience memories competing for the same retrieval context
+
+cross-store stress:
+  restart between write and retrieve; stats reopen; persistent graph reopen
+```
+
+## 5.3 Entity-neutrality requirements
+
+Fixture entities must be heterogeneous and role-free:
+
+```text
+people, places, projects, topics, objects, organizations, factions, custom domain concepts
+no fixture or metric may special-case user/assistant/player/NPC roles
+hub-entity scenarios must exist for at least three different entity kinds
+```
+
+---
+
+# 6. Example assistant loop
+
+A minimal example loop demonstrates the intended integration pattern and gives the harness a realistic call sequence:
+
+```text
+observe interaction event from fixture stream
+retrieve continuity context for the event
+record what was retrieved and why
+decide what to remember (fixture-scripted, not model-driven)
+write through prepare/validate/commit or remember()
+periodically: correct, forget, link per fixture script
+```
+
+The loop exercises:
+
+```text
+remember()
+prepare() / validate_plan() / commit()
+retrieve()
+correct()
+forget()
+link()
+```
+
+The loop is fixture-scripted and deterministic. It is an example and an eval driver, not a product feature.
+
+---
+
+# 7. Metrics
+
+## 7.1 Continuity recall
+
+After a long simulated gap, do retrievals for a returning entity/topic surface the relevant dormant episodes without exact wording overlap?
+
+```text
+inputs: long-gap fixtures with labeled expected-recall sets
+measure: recall@k against labeled sets, by gap length
+```
+
+## 7.2 Entity continuity without flooding
+
+Do recurring hub entities anchor recall while staying bounded?
+
+```text
+measure: share of context pack occupied by hub-incident memories
+measure: labeled-relevant hits among hub expansions
+measure: fanout budget utilization vs cap per relation/object pair
+```
+
+## 7.3 Temporal retrieval quality
+
+```text
+measure: retrieval correctness for recency-, order-, and interval-conditioned fixture queries
+```
+
+## 7.4 Correction safety
+
+```text
+measure: zero suppressed or superseded memories admitted into context packs
+measure: superseding memory retrieved where its predecessor would have been
+```
+
+## 7.5 Rationale quality
+
+```text
+measure: share of context pack members carrying a retrieval rationale
+measure: rationale category distribution (semantic, entity, thread, temporal, salience, scope)
+```
+
+## 7.6 Context pollution rate
+
+```text
+measure: share of context pack members not in the labeled-relevant set for the query
+measure: pollution attributed by rationale category (which signal admitted the noise)
+```
+
+## 7.7 Fanout discipline
+
+```text
+measure: expansions exceeding budget (must be zero)
+measure: conservative-fallback activations under induced stats failure
+measure: selectivity score distributions across fixture entity kinds
+```
+
+Metric thresholds are not pass/fail gates in v0.1.4. The harness reports values; v0.1.5 decides dispositions.
+
+---
+
+# 8. Report format
+
+Eval runs produce machine-readable reports plus a human-readable summary:
+
+```text
+run metadata: fixture set, seeds, config snapshot, schema versions, timestamp
+metric values per scenario and aggregated
+per-query samples: query, context pack contents, rationale, selectivity telemetry
+fanout decisions: budgets, utilization, rejections
+stats health events and fallback activations
+restart/persistence observations
+```
+
+Reports should be diffable across runs so v0.1.5 can show before/after evidence for fixes and tuning.
+
+---
+
+# 9. Acceptance criteria
+
+```text
+Eval runs are deterministic and reproducible under fixed fixtures and seeds.
+Eval runs require no external LLM or embedding-provider calls.
+Fixtures include heterogeneous high-degree entities across at least three entity kinds.
+No fixture, metric, or harness rule special-cases application roles or entity names.
+The harness exercises remember/retrieve/correct/forget/link and prepare/validate/commit.
+The harness measures behavior across restart for persistent graph and stats stores.
+Eval reports include metric values and per-query retrieval rationale samples.
+Reports are machine-readable and diffable across runs.
+Selectivity and fanout measurements are recorded in a form usable for tuning defaults.
+Running the harness does not modify library behavior or defaults.
+```
+
+---
+
+# 10. YAGNI rules
+
+Do not implement in v0.1.4:
+
+```text
+model-graded scoring
+live-provider eval modes
+statistical significance tooling beyond simple aggregation
+dashboard or visualization UI
+fixture DSL beyond what the scenario library needs
+plugin system for third-party metrics
+long-running soak/performance benchmarking infrastructure
+```
+
+Do design for:
+
+```text
+fixture reuse by v0.1.5 regression fixtures
+report diffing across runs
+new scenarios added cheaply as later phases land
+v0.2+ scenario extension (scopes, commitments) without harness rework
+v0.4 observability features consuming the same fixture base
+```

--- a/docs/design/roadmap-phases/v0_1_5_eval_driven_v0_1_family_closeout.md
+++ b/docs/design/roadmap-phases/v0_1_5_eval_driven_v0_1_family_closeout.md
@@ -1,0 +1,246 @@
+# v0.1.5 Design Draft: Eval-Driven v0.1 Family Closeout
+
+## Version intent
+
+Run the v0.1.4 continuity evaluation harness against the full v0.1 family surface, identify weaknesses, fix what should be fixed now, tune unmeasured defaults from measured data, and explicitly close the v0.1 family before v0.2 scoped continuity work begins.
+
+This phase is the v0.1 family's exit gate:
+
+```text
+v0.1     starter episodic memory
+v0.1 backend  storage contracts
+v0.1.1   persistent graph authority
+v0.1.2   selectivity and retrieval guardrails
+v0.1.3   intake interfaces and write planning
+v0.1.4   continuity evaluation harness
+v0.1.5   eval-driven closeout  <- this phase
+```
+
+After v0.1.5, the substrate is considered measured, tuned, and stable enough to carry scoped continuity, reflection, and the later epistemic layers.
+
+---
+
+# 1. Why this phase exists
+
+The v0.1 family was built against structural acceptance criteria. v0.1.4 builds the instrument that measures behavioral quality. Neither phase owns acting on what the instrument finds.
+
+Without an explicit closeout phase, two failure modes are likely:
+
+```text
+findings accumulate as known issues while v0.2 starts on top of them
+tuning of alpha/gamma/fanout defaults never happens because no phase owns it
+```
+
+v0.1.5 makes findings-to-fixes an owned, finite work item with an explicit end state.
+
+---
+
+# 2. Scope
+
+## 2.1 In scope
+
+```text
+running the v0.1.4 harness across v0.1 through v0.1.4 behavior
+recording findings as a structured eval report
+classifying findings with explicit dispositions
+fixing accepted findings in retrieval, guardrails, write path, and persistence
+tuning selectivity and fanout defaults from measured data
+regression fixtures for every fixed finding
+re-running the harness to confirm fixes and tuned defaults
+declaring v0.2 entry against the closed v0.1 family
+```
+
+## 2.2 Non-goals
+
+Do not implement in v0.1.5:
+
+```text
+v0.2 continuity concepts
+new memory object types
+new public memory facade APIs
+new retrieval signals beyond tuning what exists
+harness feature growth beyond what findings require
+learned retrieval policy
+performance optimization beyond fixing measured defects
+speculative refactoring
+```
+
+If a finding's correct fix requires a new concept or signal, the finding is deferred with a target phase, not fixed here.
+
+---
+
+# 3. Findings workflow
+
+## 3.1 Finding record
+
+Every finding from an eval run is recorded with:
+
+```text
+finding ID
+scenario and metric that revealed it
+observed vs expected behavior
+severity: critical / major / minor
+suspected layer: retrieval, selectivity/fanout, link guard, write path, persistence, fixture/harness defect
+disposition: fix-now / defer / accept-as-designed
+rationale for the disposition
+target phase, when deferred
+```
+
+## 3.2 Disposition rules
+
+```text
+fix-now:
+  behavior contradicts a v0.1 family acceptance criterion or philosophy invariant,
+  and the fix does not require new concepts or signals
+
+defer:
+  the correct fix belongs to a later phase's concepts
+  (for example: weak serendipity gaps belong to v0.5,
+   richer traces belong to v0.4, scope-conditioned retrieval belongs to v0.2)
+
+accept-as-designed:
+  the behavior is an explicit documented tradeoff
+  (for example: missing weak associative recall under the v0.1.2 link guard)
+```
+
+Harness/fixture defects are fixed in the harness and do not count against the library.
+
+## 3.3 Severity guidance
+
+```text
+critical: correction safety violations, ungrounded behavior-influencing memory,
+          lifecycle exclusion failures, fanout cap violations
+major:    poor continuity recall, hub flooding, high pollution rates,
+          missing rationale, persistence drift
+minor:    suboptimal ranking, noisy diagnostics, rough report output
+```
+
+Critical findings cannot be dispositioned accept-as-designed.
+
+---
+
+# 4. Tuning workflow
+
+The v0.1.2 defaults were set without workload data:
+
+```text
+selectivity smoothing alpha = 1.0
+fanout shaping gamma = 1.0
+relation/object fanout budgets (configurable since the v0.1.2 closeout)
+conservative-fallback budget
+```
+
+v0.1.5 tunes them with measured evidence:
+
+```text
+sweep candidate values across the fixture scenario library
+compare continuity recall, pollution rate, and fanout discipline metrics
+prefer values that improve recall without raising pollution or breaching caps
+record the chosen values together with the comparison data that justified them
+update shipped defaults and document the tuning basis
+```
+
+Tuning constraints:
+
+```text
+relation caps remain hard upper bounds
+conservative fallback on unhealthy stats is not weakened
+entity-neutrality is not weakened
+no per-entity or per-name tuning of any kind
+```
+
+## 4.1 Selectivity scope revisit
+
+v0.1.2 applies selectivity only when the vector root candidate is an Entity. That boundary was documented as intentional during the v0.1.2 closeout, with this phase named as the revisit point.
+
+v0.1.5 should answer with eval data:
+
+```text
+Does entity-root-only selectivity leave measurable hub flooding through non-entity roots?
+If yes: widen selectivity application and measure again.
+If no: re-affirm the boundary and record the evidence.
+```
+
+---
+
+# 5. Fix workflow
+
+Every fix-now finding follows:
+
+```text
+write or extend a regression fixture that reproduces the finding
+fix the defect within existing concepts and signals
+re-run the affected scenarios and the full structural test suite
+confirm the metric moved and no other metric regressed
+record before/after report references on the finding
+```
+
+Fixes must preserve all v0.1 family invariants:
+
+```text
+Oxigraph decides graph truth and final inclusion
+Qdrant remains candidate recall only
+stats remain derived, rebuildable policy metadata
+behavior-influencing derived memory keeps episode/observation provenance
+suppressed/superseded memories stay excluded by default
+no entity identity or application role special-casing
+```
+
+---
+
+# 6. Closeout declaration
+
+The v0.1 family is closed when:
+
+```text
+all fix-now findings are resolved with regression coverage
+all deferred findings carry rationale and a target phase
+tuned defaults are shipped and documented with their measurement basis
+the full harness re-run shows no critical findings
+all v0.1 through v0.1.4 structural acceptance criteria still pass
+the closeout report is recorded and linked from the roadmap or plans archive
+```
+
+v0.2 entry is then explicitly confirmed against the closeout report.
+
+---
+
+# 7. Acceptance criteria
+
+```text
+Eval findings are recorded with severity and disposition.
+Critical findings are never dispositioned accept-as-designed.
+Every fix-now finding is resolved and covered by a regression test or fixture.
+Deferred findings carry rationale and a target phase.
+Tuned defaults are documented together with the measurements that justified them.
+The selectivity scope boundary is widened or re-affirmed with recorded evidence.
+Fixes introduce no new memory object types, public facade APIs, or retrieval signals.
+All v0.1 through v0.1.4 acceptance criteria still pass after fixes and tuning.
+The final harness re-run shows no critical findings.
+v0.2 entry is explicitly confirmed against the closed v0.1 family.
+```
+
+---
+
+# 8. YAGNI rules
+
+Do not implement in v0.1.5:
+
+```text
+new retrieval signals
+new memory concepts
+learned or adaptive tuning loops
+continuous tuning infrastructure
+automatic finding triage
+performance benchmarking beyond defect confirmation
+v0.2 scope inference or reflection previews
+```
+
+Do design for:
+
+```text
+findings and dispositions reusable as v0.2+ planning input
+regression fixtures joining the permanent harness scenario library
+tuning methodology repeatable when later phases change retrieval behavior
+deferred findings feeding directly into v0.2/v0.4/v0.5 phase planning
+```

--- a/docs/design/roadmap-phases/v0_1_starter_episodic_memory.md
+++ b/docs/design/roadmap-phases/v0_1_starter_episodic_memory.md
@@ -269,6 +269,8 @@ fulfills_commitment
 associated_with
 ```
 
+Admission note: `associated_with`-style links are admissible only with stronger evidence or explicit application intent until v0.5 associative structures exist. Shared low-selectivity co-occurrence alone must not create durable pairwise links; see [ADR-I-0011](../../decisions/implementation/ADR-I-0011-guard-against-low-information-co-occurrence-links.md).
+
 ---
 
 # 4. Starter write pipeline
@@ -364,10 +366,10 @@ async fn link(&self, draft: MemoryLinkDraft) -> Result<MemoryLink, CustomError>;
 Optional low-level diagnostics:
 
 ```rust
-RetrieveOutcome may include a RetrievalTrace when the caller enables trace output.
+RetrieveOutcome may include light RetrievalRationale or RetrievalTelemetry when the caller enables diagnostic output.
 ```
 
-Low-level graph/vector APIs are internal in v0.1; public diagnostics are exposed through optional retrieval trace output.
+Low-level graph/vector APIs are internal in v0.1; public diagnostics are limited to optional per-retrieval rationale or telemetry. Durable first-class `RetrievalTrace` objects are deferred to v0.4.
 
 ---
 

--- a/docs/design/roadmap-phases/v0_1_starter_episodic_memory.md
+++ b/docs/design/roadmap-phases/v0_1_starter_episodic_memory.md
@@ -365,7 +365,7 @@ async fn link(&self, draft: MemoryLinkDraft) -> Result<MemoryLink, CustomError>;
 
 Optional low-level diagnostics:
 
-```rust
+```text
 RetrieveOutcome may include light RetrievalRationale or RetrievalTelemetry when the caller enables diagnostic output.
 ```
 

--- a/docs/design/roadmap-phases/v0_4_retrieval_observability_governance.md
+++ b/docs/design/roadmap-phases/v0_4_retrieval_observability_governance.md
@@ -61,6 +61,8 @@ Why was a possible cluster member included, excluded, or rejected?
 
 A diagnostic object explaining retrieval.
 
+Earlier v0.1-family phases expose only light per-retrieval rationale/telemetry and internal/admin-facing reconciliation diagnostics. v0.4 is where durable first-class `RetrievalTrace` objects become part of retrieval observability.
+
 ```json
 {
   "id": "trace_...",

--- a/docs/project_philosophy.md
+++ b/docs/project_philosophy.md
@@ -170,7 +170,7 @@ This preserves human-like recall while reducing false continuity and graph pollu
 - **Bound entity expansion.** Recurring entities should support recall without causing unbounded graph traversal or accidental pairwise link growth.
 - **Do not collapse memory into unsupported summaries only.** Summaries are useful for compression, but behavior-influencing memory should remain grounded in episodes, observations, provenance, and correction paths.
 - **Let memory influence behavior, not dictate it.** The LLM should receive memory as grounded context. It should not be forced into brittle rules from stale memories.
-- **Support correction and forgetting.** Persistent memory must support updates, contradictions, deletion, decay, and user-controlled correction.
+- **Support correction and forgetting.** Persistent memory must support updates, contradictions, suppression, decay, and user-controlled correction. The memory record itself is append-only: forgetting changes influence, not history. Destructive deletion is not a memory operation; erasure exists only as an out-of-band operational action for compliance, security remediation, or explicit operator-directed alteration.
 - **Expose retrieval rationale.** Implementation designers and application developers need to understand why a memory was retrieved.
 - **Stay backend-agnostic where practical.** The default stack can use OpenAI and Qdrant, but the philosophy should not depend on either vendor.
 
@@ -188,7 +188,7 @@ The API should reinforce the intended mental model. Names and workflows should m
 - **link** to connect entities, memories, and relations.
 - **reinforce** to update salience or character signals based on repeated evidence.
 - **correct** to update or revise memory when the user or system clarifies something.
-- **forget** to delete, suppress, or decay memories when appropriate.
+- **forget** to suppress, archive, or decay memories when appropriate. Forgetting is never destructive; the record remains for audit, correction, and un-suppression.
 
 ### 9.2 Data model expectations
 

--- a/docs/roadmap/development_roadmap.md
+++ b/docs/roadmap/development_roadmap.md
@@ -82,15 +82,17 @@ current relationship state
 current factual beliefs, once the later belief layer exists
 ```
 
-## 2.5 Correction should usually supersede, not erase
+## 2.5 Correction supersedes; the record is append-only
 
 Most corrections should create new memory and links:
 
 ```text
 new memory supersedes old memory
 correction episode explains why
-old memory remains historical unless suppressed or a later explicit destructive policy is implemented
+old memory remains historical; suppression removes influence, never the record
 ```
+
+Destructive deletion is not a memory operation. Erasure exists only as an out-of-band operational purge (compliance, security remediation, operator-directed alteration) that tombstones dangling provenance targets. See ADR-D-0017.
 
 ## 2.6 Retrieval should be explainable
 
@@ -255,6 +257,8 @@ Assisted remember workflows may accept raw or semi-raw input as transient proces
 | v0.1.1 | Persistent graph authority | Finished. Durable Oxigraph-backed graph authority, restart-safe retrieval, Qdrant/Oxigraph reconciliation, and persistence validation. |
 | v0.1.2 | Continuous entity selectivity and retrieval guardrails | New. Use-case-agnostic guardrails for high-degree or low-selectivity entities, persistent retrieval statistics, continuous selectivity scoring, relation-specific fanout control, low-information co-occurrence prevention, and diagnostics. |
 | v0.1.3 | Remember intake interfaces and deterministic write planning | Generation-ready write path with `RememberWritePlan`, memory candidates, validation, deterministic helpers, draft/validate/commit flow, and shared manual/future-generated commit machinery. |
+| v0.1.4 | Continuity evaluation harness | New. Deterministic long-horizon evaluation harness: synthetic interaction fixtures, a minimal example assistant loop, continuity-oriented retrieval-quality metrics, selectivity/fanout measurement, and hub-entity stress scenarios. |
+| v0.1.5 | Eval-driven v0.1 family closeout | New. Run the evaluation harness, record findings, tune selectivity/fanout defaults from measured data, fix revealed retrieval/guardrail/write-path/persistence issues, and close out the v0.1 family before v0.2. |
 | v0.2 | Scoped continuity and reflection | `ContinuityScope`, scoped reflection, relationship state between arbitrary entities, character signals for continuing entities, open-loop/commitment lifecycle, and current continuity views. |
 | v0.3 | Factual rigor, temporal validity, and entity evolution | Assertions, claims, evidence links, belief assessments, source assessment, temporal validity, entity drift handling, and current-belief views. |
 | v0.4 | Retrieval observability and governance | Retrieval traces, context subgraphs, validation rules, graph health reports, policy diagnostics, rejected expansion traces, cluster/activation diagnostics, and retention assessment. |
@@ -1059,7 +1063,116 @@ v0.1.3 keeps candidate state simpler unless implementation clearly requires more
 
 ---
 
-# 10. v0.2: scoped continuity and reflection
+# 10. v0.1.4: continuity evaluation harness
+
+Detailed draft: [`v0_1_4_continuity_evaluation_harness.md`](../design/roadmap-phases/v0_1_4_continuity_evaluation_harness.md)
+
+## Intent
+
+Close the gap between structural acceptance tests and the actual product goal before richer continuity features build on the v0.1 substrate.
+
+The philosophy's success criteria are behavioral and longitudinal: recall after long gaps, entity anchoring without hub flooding, stable behavior shaped by history. The v0.1 family has so far been validated through structural acceptance tests and diagnostics. v0.1.4 adds a way to measure whether retrieval actually serves continuity under long-horizon workloads.
+
+The intended sequence is:
+
+```text
+v0.1.3 completes the generation-ready write path
+v0.1.4 builds the harness that exercises the full write and retrieve paths
+v0.1.5 runs the harness, fixes what it reveals, and closes the v0.1 family
+then v0.2 builds scoped continuity on a measured substrate
+```
+
+## Goals
+
+```text
+build deterministic synthetic long-horizon interaction fixtures
+cover months-scale episode accumulation, recurring entities, corrections, supersession, suppression, and thread drift
+provide a minimal example assistant loop exercising remember/retrieve/correct/forget/link and prepare/validate/commit
+define continuity-oriented retrieval-quality metrics
+measure selectivity and fanout behavior under hub-entity stress
+measure restart and persistence behavior under eval workloads
+produce repeatable machine-readable eval reports
+```
+
+## Metrics direction
+
+```text
+continuity recall: relevant past episodes surface after long gaps without exact wording
+entity continuity: recurring entities anchor recall without flooding context
+temporal retrieval quality: recency, order, and interval relevance
+correction safety: suppressed and superseded memories stay excluded
+rationale quality: retrieved memories carry inspectable retrieval reasons
+context pollution rate: low-relevance memories admitted into context packs
+fanout discipline: bounded expansion under high-degree fixtures
+```
+
+## Non-goals
+
+```text
+learned retrieval policy
+public benchmark publication
+live LLM calls inside deterministic eval runs
+CI-blocking quality gates
+new memory object types
+new public memory facade APIs
+```
+
+## Acceptance criteria
+
+```text
+Eval runs are deterministic and reproducible under fixed fixtures.
+Fixtures include heterogeneous high-degree entities: people, places, projects, topics, objects, and arbitrary custom entities.
+The harness exercises lifecycle facades and the prepare/validate/commit path.
+Eval reports include metric values and per-query retrieval rationale samples.
+Eval runs require no external LLM calls.
+Selectivity and fanout measurements are recorded in a form usable for tuning defaults.
+```
+
+---
+
+# 11. v0.1.5: eval-driven v0.1 family closeout
+
+Detailed draft: [`v0_1_5_eval_driven_v0_1_family_closeout.md`](../design/roadmap-phases/v0_1_5_eval_driven_v0_1_family_closeout.md)
+
+## Intent
+
+Run the v0.1.4 harness against the full v0.1 family feature surface, identify weaknesses, fix them, and close out the v0.1 family before scoped continuity work begins.
+
+## Goals
+
+```text
+run the evaluation harness across v0.1 through v0.1.4 behavior
+record findings as a structured eval report
+classify findings: fix now, defer with rationale and target phase, or accept as designed
+fix revealed retrieval, guardrail, write-path, and persistence issues
+tune selectivity and fanout defaults (alpha, gamma, relation budgets) from measured data
+re-run the harness to confirm fixes and tuned defaults
+declare the v0.1 family closed for v0.2 entry
+```
+
+## Non-goals
+
+```text
+v0.2 continuity concepts
+new memory object types
+new retrieval signals beyond tuning what exists
+harness feature growth beyond what findings require
+```
+
+## Acceptance criteria
+
+```text
+Eval findings are recorded with severity and disposition.
+Every fix-now finding is resolved and covered by a regression test or fixture.
+Deferred findings carry rationale and a target phase.
+Tuned defaults are documented together with the measurements that justified them.
+All v0.1 through v0.1.4 acceptance criteria still pass after fixes.
+v0.2 entry is explicitly confirmed against the closed v0.1 family.
+```
+
+---
+
+# 12. v0.2: scoped continuity and reflection
 
 Detailed draft: [`v0_2_scoped_continuity_reflection.md`](../design/roadmap-phases/v0_2_scoped_continuity_reflection.md)
 
@@ -1098,7 +1211,7 @@ Open loops and commitments can be retrieved by scope without assuming who the ma
 
 ---
 
-# 11. v0.3: factual rigor, temporal validity, and entity evolution
+# 13. v0.3: factual rigor, temporal validity, and entity evolution
 
 Detailed draft: [`v0_3_factual_rigor_temporal_validity_entity_evolution.md`](../design/roadmap-phases/v0_3_factual_rigor_temporal_validity_entity_evolution.md)
 
@@ -1129,7 +1242,7 @@ This is important, but it should not block the starter because Character Memory'
 
 ---
 
-# 12. v0.4: retrieval observability and governance
+# 14. v0.4: retrieval observability and governance
 
 Detailed draft: [`v0_4_retrieval_observability_governance.md`](../design/roadmap-phases/v0_4_retrieval_observability_governance.md)
 
@@ -1211,7 +1324,7 @@ The default intent is `Continuity`.
 
 ---
 
-# 13. v0.5: controlled associative recall and clustering
+# 15. v0.5: controlled associative recall and clustering
 
 Detailed draft: [`v0_5_controlled_associative_recall_clustering.md`](../design/roadmap-phases/v0_5_controlled_associative_recall_clustering.md)
 
@@ -1273,7 +1386,7 @@ Durable graph truth is the associative unit, membership lifecycle, and support e
 
 ---
 
-# 14. v0.6: assisted remember workflow and memory candidate generation
+# 16. v0.6: assisted remember workflow and memory candidate generation
 
 Detailed draft: [`v0_6_assisted_remember_workflow_memory_candidate_generation.md`](../design/roadmap-phases/v0_6_assisted_remember_workflow_memory_candidate_generation.md)
 
@@ -1367,7 +1480,7 @@ Generated candidates use the same validation and commit path as manual candidate
 
 ---
 
-# 15. v1.0+: multimodal and embodied expansion
+# 17. v1.0+: multimodal and embodied expansion
 
 Detailed draft: [`v1_0_multimodal_embodied_expansion.md`](../design/roadmap-phases/v1_0_multimodal_embodied_expansion.md)
 
@@ -1395,7 +1508,7 @@ This is a future path, not starter scope.
 
 ---
 
-# 16. Public API evolution
+# 18. Public API evolution
 
 ## v0.1 API
 
@@ -1477,6 +1590,12 @@ let outcome = memory.commit(approved_plan, commit_options).await?;
 
 `RequireApproval` and `ApplicationReviewCallback` are not core v0.1.3 commit modes. They are application workflows or future adapters.
 
+## v0.1.4 / v0.1.5 API surface
+
+The evaluation harness is a development and measurement tool. It adds no public memory facade APIs.
+
+v0.1.5 may adjust configuration defaults (selectivity smoothing, fanout budgets) based on measured data, but it does not change the public API shape.
+
 ## v0.2 API additions
 
 ```rust
@@ -1537,7 +1656,7 @@ Generated processors should produce `MemoryCandidate` and `RememberWritePlan` va
 
 ---
 
-# 17. YAGNI rules
+# 19. YAGNI rules
 
 Do not implement in v0.1 / v0.1.2:
 

--- a/docs/roadmap/development_roadmap.md
+++ b/docs/roadmap/development_roadmap.md
@@ -92,7 +92,7 @@ correction episode explains why
 old memory remains historical; suppression removes influence, never the record
 ```
 
-Destructive deletion is not a memory operation. Erasure exists only as an out-of-band operational purge (compliance, security remediation, operator-directed alteration) that tombstones dangling provenance targets. See ADR-D-0017.
+Destructive deletion is not a memory operation. Erasure exists only as an out-of-band operational purge (compliance, security remediation, operator-directed alteration) that tombstones dangling provenance targets. See [ADR-D-0017](../decisions/design/ADR-D-0017-append-only-memory-record-with-out-of-band-purge.md).
 
 ## 2.6 Retrieval should be explainable
 


### PR DESCRIPTION
## Summary
- add v0.1.4 continuity evaluation harness and v0.1.5 eval-driven closeout phase docs
- document append-only memory record semantics with out-of-band purge boundaries
- align roadmap/philosophy/ADR/README wording and archive the approved closeout plan

## Validation
- pre-commit markdown/doc hooks passed during commit
- documentation-only branch; no cargo validation required

## Notes
- Implementation/test changes are separated into PR for branch `copilot/v0-1-2-closeout-impl`.