### PR TITLE
⬆️ Bump the Rust toolchain to 1.97.0

### DIFF
--- a/.github/workflows/check_formatting.yaml
+++ b/.github/workflows/check_formatting.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Rust toolchain with rustfmt
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.95.0
+          toolchain: 1.97.0
           components: rustfmt
 
       - name: Run cargo fmt check

--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.95.0
+          toolchain: 1.97.0
 
       - name: Run cargo check
         run: cargo check
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.95.0
+          toolchain: 1.97.0
 
       - name: Compile tests without running them
         run: cargo test --no-run
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Rust toolchain with clippy
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.95.0
+          toolchain: 1.97.0
           components: clippy
 
       - name: Run clippy with warnings denied
@@ -95,7 +95,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.95.0
+          toolchain: 1.97.0
 
       - name: Validate live integration configuration
         shell: bash

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.97.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Toolchain file plus the five workflow pins move from 1.95.0 to 1.97.0, matching the evaluation repository's pin. Prerequisite for evaluating the in-process Qdrant Edge crate and general hygiene.

## Evidence
- fmt clean; clippy -D warnings on 1.97.0 with an empty new-lint census; service-up `cargo test` green; the three ignored live Qdrant tests 3/3; test collections 0 → 0; Cargo.lock unchanged.
- Reviewer offline formality: APPROVED (diff is exactly the six pins; no other 1.95 reference remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)