### PR TITLE
🧪 Required-service tests fail instead of skipping

### DIFF
--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -83,6 +83,7 @@ jobs:
           - 6333:6333
           - 6334:6334
     env:
+      REQUIRE_QDRANT_TESTS: 1
       QDRANT_CONNECTION_STRING: ${{ vars.QDRANT_CONNECTION_STRING }}
       OXIGRAPH_PATH: ./data/oxigraph
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/tests/initialization_tests.rs
+++ b/tests/initialization_tests.rs
@@ -2,14 +2,17 @@ use character_memory::{CustomError, VectorDatabaseError};
 
 #[path = "support/mod.rs"]
 pub mod test_support;
-use test_support::{cleanup_collection, is_qdrant_unavailable_error, try_setup_character_memory};
+use test_support::{
+    cleanup_collection, is_qdrant_unavailable_error, should_skip_qdrant_unavailable,
+    try_setup_character_memory,
+};
 
 #[tokio::test]
 async fn test_character_memory_initialization() {
     // Setup
     let (_character_memory, collection_name) = match try_setup_character_memory().await {
         Ok(setup) => setup,
-        Err(CustomError::VectorDatabaseError(error)) if is_qdrant_unavailable_error(&error) => {
+        Err(CustomError::VectorDatabaseError(error)) if should_skip_qdrant_unavailable(&error) => {
             println!("skipping live initialization test because Qdrant is unavailable: {error}");
             return;
         }

--- a/tests/public_facade_tests.rs
+++ b/tests/public_facade_tests.rs
@@ -13,7 +13,7 @@ async fn public_remember_and_retrieve_use_graph_authoritative_path() {
     let (memory, collection_name) = match test_support::try_setup_character_memory().await {
         Ok(setup) => setup,
         Err(CustomError::VectorDatabaseError(error))
-            if test_support::is_qdrant_unavailable_error(&error) =>
+            if test_support::should_skip_qdrant_unavailable(&error) =>
         {
             println!("skipping live public facade test because Qdrant is unavailable: {error}");
             return;
@@ -106,7 +106,7 @@ async fn public_correct_and_forget_hide_stale_memories_from_normal_retrieval() {
     let (memory, collection_name) = match test_support::try_setup_character_memory().await {
         Ok(setup) => setup,
         Err(CustomError::VectorDatabaseError(error))
-            if test_support::is_qdrant_unavailable_error(&error) =>
+            if test_support::should_skip_qdrant_unavailable(&error) =>
         {
             println!(
                 "skipping live public lifecycle facade test because Qdrant is unavailable: {error}"

--- a/tests/retrieval_guardrails_tests.rs
+++ b/tests/retrieval_guardrails_tests.rs
@@ -23,7 +23,7 @@ async fn stats_persist_across_facade_reopen() {
     let memory = match setup(&collection_name, &fixture, None).await {
         Ok(memory) => memory,
         Err(CustomError::VectorDatabaseError(error))
-            if test_support::is_qdrant_unavailable_error(&error) =>
+            if test_support::should_skip_qdrant_unavailable(&error) =>
         {
             println!("skipping stats persistence test because Qdrant is unavailable: {error}");
             return;
@@ -126,7 +126,7 @@ async fn restart_safe_retrieval_excludes_suppressed_and_superseded_memories() {
     let memory = match setup(&collection_name, &fixture, None).await {
         Ok(memory) => memory,
         Err(CustomError::VectorDatabaseError(error))
-            if test_support::is_qdrant_unavailable_error(&error) =>
+            if test_support::should_skip_qdrant_unavailable(&error) =>
         {
             println!("skipping restart-safe retrieval test because Qdrant is unavailable: {error}");
             return;
@@ -259,7 +259,7 @@ async fn selectivity_telemetry_and_fanout_override_bound_entity_root_expansion()
     let memory = match setup(&collection_name, &fixture, None).await {
         Ok(memory) => memory,
         Err(CustomError::VectorDatabaseError(error))
-            if test_support::is_qdrant_unavailable_error(&error) =>
+            if test_support::should_skip_qdrant_unavailable(&error) =>
         {
             println!("skipping selectivity fanout test because Qdrant is unavailable: {error}");
             return;

--- a/tests/support/base.rs
+++ b/tests/support/base.rs
@@ -156,6 +156,14 @@ pub fn is_qdrant_unavailable_error(error: &VectorDatabaseError) -> bool {
         )
 }
 
+pub fn should_skip_qdrant_unavailable(error: &VectorDatabaseError) -> bool {
+    let unavailable = is_qdrant_unavailable_error(error);
+    if unavailable && std::env::var_os("REQUIRE_QDRANT_TESTS").is_some() {
+        panic!("Qdrant is required for this test but is unavailable: {error}");
+    }
+    unavailable
+}
+
 pub async fn cleanup_collection(collection_name: &str) {
     let settings = load_test_settings().expect("Failed to load settings from environment");
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -4,7 +4,7 @@ mod persistent;
 
 pub use base::{
     cleanup_collection, config_error, is_qdrant_unavailable_error, load_test_settings,
-    unique_collection_name, DeterministicEmbeddingProvider,
+    should_skip_qdrant_unavailable, unique_collection_name, DeterministicEmbeddingProvider,
 };
 pub use basic::try_setup_character_memory;
 pub use persistent::try_setup_persistent_character_memory;

--- a/tests/write_planning_tests.rs
+++ b/tests/write_planning_tests.rs
@@ -768,15 +768,9 @@ async fn setup_basic() -> Option<(CharacterMemory, String)> {
     match try_setup_in_memory_character_memory().await {
         Ok(fixture) => Some(fixture),
         Err(CustomError::VectorDatabaseError(error))
-            if base::is_qdrant_unavailable_error(&error) =>
+            if base::should_skip_qdrant_unavailable(&error) =>
         {
             println!("skipping write-planning test because Qdrant is unavailable: {error}");
-            None
-        }
-        Err(error) if is_qdrant_timeout_signature(&error) => {
-            println!(
-                "skipping write-planning test because local Qdrant gRPC mutation stalled: {error}"
-            );
             None
         }
         Err(error) => panic!("unexpected basic setup failure: {error}"),
@@ -796,15 +790,11 @@ async fn setup_persistent(
     {
         Ok(memory) => Some(memory),
         Err(CustomError::VectorDatabaseError(error))
-            if base::is_qdrant_unavailable_error(&error) =>
+            if base::should_skip_qdrant_unavailable(&error) =>
         {
             println!(
                 "skipping persistent write-planning test because Qdrant is unavailable: {error}"
             );
-            None
-        }
-        Err(error) if is_qdrant_timeout_signature(&error) => {
-            println!("skipping persistent write-planning test because local Qdrant gRPC mutation stalled: {error}");
             None
         }
         Err(error) => panic!("unexpected persistent setup failure: {error}"),
@@ -1171,11 +1161,6 @@ fn graph_only_commit_options() -> CommitOptions {
         update_vectors: false,
         update_stats: false,
     }
-}
-
-fn is_qdrant_timeout_signature(error: &CustomError) -> bool {
-    let message = error.to_string();
-    message.contains("Vector database error") && message.contains("Timeout expired")
 }
 
 fn has_candidate_kind(


### PR DESCRIPTION
## Summary
v0.1.6 Wave 1, Task_1 (live-gate hardening), targeting the planning branch per the phase's merge shape.

- One environment switch (`REQUIRE_QDRANT_TESTS`) honoured by the shared test support turns every typed Qdrant-unavailable skip into a panic; all eight former skip sites route through it.
- Both prose-matched timeout skip branches are removed; no test gates on error text.
- The service-backed CI job sets the switch, so a missing service fails the job rather than silently passing.

## Validation
- Worker (cm-worker2): service-up `cargo test` with the switch set, 405 passed / 0 failed / 3 pre-existing ignored; collection census 0 before / 0 after; fmt and Clippy `-D warnings` clean.
- Reviewer (cm-reviewer, Tier D): approved at a633b2e, no findings; forced-down controls with the switch set fail the exact former skip sites instead of passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)